### PR TITLE
add test to ensure clocks cannot be equivelent based only on hour or minute

### DIFF
--- a/clock/clock_test.rb
+++ b/clock/clock_test.rb
@@ -43,6 +43,15 @@ class ClockTest < MiniTest::Unit::TestCase
     assert_equal clock1, clock2
   end
 
+  def test_inequivalent_clocks
+    skip
+    clock1 = Clock.at(15, 37)
+    clock2 = Clock.at(15, 36)
+    clock3 = Clock.at(14, 37)
+    refute_equal clock1, clock2
+    refute_equal clock1, clock3
+  end
+
   def test_wrap_around_backwards
     skip
     clock = Clock.at(0, 30) - 60


### PR DESCRIPTION
I was able to make all the tests pass without actually enforcing equality between two clocks, I think this ought to take care of that.
