### PR TITLE
Evens not divisible by four are not leap years

### DIFF
--- a/leap/leap_test.rb
+++ b/leap/leap_test.rb
@@ -10,6 +10,10 @@ class YearTest < MiniTest::Unit::TestCase
     skip
     refute Year.leap?(1997)
   end
+  
+  def test_non_leap_even_year
+    refute Year.leap?(1998)
+  end
 
   def test_century
     skip


### PR DESCRIPTION
I made the mistake of just checking even-ness, not checking that years were divisible by four.
