### PR TITLE
Attempt to thwart mapping-style bob solutions.

### DIFF
--- a/bob/bob_test.rb
+++ b/bob/bob_test.rb
@@ -29,6 +29,12 @@ class TeenagerTest < MiniTest::Unit::TestCase
     assert_equal 'Woah, chill out!', teenager.hey('WATCH OUT!')
   end
 
+  def test_shouting_gibberish
+    skip
+    gibberish = ('A'..'Z').to_a.shuffle[0,10].join
+    assert_equal 'Woah, chill out!', teenager.hey(gibberish)
+  end
+
   def test_asking_a_question
     skip
     assert_equal 'Sure.', teenager.hey('Does this cryogenic chamber make me look fat?')
@@ -37,6 +43,12 @@ class TeenagerTest < MiniTest::Unit::TestCase
   def test_asking_a_numeric_question
     skip
     assert_equal 'Sure.', teenager.hey('You are, what, like 15?')
+  end
+
+  def test_asking_gibberish
+    skip
+    gibberish = ('a'..'z').to_a.shuffle[0,10].join
+    assert_equal 'Sure.', teenager.hey("#{gibberish}?")
   end
 
   def test_talking_forcefully
@@ -96,7 +108,8 @@ class TeenagerTest < MiniTest::Unit::TestCase
 
   def test_prolonged_silence
     skip
-    assert_equal 'Fine. Be that way!', teenager.hey('    ')
+    silence = " " * rand(1..10)
+    assert_equal 'Fine. Be that way!', teenager.hey(silence)
   end
 
   def test_on_multiple_line_questions


### PR DESCRIPTION
Note: this introduces a dependency on 1.9.3. Is that OK, or should I reimplement this using 1.8.7 features?
