### PR TITLE
Break Ruby's built-in `leap?` function.

### DIFF
--- a/leap/leap_test.rb
+++ b/leap/leap_test.rb
@@ -1,5 +1,15 @@
+require 'date'
 require 'minitest/autorun'
 require_relative 'year'
+
+class Date
+  def leap?
+    throw "Try to implement this yourself instead of using Ruby's implementation."
+  end
+  
+  alias :gregorian_leap?, :leap?
+  alias :julian_leap?, :leap?
+end
 
 class YearTest < MiniTest::Unit::TestCase
   def test_leap_year


### PR DESCRIPTION
It seems that many people ignore the README and use Ruby's `leap?` method. This PR uses monkey patching to break it.
