### PR TITLE
make Ruby house consistent with Python and the README, see xhaskell #6

### DIFF
--- a/house/example.rb
+++ b/house/example.rb
@@ -8,25 +8,25 @@ class House
   end
 
   def line(i)
-    "This is %s.\n" % pieces.last(i).join(' ')
+    "This is %s.\n" % pieces.last(i).map {|s| s.join("\n") }.join(' ')
   end
 
   private
 
   def pieces
     [
-      'the horse and the hound and the horn that belonged to',
-      'the farmer sowing his corn that kept',
-      'the rooster that crowed in the morn that woke',
-      'the priest all shaven and shorn that married',
-      'the man all tattered and torn that kissed',
-      'the maiden all forlorn that milked',
-      'the cow with the crumpled horn that tossed',
-      'the dog that worried',
-      'the cat that killed',
-      'the rat that ate',
-      'the malt that lay in',
-      'the house that Jack built',
+      ['the horse and the hound and the horn', 'that belonged to'],
+      ['the farmer sowing his corn', 'that kept'],
+      ['the rooster that crowed in the morn', 'that woke'],
+      ['the priest all shaven and shorn', 'that married'],
+      ['the man all tattered and torn', 'that kissed'],
+      ['the maiden all forlorn', 'that milked'],
+      ['the cow with the crumpled horn', 'that tossed'],
+      ['the dog', 'that worried'],
+      ['the cat', 'that killed'],
+      ['the rat', 'that ate'],
+      ['the malt', 'that lay in'],
+      ['the house that Jack built'],
     ]
   end
 end

--- a/house/house_test.rb
+++ b/house/house_test.rb
@@ -6,29 +6,94 @@ class HouseTest < MiniTest::Unit::TestCase
     expected = <<-RHYME
 This is the house that Jack built.
 
-This is the malt that lay in the house that Jack built.
+This is the malt
+that lay in the house that Jack built.
 
-This is the rat that ate the malt that lay in the house that Jack built.
+This is the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
 
-This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
+This is the horse and the hound and the horn
+that belonged to the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
     RHYME
     assert_equal expected, House.recite
   end
 end
-


### PR DESCRIPTION
Per the discussion in exercism/xhaskell#6, here is a version of the Ruby `house` implementation that has newlines in the same places as the README and the Python implementations.
