### PR TITLE
[Gigasecond] Replace constructor by factory method for more expressiveness

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -6,26 +6,26 @@ require_relative 'gigasecond'
 class GigasecondTest < MiniTest::Unit::TestCase
 
   def test_1
-    gs = Gigasecond.new(Date.new(2011, 4, 25))
+    gs = Gigasecond.from(Date.new(2011, 4, 25))
     assert_equal Date.new(2043, 1, 1), gs.date
   end
 
   def test_2
     skip
-    gs = Gigasecond.new(Date.new(1977, 6, 13))
+    gs = Gigasecond.from(Date.new(1977, 6, 13))
     assert_equal Date.new(2009, 2, 19), gs.date
   end
 
   def test_3
     skip
-    gs = Gigasecond.new(Date.new(1959, 7, 19))
+    gs = Gigasecond.from(Date.new(1959, 7, 19))
     assert_equal Date.new(1991, 3, 27), gs.date
   end
 
   def test_yourself
     skip
     your_birthday = Date.new(year, month, day)
-    gs = Gigasecond.new(your_birthday)
+    gs = Gigasecond.from(your_birthday)
     assert_equal Date.new(2009, 1, 31), gs.date
   end
 


### PR DESCRIPTION
As you suggested (http://exercism.io/submissions/f9bce43604cfd5b4685088fb), here's the PR for using a factory method instead of a constructor in the Gigasecond test
