### PR TITLE
Add comment to explain changes in tests and force Gigasecond.from to return a Date

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -4,29 +4,39 @@ require 'time'
 require_relative 'gigasecond'
 
 class GigasecondTest < MiniTest::Unit::TestCase
+  # These tests were revised around July 2014. If your solution was
+  # created before that revision, you can solve it by using the following
+  # code:
+  #
+  # def Gigasecond.from(start_date)
+  #   Gigasecond.new(start_date).date
+  # end
+  #
+  # Keep in mind that that code is a workaround to get your tests working
+  # and does not necessarily provide the cleanest solution to the test as
+  # it is now.
 
   def test_1
-    gs = Gigasecond.from(Date.new(2011, 4, 25))
-    assert_equal Date.new(2043, 1, 1), gs.date
+    test_date = Date.new(2011, 4, 25)
+    assert_equal Date.new(2043, 1, 1), Gigasecond.from(test_date)
   end
 
   def test_2
     skip
-    gs = Gigasecond.from(Date.new(1977, 6, 13))
-    assert_equal Date.new(2009, 2, 19), gs.date
+    test_date = Date.new(1977, 6, 13)
+    assert_equal Date.new(2009, 2, 19), Gigasecond.from(test_date)
   end
 
   def test_3
     skip
-    gs = Gigasecond.from(Date.new(1959, 7, 19))
-    assert_equal Date.new(1991, 3, 27), gs.date
+    test_date = Date.new(1959, 7, 19)
+    assert_equal Date.new(1991, 3, 27), Gigasecond.from(test_date)
   end
 
   def test_yourself
     skip
     your_birthday = Date.new(year, month, day)
-    gs = Gigasecond.from(your_birthday)
-    assert_equal Date.new(2009, 1, 31), gs.date
+    assert_equal Date.new(2009, 1, 31), Gigasecond.from(your_birthday)
   end
 
 end


### PR DESCRIPTION
Refs #22. Hope this helps?
