### PR TITLE
Addressing issue #35 - make robot-name tests more strict

### DIFF
--- a/robot-name/robot_name_test.rb
+++ b/robot-name/robot_name_test.rb
@@ -3,7 +3,7 @@ require_relative 'robot'
 
 class RobotTest < MiniTest::Unit::TestCase
   def test_has_name
-    assert_match /[a-zA-Z]{2}\d{3}/, Robot.new.name
+    assert_match /^[a-zA-Z]{2}\d{3}$/, Robot.new.name
   end
 
   def test_name_sticks
@@ -25,6 +25,6 @@ class RobotTest < MiniTest::Unit::TestCase
     robot.reset
     name2 = robot.name
     assert name != name2
-    assert_match /[a-zA-Z]{2}\d{3}/, name2
+    assert_match /^[a-zA-Z]{2}\d{3}$/, name2
   end
 end


### PR DESCRIPTION
Strictifies tests of the robot-name problem, making them enforce the `AB123` name format for robots, instead of accepting strings like `0.4367247`.
