### PR TITLE
Multiple Changes to CustomSet Exercise

### DIFF
--- a/custom-set/custom_set_test.rb
+++ b/custom-set/custom_set_test.rb
@@ -6,12 +6,17 @@ class CustomSetTest < MiniTest::Unit::TestCase
   def test_equal
     assert_equal CustomSet.new([1, 3]), CustomSet.new([3, 1])
   end
+  
+  def test_no_duplicates
+    assert_equal CustomSet.new([1, 1]), CustomSet.new([1])
+  end   
 
   def test_delete
     skip
     assert_equal CustomSet.new([1,3]), CustomSet.new([3,2,1]).delete(2)
     assert_equal CustomSet.new([1,2,3]), CustomSet.new([3,2,1]).delete(4)
     assert_equal CustomSet.new([1,2,3]), CustomSet.new([3,2,1]).delete(2.0)
+    assert_equal CustomSet.new([1,3]), CustomSet.new([3,2.0,1]).delete(2.0)
   end
 
   def test_difference
@@ -83,11 +88,11 @@ class CustomSetTest < MiniTest::Unit::TestCase
     assert CustomSet.new.subset?(CustomSet.new)
   end
 
-  def test_to_list
+  def test_to_a
     skip
-    assert_equal [], CustomSet.new.to_list.sort
-    assert_equal [1,2,3], CustomSet.new([3,1,2]).to_list.sort
-    assert_equal [1,2,3], CustomSet.new([3,1,2,1]).to_list.sort
+    assert_equal [], CustomSet.new.to_a.sort
+    assert_equal [1,2,3], CustomSet.new([3,1,2]).to_a.sort
+    assert_equal [1,2,3], CustomSet.new([3,1,2,1]).to_a.sort
   end
 
   def test_union

--- a/custom-set/example.rb
+++ b/custom-set/example.rb
@@ -2,7 +2,7 @@ class CustomSet
   attr_reader :data
 
   def initialize(input_data = [])
-    @data = parse_data(input_data)
+    @data = parse_data(input_data.uniq)
   end
 
   def delete(datum)
@@ -53,7 +53,7 @@ class CustomSet
     other.nodes.all?{ |other_node| nodes.any?{|node| node.eql?(other_node) } }
   end
 
-  def to_list
+  def to_a
     nodes.uniq
   end
 


### PR DESCRIPTION
1. Add test case to check for duplicates. A Set should check for uniqueness. Many users are implementing internally with an array instead of a hash. Also the example code was fixed.
2. Ruby does not have a concept of list, so replacing to_list with to_a
3. Added additional test case in delete to show that CustomSet.new([1,2,3]) != CustomSet.new([1,2.0,3]). I saw some users confused by this.
