### PR TITLE
Changing 'bob' references to 'hamming' in hamming/GETTING_STARTED.md

### DIFF
--- a/hamming/GETTING_STARTED.md
+++ b/hamming/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-These exercises lean on Test-Driven Development (TDD), but tcompute're not an
+These exercises lean on Test-Driven Development (TDD), but they're not an
 exact match.
 
 The following steps assume that you are in the same directory as the test


### PR DESCRIPTION
Not sure if hamming/GETTING_STARTED.md was intended to be more of a template, or to specifically call out the hamming exercise.  Assuming the latter I've updated the references to 'bob' with 'hamming' and addressed the other anomalies.
