### PR TITLE
Fix test to require exact gigasecond, rather than approximate gs based on date

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -1,6 +1,7 @@
 require 'minitest/autorun'
 require 'date'
 require 'time'
+
 require_relative 'gigasecond'
 
 class GigasecondTest < MiniTest::Unit::TestCase
@@ -20,6 +21,12 @@ class GigasecondTest < MiniTest::Unit::TestCase
     skip
     gs = Gigasecond.from(Date.new(1959, 7, 19))
     assert_equal Date.new(1991, 3, 27), gs
+  end
+
+  def test_time_with_seconds
+    skip
+    gs = Gigasecond.from(Time.new(1959, 7, 19, 23, 59, 59))
+    assert_equal Date.new(1991, 3, 28), gs
   end
 
   def test_yourself


### PR DESCRIPTION
Would love to know if this test does what I think it does, I tested it against [This](http://exercism.io/submissions/48a7ecca13d4c47904131b4b) and it failed, passed with the example.
