### PR TITLE
Fix squareness of last crypto-square test

### DIFF
--- a/crypto-square/crypto_square_test.rb
+++ b/crypto-square/crypto_square_test.rb
@@ -64,6 +64,6 @@ class CryptoTest < MiniTest::Unit::TestCase
   def test_more_normalized_ciphertext
     skip
     crypto = Crypto.new('Vampires are people too!')
-    assert_equal 'vrela epems etpao oirpo', crypto.normalize_ciphertext
+    assert_equal 'vrel aepe mset paoo irpo', crypto.normalize_ciphertext
   end
 end


### PR DESCRIPTION
A quick fix to resolve https://github.com/exercism/xruby/issues/37.

Not sure if any other changes might be desirable, e.g. another test case? README amends?
