### PR TITLE
add test to make sure 

### DIFF
--- a/hamming/hamming_test.rb
+++ b/hamming/hamming_test.rb
@@ -32,6 +32,16 @@ class HammingTest < MiniTest::Unit::TestCase
     assert_equal 1, Hamming.compute('GGACG', 'GGTCG')
   end
 
+  def test_nonunique_characters_within_first_strand
+    skip
+    assert_equal 1, Hamming.compute('AGA', 'AGG')
+  end
+
+  def test_nonunique_characters_within_second_strand
+    skip
+    assert_equal 1, Hamming.compute('AGG', 'AGA')
+  end
+
   def test_large_hamming_distance
     skip
     assert_equal 4, Hamming.compute('GATACA', 'GCATAA')


### PR DESCRIPTION
I see you've removed the original tests that were the impetus for my additional tests: 3cbd1b567c287d6b1d4b1d0422d3dbccaab2c0f8 (Testing for longer length strands)

When I was initially doing this exercise I was trying to use the `-` operator, which allowed to falsely get passing tests. 

```
[a,a,b,b,b]-[a,a,b]
=> []
```

rather than:

```
=> [b,b]
```

More contextually relevant example:

```
puts "Should be 1 => #{('AGA'.chars - 'AGG'.chars).length}"
puts "Should be 1 => #{('GGACG'.chars - 'GGTCG'.chars).length}"
```

The first will result in 0, rather than 1 and the second `puts` will result in 1.

So I added two tests to make sure that we're not checking for instances of y, from x (rather than just subtracting from a continuous snippet).
