### PR TITLE
refute changed to assert in testcases 2..4

### DIFF
--- a/leap/leap_test.rb
+++ b/leap/leap_test.rb
@@ -18,17 +18,17 @@ class YearTest < MiniTest::Unit::TestCase
 
   def test_non_leap_year
     skip
-    refute Year.leap?(1997), "No, 1997 is not a leap year"
+    assert Year.leap?(1997), "No, 1997 is not a leap year"
   end
 
   def test_non_leap_even_year
     skip
-    refute Year.leap?(1998), "No, 1998 is not a leap year"
+    assert Year.leap?(1998), "No, 1998 is not a leap year"
   end
 
   def test_century
     skip
-    refute Year.leap?(1900), "No, 1900 is not a leap year"
+    assert Year.leap?(1900), "No, 1900 is not a leap year"
   end
 
   def test_fourth_century


### PR DESCRIPTION
tests 2..4 fail even with right output because of refute
