### PR TITLE
Removed simple delegator from example.rb

### DIFF
--- a/leap/example.rb
+++ b/leap/example.rb
@@ -1,4 +1,4 @@
-class Year < SimpleDelegator
+class Year
   def self.leap?(number)
     Year.new(number).leap?
   end


### PR DESCRIPTION
Should have spotted this in prior change.  I think from now on I will soft link example.rb with the file required for tests, to avoid missing something like this.
