### PR TITLE
generator: refactor implementation, part 2 - extract Repository

### DIFF
--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -16,7 +16,7 @@ module Generator
     attr_reader :paths
 
     def generators
-      implementations.map { |slug| generator(implementation(exercise(slug))) }
+      implementations.map { |slug| generator(implementation(slug)) }
     end
 
     def implementations
@@ -35,11 +35,8 @@ module Generator
       @options[:freeze] || @options[:all]
     end
 
-    def exercise(slug)
-      Exercise.new(slug: slug)
-    end
-
-    def implementation(exercise)
+    def implementation(slug)
+      exercise = Exercise.new(slug: slug)
       LoggingImplementation.new(
         implementation: Implementation.new(paths: paths, exercise: exercise),
         logger: logger

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -13,6 +13,7 @@ module Generator
     end
 
     private
+
     attr_reader :paths
 
     def generators
@@ -37,8 +38,9 @@ module Generator
 
     def implementation(slug)
       exercise = Exercise.new(slug: slug)
+      repository = Repository.new(paths: paths, slug: slug)
       LoggingImplementation.new(
-        implementation: Implementation.new(paths: paths, exercise: exercise),
+        implementation: Implementation.new(repository: repository, exercise: exercise),
         logger: logger
       )
     end

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -3,14 +3,14 @@ module Generator
     module MetadataFiles
       def canonical_data
         CanonicalDataFile.new(
-          filename: File.join(exercise_metadata_path, 'canonical-data.json'),
+          filename: File.join(metadata_path, 'canonical-data.json'),
           repository_root: paths.metadata)
       end
 
       private
 
-      def exercise_metadata_path
-        File.join(paths.metadata, 'exercises', exercise.slug)
+      def metadata_path
+        File.join(paths.metadata, 'exercises', slug)
       end
     end
 

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -19,6 +19,11 @@ module Generator
         TestsTemplateFile.new(filename: tests_template_absolute_filename)
       end
 
+      # FIXME: make this like everything else
+      def source_filepath
+          File.join(generator_path, case_filename)
+      end
+
       private
 
       def exercise_path
@@ -27,6 +32,10 @@ module Generator
 
       def meta_path
         File.join(exercise_path, '.meta')
+      end
+
+      def generator_path
+        File.join(meta_path, 'generator')
       end
 
       def solutions_path
@@ -60,6 +69,10 @@ module Generator
 
       def tests_template_filename
         'test_template.erb'
+      end
+
+      def case_filename
+        "#{slug_underscored}_case.rb"
       end
 
       def slug_underscored

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -19,9 +19,8 @@ module Generator
         TestsTemplateFile.new(filename: tests_template_absolute_filename)
       end
 
-      # FIXME: make this like everything else
-      def source_filepath
-          File.join(generator_path, case_filename)
+      def test_case
+        TestCaseFile.new(filename: File.join(generator_path, case_filename))
       end
 
       private
@@ -105,6 +104,9 @@ module Generator
     end
 
     class TestsTemplateFile < Readable
+    end
+
+    class TestCaseFile < Readable
     end
   end
 end

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -22,7 +22,7 @@ module Generator
       private
 
       def exercise_path
-        File.join(paths.track, 'exercises', exercise.slug)
+        File.join(paths.track, 'exercises', slug)
       end
 
       def meta_path
@@ -34,7 +34,7 @@ module Generator
       end
 
       def minitest_tests_filename
-        "#{exercise.name}_test.rb"
+        "#{slug_underscored}_test.rb"
       end
 
       def version_filename
@@ -42,7 +42,7 @@ module Generator
       end
 
       def example_filename
-        "#{exercise.name}.rb"
+        "#{slug_underscored}.rb"
       end
 
       def tests_template_absolute_filename
@@ -60,6 +60,10 @@ module Generator
 
       def tests_template_filename
         'test_template.erb'
+      end
+
+      def slug_underscored
+        slug.tr('-', '_')
       end
     end
 

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -33,12 +33,6 @@ module Generator
         values: template_values
       )
     end
-
-    private
-
-    def paths
-      repository.paths
-    end
   end
 
   # This exists to give us a clue as to what we are delegating to.

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -1,10 +1,12 @@
 require 'delegate'
+require 'forwardable'
 
 module Generator
   class Implementation
-    include Files::TrackFiles
-    include Files::MetadataFiles
+    extend Forwardable
     include TemplateValuesFactory
+
+    def_delegators :@repository, :tests_version, :example_solution, :tests_template, :minitest_tests, :canonical_data
 
     def initialize(repository:, exercise:)
       @repository = repository

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -6,12 +6,12 @@ module Generator
     include Files::MetadataFiles
     include TemplateValuesFactory
 
-    def initialize(paths:, exercise:)
-      @paths = paths
+    def initialize(repository:, exercise:)
+      @repository = repository
       @exercise = exercise
     end
 
-    attr_reader :paths, :exercise
+    attr_reader :repository, :exercise
 
     def version
       tests_version.to_i
@@ -30,6 +30,12 @@ module Generator
         template: tests_template.to_s,
         values: template_values
       )
+    end
+
+    private
+
+    def paths
+      repository.paths
     end
   end
 

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -6,7 +6,7 @@ module Generator
     extend Forwardable
     include TemplateValuesFactory
 
-    def_delegators :@repository, :tests_version, :example_solution, :tests_template, :minitest_tests, :canonical_data
+    def_delegators :@repository, :tests_version, :example_solution, :tests_template, :minitest_tests, :canonical_data, :test_case
 
     def initialize(repository:, exercise:)
       @repository = repository

--- a/lib/generator/repository.rb
+++ b/lib/generator/repository.rb
@@ -1,0 +1,12 @@
+module Generator
+  class Repository
+    include Files::TrackFiles
+    include Files::MetadataFiles
+
+    attr_reader :paths, :slug
+    def initialize(paths:, slug:)
+      @paths = paths
+      @slug = slug
+    end
+  end
+end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -47,8 +47,7 @@ module Generator
     end
 
     def cases_load_name
-      #Files::GeneratorCases.source_filepath(paths.track, exercise.slug)
-      repository.source_filepath
+      test_case.filename
     end
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -47,7 +47,8 @@ module Generator
     end
 
     def cases_load_name
-      Files::GeneratorCases.source_filepath(paths.track, exercise.slug)
+      #Files::GeneratorCases.source_filepath(paths.track, exercise.slug)
+      repository.source_filepath
     end
   end
 end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -10,9 +10,9 @@ module Generator
       class TestMetadataFiles
         def initialize
           @paths = FixturePaths
-          @exercise = Exercise.new(slug: 'alpha')
+          @slug = 'alpha'
         end
-        attr_reader :paths, :exercise
+        attr_reader :paths, :slug
         include MetadataFiles
       end
 

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -39,6 +39,11 @@ module Generator
         assert_equal expected_filename, subject.tests_template.filename
       end
 
+      def test_test_case
+        subject = TestTrackFiles.new
+        expected_filename = FixturePaths.track + '/exercises/alpha-beta/.meta/generator/alpha_beta_case.rb'
+        assert_equal expected_filename, subject.test_case.filename
+      end
 
       class TestTrackFilesUseDefault
         def initialize

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -11,9 +11,9 @@ module Generator
       class TestTrackFiles
         def initialize
           @paths = FixturePaths
-          @exercise = Exercise.new(slug: 'alpha-beta')
+          @slug  = 'alpha-beta'
         end
-        attr_reader :paths, :exercise
+        attr_reader :paths, :slug
         include TrackFiles
       end
 
@@ -43,9 +43,9 @@ module Generator
       class TestTrackFilesUseDefault
         def initialize
           @paths = FixturePaths
-          @exercise = Exercise.new(slug: 'notemplate')
+          @slug = 'no-template'
         end
-        attr_reader :paths, :exercise
+        attr_reader :paths, :slug
         include TrackFiles
       end
 

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -9,13 +9,16 @@ module Generator
 
     def test_version
       exercise = Minitest::Mock.new.expect :slug, 'alpha'
-      subject = Implementation.new(paths: FixturePaths, exercise: exercise)
+      repository = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(repository: repository, exercise: exercise)
       assert_equal 1, subject.version
     end
 
     def test_update_tests_version
       mock_file = Minitest::Mock.new.expect :write, '2'.length, [2]
-      subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
+      exercise = Exercise.new(slug: 'alpha')
+      repository = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(repository: repository, exercise: exercise)
       # Verify iniital condition from fixture file
       assert_equal 1, subject.tests_version.to_i
       File.stub(:open, true, mock_file) do
@@ -27,7 +30,9 @@ module Generator
     def test_update_example_solution
       expected_content = "# This is the example\n\nclass BookKeeping\n  VERSION = 1\nend\n"
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
+      exercise = Exercise.new(slug: 'alpha')
+      repository = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(repository: repository, exercise: exercise)
       File.stub(:open, true, mock_file) do
         assert_equal expected_content, subject.update_example_solution
       end
@@ -80,7 +85,9 @@ class AlphaTest < Minitest::Test
 end
 TESTS_FILE
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
+      exercise = Exercise.new(slug: 'alpha')
+      repository = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(repository: repository, exercise: exercise)
       GitCommand.stub(:abbreviated_commit_hash, '123456789') do
         File.stub(:open, true, mock_file) do
           assert_equal expected_content, subject.build_tests

--- a/test/generator/repository_test.rb
+++ b/test/generator/repository_test.rb
@@ -1,0 +1,10 @@
+require_relative '../test_helper'
+
+module Generator
+  class RepositoryTest < Minitest::Test
+    def test_construction
+      subject = Repository.new(paths: nil, slug: nil)
+      assert_instance_of Repository, subject
+    end
+  end
+end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -62,9 +62,8 @@ module Generator
         mock_canonical_data
       end
 
-      def repository
-        mock_repository = Minitest::Mock.new
-        mock_repository.expect :source_filepath, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb'
+      def test_case
+        Files::TestCaseFile.new(filename: 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb')
       end
 
       include TemplateValuesFactory

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -62,10 +62,9 @@ module Generator
         mock_canonical_data
       end
 
-      def paths
-        mock_paths = Minitest::Mock.new
-        mock_paths.expect :track, 'test/fixtures/xruby'
-        mock_paths
+      def repository
+        mock_repository = Minitest::Mock.new
+        mock_repository.expect :source_filepath, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb'
       end
 
       include TemplateValuesFactory


### PR DESCRIPTION
Extract a `Repository` class that takes `paths` and `slug` as constructor arguments.

Repository in this case is an implementation of the Repository pattern which acts as an interface to all the data that an `Implementation` needs rather than anything related to Git repositories.

Continues the work done in #677, 
Supersedes  #643

