### PR TITLE
dominoes: Update generator and test cases

### DIFF
--- a/exercises/dominoes/.meta/generator/dominoes_case.rb
+++ b/exercises/dominoes/.meta/generator/dominoes_case.rb
@@ -9,7 +9,7 @@ class DominoesCase < Generator::ExerciseCase
     <<-WL.chomp
 input_dominoes = #{input}
     output_chain = Dominoes.chain(input_dominoes)
-    #{can_chain ? 'assert' : 'refute' }_correct_chain(input_dominoes, output_chain)
+    #{expected ? 'assert' : 'refute' }_correct_chain(input_dominoes, output_chain)
     WL
   end
 

--- a/exercises/dominoes/dominoes_test.rb
+++ b/exercises/dominoes/dominoes_test.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require_relative 'dominoes'
 
-# Common test data version: 1.0.1 33f20d3
+# Common test data version: 2.0.0 b4ceaf4
 class DominoesTest < Minitest::Test
   def test_empty_input_empty_output
     # skip


### PR DESCRIPTION
Fixed the generator which broke when the expected value key was changed in the canonical data.

Regenerated test cases based on updated canonical data.

No change to the content of the tests so no BookKeeping::VERSION increment is required.
