### PR TITLE
Remove instructions for direct test execution.

### DIFF
--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -22,8 +22,3 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-The test files may have the execution bit set so you may also be able to
-run it like this:
-
-    ./hello_world_test.rb
-


### PR DESCRIPTION
Since the [removal of the shebang line](https://github.com/exercism/ruby/pull/685) tests are no longer directly executable, so remove the instructions about that from the Readme.

