### PR TITLE
Fix phone-number test method name.

### DIFF
--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -53,12 +53,12 @@ class PhoneNumberTest < Minitest::Test
     assert_nil PhoneNumber.clean("123-@:!-7890")
   end
 
-  def test_invalid_if_area_code_does_not_start_with_2_9
+  def test_invalid_if_area_code_does_not_start_with_2_2
     skip
     assert_nil PhoneNumber.clean("(123) 456-7890")
   end
 
-  def test_invalid_if_exchange_code_does_not_start_with_2_9
+  def test_invalid_if_exchange_code_does_not_start_with_4_5
     skip
     assert_nil PhoneNumber.clean("(223) 056-7890")
   end


### PR DESCRIPTION
The test method names are referencing area and exchange codes that start
with 2_9, but the actual inputs start with 2_2 and 4_5 respectively.

This change updates the name to reflect the actual inputs.

REF #598