### PR TITLE
config.json: Add blurb, fix Gitter name

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "language": "Ruby",
   "active": true,
   "blurb" : "Ruby is a dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.",
-  "gitter": "xruby",
+  "gitter": "ruby",
   "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "exercises": [
     {

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "language": "Ruby",
   "active": true,
+  "blurb" : "Ruby is a dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.",
   "gitter": "xruby",
   "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "exercises": [


### PR DESCRIPTION
The `blurb` is required by Nextercism to give a short overview of the language.

This text is taken from the front page of https://www.ruby-lang.org/en/
