### PR TITLE
generator: hamming: Change error expectation to match json data.

### DIFF
--- a/exercises/hamming/.meta/generator/hamming_case.rb
+++ b/exercises/hamming/.meta/generator/hamming_case.rb
@@ -2,7 +2,7 @@ require 'generator/exercise_case'
 
 class HammingCase < Generator::ExerciseCase
   def workload
-    if raises_error?
+    if expects_error?
       assert_raises(ArgumentError) { test_case }
     else
       assert_equal { test_case }
@@ -13,5 +13,9 @@ class HammingCase < Generator::ExerciseCase
 
   def test_case
     "Hamming.compute('#{strand1}', '#{strand2}')"
+  end
+
+  def expects_error?
+    expected.is_a? Hash
   end
 end


### PR DESCRIPTION
The 'Hamming' canonical data has changed to return a hash when the
expected value is an error, rather than the integer value -1 that was
used previously.

Fixes #707 