### PR TITLE
Moving away from using Fixnum due to deprecation

### DIFF
--- a/exercises/collatz-conjecture/.meta/generator/collatz_conjecture_case.rb
+++ b/exercises/collatz-conjecture/.meta/generator/collatz_conjecture_case.rb
@@ -4,7 +4,7 @@ class CollatzConjectureCase < Generator::ExerciseCase
 
   def workload
     case expected
-    when Fixnum
+    when Integer
       standard_assertion
     when Hash
       error_assertion

--- a/exercises/roman-numerals/.meta/solutions/roman_numerals.rb
+++ b/exercises/roman-numerals/.meta/solutions/roman_numerals.rb
@@ -2,7 +2,7 @@ module BookKeeping
   VERSION = 2
 end
 
-class Fixnum
+class Integer
   def to_roman
     i = self
     s = ''

--- a/lib/generator/underscore.rb
+++ b/lib/generator/underscore.rb
@@ -10,7 +10,7 @@ module Generator
       end
     end
 
-    refine Fixnum do
+    refine Integer do
       def underscore
         self.to_s.reverse.gsub(/...(?=.)/, '\&_').reverse
       end


### PR DESCRIPTION
Ruby is/has deprecated the use of Fixnum, so we should as well.