### PR TITLE
Autogenerate README based on description.md

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -3,7 +3,7 @@
 require_relative '../lib/helper'
 require 'generator'
 
-paths = Generator::Paths.new(track: EXERCISM_RUBY_ROOT, metadata: METADATA_REPOSITORY_PATH)
+paths = Generator::Paths.new(track: EXERCISM_RUBY_ROOT, docs: EXERCISM_RUBY_DOCS, metadata: METADATA_REPOSITORY_PATH)
 
 generators = Generator::CommandLine.new(paths).parse(ARGV)
 exit 1 unless generators

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -22,3 +22,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -1,5 +1,3 @@
-# Acronym
-
 Convert a phrase to its acronym.
 
 Techies love their TLA (Three Letter Acronyms)!

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -32,10 +32,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Julien Vanier [https://github.com/monkbroc](https://github.com/monkbroc)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -1,4 +1,4 @@
-# All Your Base
+# All_your_base
 
 Convert a number, represented as a sequence of digits in one base, to any other base.
 
@@ -54,8 +54,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -1,5 +1,3 @@
-# All_your_base
-
 Convert a number, represented as a sequence of digits in one base, to any other base.
 
 Implement general base conversion. Given a number in base **a**,

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -1,5 +1,3 @@
-# Alphametics
-
 Write a function to solve alphametics puzzles.
 
 [Alphametics](https://en.wikipedia.org/wiki/Alphametics) is a puzzle where

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -55,7 +55,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -30,10 +30,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,5 +1,3 @@
-# Anagram
-
 Given a word and a list of possible anagrams, select the correct sublist.
 
 Given `"listen"` and a list of candidates like `"enlists" "google"

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,4 +1,4 @@
-# Beer Song
+# Beer_song
 
 Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
 
@@ -343,11 +343,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,5 +1,3 @@
-# Beer_song
-
 Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
 
 Note that not all verses are identical.

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -52,10 +52,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -1,5 +1,3 @@
-# Binary
-
 Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
 
 Implement binary to decimal conversion. Given a binary input

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,5 +1,3 @@
-# Bob
-
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -35,10 +35,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -70,10 +70,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-The Bowling Game Kata at but UncleBob [http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -1,5 +1,3 @@
-# Bowling
-
 Score a bowling game.
 
 Bowling is game where players roll a heavy ball to knock down pins

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -1,5 +1,3 @@
-# Bracket_push
-
 Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
 verify that all the pairs are matched and nested correctly.
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -1,4 +1,4 @@
-# Bracket Push
+# Bracket_push
 
 Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
 verify that all the pairs are matched and nested correctly.
@@ -26,11 +26,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Ginna Baker
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -1,5 +1,3 @@
-# Change
-
 Correctly determine the fewest number of coins to be given to a customer such
 that the sum of the coins' value would equal the correct amount of change.
 

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -1,21 +1,20 @@
-# Raindrops
+# Change
 
-Convert a number to a string, the contents of which depend on the number's factors.
+Correctly determine the fewest number of coins to be given to a customer such
+that the sum of the coins' value would equal the correct amount of change.
 
-- If the number has 3 as a factor, output 'Pling'.
-- If the number has 5 as a factor, output 'Plang'.
-- If the number has 7 as a factor, output 'Plong'.
-- If the number does not have 3, 5, or 7 as a factor,
-  just pass the number's digits straight through.
+## For example
 
-## Examples
+- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) or [0, 1, 1, 0, 0]
+- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]
 
-- 28's factors are 1, 2, 4, **7**, 14, 28.
-  - In raindrop-speak, this would be a simple "Plong".
-- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
-  - In raindrop-speak, this would be a "PlingPlang".
-- 34 has four factors: 1, 2, 17, and 34.
-  - In raindrop-speak, this would be "34".
+## Edge cases
+
+- Does your algorithm work for any given set of coins?
+- Can you ask for negative change?
+- Can you ask for a change value smaller than the smallest coin value?
 
 * * * *
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,5 +1,3 @@
-# Clock
-
 Implement a clock that handles times without dates.
 
 You should be able to add and subtract minutes to it.

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -30,10 +30,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -1,4 +1,4 @@
-# Collatz Conjecture
+# Collatz_conjecture
 
 The Collatz Conjecture or 3x+1 problem can be summarized as follows:
 
@@ -49,11 +49,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -1,5 +1,3 @@
-# Collatz_conjecture
-
 The Collatz Conjecture or 3x+1 problem can be summarized as follows:
 
 Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -1,5 +1,3 @@
-# Connect
-
 Compute the result for a game of Hex / Polygon.
 
 The abstract boardgame known as

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -54,7 +54,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -1,4 +1,4 @@
-# Custom Set
+# Custom_set
 
 Create a custom set type.
 
@@ -30,8 +30,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -1,5 +1,3 @@
-# Custom_set
-
 Create a custom set type.
 
 Sometimes it is necessary to define a custom data structure of some

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,5 +1,3 @@
-# Difference_of_squares
-
 Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
 
 The square of the sum of the first ten natural numbers is

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,4 +1,4 @@
-# Difference Of Squares
+# Difference_of_squares
 
 Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
 
@@ -35,11 +35,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -38,7 +38,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -1,5 +1,3 @@
-# Dominoes
-
 Make a chain of dominoes.
 
 Compute a way to order a given set of dominoes in such a way that they form a

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -68,10 +68,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,5 +1,3 @@
-# Etl
-
 We are going to do the `Transform` step of an Extract-Transform-Load.
 
 ### ETL

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -28,10 +28,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,5 +1,3 @@
-# Gigasecond
-
 Calculate the moment when someone has lived for 10^9 seconds.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -51,10 +51,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -1,5 +1,3 @@
-# Grains
-
 Calculate the number of grains of wheat on a chessboard given that the number
 on each square doubles.
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -59,10 +59,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,5 +1,3 @@
-# Hamming
-
 Calculate the Hamming difference between two DNA strands.
 
 A mutation is simply a mistake that occurs during the creation or

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,5 +1,3 @@
-# Hello_world
-
 The classical introductory exercise. Just say "Hello, World!".
 
 ["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,4 +1,4 @@
-# Hello World
+# Hello_world
 
 The classical introductory exercise. Just say "Hello, World!".
 
@@ -37,11 +37,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -1,5 +1,3 @@
-# Isogram
-
 Determine if a word or phrase is an isogram.
 
 An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -36,10 +36,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Wikipedia [https://en.wikipedia.org/wiki/Isogram](https://en.wikipedia.org/wiki/Isogram)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,5 +1,3 @@
-# Largest_series_product
-
 Given a string of digits, calculate the largest product for a contiguous
 substring of digits of length n.
 

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,4 +1,4 @@
-# Largest Series Product
+# Largest_series_product
 
 Given a string of digits, calculate the largest product for a contiguous
 substring of digits of length n.
@@ -36,11 +36,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,5 +1,3 @@
-# Leap
-
 Given a year, report if it is a leap year.
 
 The tricky thing here is that a leap year in the Gregorian calendar occurs:

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -50,10 +50,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -88,10 +88,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -1,5 +1,3 @@
-# Luhn
-
 Given a number determine whether or not it is valid per the Luhn formula.
 
 The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -1,4 +1,4 @@
-# Nth Prime
+# Nth_prime
 
 Given a number n, determine what the nth prime is.
 
@@ -31,11 +31,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-A variation on Problem 7 at Project Euler [http://projecteuler.net/problem=7](http://projecteuler.net/problem=7)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -1,5 +1,3 @@
-# Nth_prime
-
 Given a number n, determine what the nth prime is.
 
 By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -1,4 +1,4 @@
-# Ocr Numbers
+# Ocr_numbers
 
 Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
 represented, or whether it is garbled.
@@ -101,11 +101,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Inspired by the Bank OCR kata [http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR](http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -1,5 +1,3 @@
-# Ocr_numbers
-
 Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
 represented, or whether it is garbled.
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -32,10 +32,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -1,5 +1,3 @@
-# Pangram
-
 Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
 "every letter") is a sentence using every letter of the alphabet at least once.
 The best known English pangram is: 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,5 +1,3 @@
-# Phone_number
-
 Clean up user-entered phone numbers so that they can be sent SMS messages.
 
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,4 +1,4 @@
-# Phone Number
+# Phone_number
 
 Clean up user-entered phone numbers so that they can be sent SMS messages.
 
@@ -50,11 +50,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -1,5 +1,3 @@
-# Pig_latin
-
 Implement a program that translates from English to Pig Latin.
 
 Pig Latin is a made-up children's language that's intended to be

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -1,4 +1,4 @@
-# Pig Latin
+# Pig_latin
 
 Implement a program that translates from English to Pig Latin.
 
@@ -40,11 +40,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-The Pig Latin exercise at Test First Teaching by Ultrasaurus [https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/](https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -1,4 +1,4 @@
-# Queen Attack
+# Queen_attack
 
 Given the position of two queens on a chess board, indicate whether or not they
 are positioned so that they can attack each other.
@@ -49,11 +49,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -1,5 +1,3 @@
-# Queen_attack
-
 Given the position of two queens on a chess board, indicate whether or not they
 are positioned so that they can attack each other.
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,5 +1,3 @@
-# Raindrops
-
 Convert a number to a string, the contents of which depend on the number's factors.
 
 - If the number has 3 as a factor, output 'Pling'.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,5 +1,3 @@
-# Rna_transcription
-
 Given a DNA strand, return its RNA complement (per RNA transcription).
 
 Both DNA and RNA strands are a sequence of nucleotides.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,4 +1,4 @@
-# Rna Transcription
+# Rna_transcription
 
 Given a DNA strand, return its RNA complement (per RNA transcription).
 
@@ -41,11 +41,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,4 +1,4 @@
-# Roman Numerals
+# Roman_numerals
 
 Write a function to convert from normal numbers to Roman Numerals.
 
@@ -65,11 +65,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,5 +1,3 @@
-# Roman_numerals
-
 Write a function to convert from normal numbers to Roman Numerals.
 
 The Romans were a clever bunch. They conquered most of Europe and ruled

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -1,0 +1,57 @@
+# Rotational_cipher
+
+Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
+
+The Caesar cipher is a simple shift cipher that relies on
+transposing all the letters in the alphabet using an integer key
+between `0` and `26`. Using a key of `0` or `26` will always yield
+the same output due to modular arithmetic. The letter is shifted
+for as many values as the value of the key.
+
+The general notation for rotational ciphers is `ROT + <key>`.
+The most commonly used rotational cipher is `ROT13`.
+
+A `ROT13` on the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: nopqrstuvwxyzabcdefghijklm
+```
+
+It is stronger than the Atbash cipher because it has 27 possible keys, and 25 usable keys.
+
+Ciphertext is written out in the same formatting as the input including spaces and punctuation.
+
+## Examples
+- ROT5  `omg` gives `trl`
+- ROT0  `c` gives `c`
+- ROT26 `Cool` gives `Cool`
+- ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
+- ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+In order to run the test, you can run the test file from the exercise
+directory. For example, if the test suite is called
+`hello_world_test.rb`, you can run the following command:
+
+    ruby hello_world_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride hello_world_test.rb
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -1,5 +1,3 @@
-# Rotational_cipher
-
 Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
 
 The Caesar cipher is a simple shift cipher that relies on

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -1,5 +1,3 @@
-# Run_length_encoding
-
 Implement run-length encoding and decoding.
 
 Run-length encoding (RLE) is a simple form of data compression, where runs

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -1,4 +1,4 @@
-# Run Length Encoding
+# Run_length_encoding
 
 Implement run-length encoding and decoding.
 
@@ -46,11 +46,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -1,5 +1,3 @@
-# Say
-
 Given a number from 0 to 999,999,999,999, spell out that number in English.
 
 ## Step 1

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -86,10 +86,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -1,5 +1,3 @@
-# Sieve
-
 Use the Sieve of Eratosthenes to find all the primes from 2 up to a given
 number.
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -51,10 +51,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Sieve of Eratosthenes at Wikipedia [http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,4 +1,4 @@
-# Space Age
+# Space_age
 
 Given an age in seconds, calculate how old someone would be on:
 
@@ -12,7 +12,8 @@ Given an age in seconds, calculate how old someone would be on:
    - Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31 Earth-years old.
+be able to say that they're 31.69 Earth-years old. Round all ages to
+the nearest hundredth of a year.
 
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
@@ -40,11 +41,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,5 +1,3 @@
-# Space_age
-
 Given an age in seconds, calculate how old someone would be on:
 
    - Earth: orbital period 365.25 Earth days, or 31557600 seconds

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,4 +1,4 @@
-# Sum Of Multiples
+# Sum_of_multiples
 
 Given a number, find the sum of all the multiples of particular numbers up to
 but not including that number.
@@ -34,11 +34,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,5 +1,3 @@
-# Sum_of_multiples
-
 Given a number, find the sum of all the multiples of particular numbers up to
 but not including that number.
 

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -1,5 +1,3 @@
-# Tournament
-
 Tally the results of a small football competition.
 
 Based on an input file containing which team played against which and what the

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -88,7 +88,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -1,5 +1,3 @@
-# Transpose
-
 Given an input text output it transposed.
 
 Roughly explained, the transpose of a matrix:

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -82,10 +82,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Reddit r/dailyprogrammer challenge #270 [Easy]. [https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text](https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -43,10 +43,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,5 +1,3 @@
-# Triangle
-
 Determine if a triangle is equilateral, isosceles, or scalene.
 
 An _equilateral_ triangle has all three sides the same length.<br/>

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -1,4 +1,4 @@
-# Two Bucket
+# Two_bucket
 
 Given two buckets of different size, demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
 
@@ -52,11 +52,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-Water Pouring Problem [http://demonstrations.wolfram.com/WaterPouringProblem/](http://demonstrations.wolfram.com/WaterPouringProblem/)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -1,5 +1,3 @@
-# Two_bucket
-
 Given two buckets of different size, demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
 
 Since this mathematical problem is fairly subject to interpretation / individual approach, the tests have been written specifically to expect one overarching solution.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,4 +1,4 @@
-# Word Count
+# Word_count
 
 Given a phrase, count the occurrences of each word in that phrase.
 
@@ -35,11 +35,6 @@ directory. For example, if the test suite is called
 To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
-
-
-## Source
-
-This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,5 +1,3 @@
-# Word_count
-
 Given a phrase, count the occurrences of each word in that phrase.
 
 For example for the input `"olly olly in come free"`

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -80,10 +80,5 @@ To include color from the command line:
 
     ruby -r minitest/pride hello_world_test.rb
 
-
-## Source
-
-Inspired by one of the generated questions in the Extreme Startup game. [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -1,5 +1,3 @@
-# Wordy
-
 Parse and evaluate simple math word problems returning the answer as an integer.
 
 

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -4,9 +4,10 @@ require_rel 'generator' # Include everything in the 'generator' subdirectory
 module Generator
   # Immutable value object for storing paths
   class Paths
-    attr_reader :track, :metadata
-    def initialize(track:, metadata:)
+    attr_reader :track, :docs, :metadata
+    def initialize(track:, docs:, metadata:)
       @track = track
+      @docs = docs
       @metadata = metadata
     end
   end
@@ -16,6 +17,7 @@ module Generator
   class GenerateTests < ImplementationDelegator
     def call
       build_tests
+      build_readme
     end
   end
 
@@ -25,6 +27,7 @@ module Generator
       update_tests_version
       update_example_solution
       build_tests
+      build_readme
     end
   end
 end

--- a/lib/generator/exercise.rb
+++ b/lib/generator/exercise.rb
@@ -12,6 +12,10 @@ module Generator
       @name ||= slug.underscore
     end
 
+    def directory
+      "exercises/#{@slug}"
+    end
+
     def case_class
       slug.camel_case + 'Case'
     end

--- a/lib/generator/exercise.rb
+++ b/lib/generator/exercise.rb
@@ -16,6 +16,10 @@ module Generator
       "exercises/#{@slug}"
     end
 
+    def readme
+      "exercises/#{@slug}/README.md"
+    end
+
     def case_class
       slug.camel_case + 'Case'
     end

--- a/lib/generator/files.rb
+++ b/lib/generator/files.rb
@@ -7,9 +7,10 @@ module Generator
     end
 
     class Readable
-      attr_reader :filename, :repository_root
-      def initialize(filename:, repository_root: nil)
+      attr_reader :filename, :docs, :repository_root
+      def initialize(filename:, docs: nil, repository_root: nil)
         @filename = filename
+        @docs = docs
         @repository_root = repository_root
       end
 

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -4,6 +4,7 @@ module Generator
       def canonical_data
         CanonicalDataFile.new(
           filename: File.join(metadata_path, 'canonical-data.json'),
+          docs: File.join(metadata_path, 'description.md'),
           repository_root: paths.metadata)
       end
 

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -36,13 +36,9 @@ module Generator
 
     def build_readme
       canonicalDocs = File.read(@repository.canonical_data().docs)
-      docs = File.read(@repository.paths.docs)
-      ne = "#{@repository.paths.track}/#{@exercise.directory}/README.md"
-      File.open(ne, "w") do |handle|
-        handle.puts "# #{@exercise.name.capitalize}\n\n"
-        handle.puts "#{canonicalDocs}\n"
-        handle.puts docs
-      end
+      rubyDocs = File.read(@repository.paths.docs)
+      readme = File.join(@repository.paths.track, @exercise.readme)
+      File.open(readme, "w") { |handle| handle.puts "#{canonicalDocs}\n#{rubyDocs}" }
     end
   end
 

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -33,6 +33,17 @@ module Generator
         values: template_values
       )
     end
+
+    def build_readme
+      canonicalDocs = File.read(@repository.canonical_data().docs)
+      docs = File.read(@repository.paths.docs)
+      ne = "#{@repository.paths.track}/#{@exercise.directory}/README.md"
+      File.open(ne, "w") do |handle|
+        handle.puts "# #{@exercise.name.capitalize}\n\n"
+        handle.puts "#{canonicalDocs}\n"
+        handle.puts docs
+      end
+    end
   end
 
   # This exists to give us a clue as to what we are delegating to.
@@ -59,6 +70,11 @@ module Generator
     def build_tests
       @implementation.build_tests
       @logger.info "Generated #{exercise.slug} tests version #{version}"
+    end
+
+    def build_readme
+      @implementation.build_readme
+      @logger.info "Generated #{exercise.slug} README"
     end
   end
 end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -1,5 +1,6 @@
 EXERCISM_RUBY_ROOT = File.join(File.dirname(__FILE__), '..').freeze
 EXERCISM_RUBY_LIB = File.join(EXERCISM_RUBY_ROOT, 'lib').freeze
+EXERCISM_RUBY_DOCS = File.join(EXERCISM_RUBY_ROOT, 'docs/EXERCISE_README_INSERT.md').freeze
 METADATA_REPOSITORY_PATH = File.join(EXERCISM_RUBY_ROOT, '..', 'problem-specifications').freeze
 
 $LOAD_PATH.unshift(EXERCISM_RUBY_LIB)

--- a/test/fixtures/docs/EXERCISE_README_INSERT.md
+++ b/test/fixtures/docs/EXERCISE_README_INSERT.md
@@ -1,0 +1,2 @@
+****
+Ruby instructions on how to run tests.

--- a/test/fixtures/metadata/exercises/alpha/description.md
+++ b/test/fixtures/metadata/exercises/alpha/description.md
@@ -1,0 +1,5 @@
+Add two numbers together
+
+## Requirements
+
+* The numbers should be added together

--- a/test/generator/command_line/generator_optparser_test.rb
+++ b/test/generator/command_line/generator_optparser_test.rb
@@ -4,6 +4,7 @@ module Generator
   class GeneratorOptparserTest < Minitest::Test
     FixturePaths = Paths.new(
       metadata: 'test/fixtures/metadata',
+      docs: 'test/fixtures/metadata',
       track: 'test/fixtures/ruby'
     )
 
@@ -87,7 +88,7 @@ module Generator
     end
 
     def test_invalid_metadata_repository_outputs_message_to_stderr
-      paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil)
+      paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil, docs: nil)
       expected_stderr = <<-MESSAGE.gsub(/^ {6}/, '')
       'problem-specifications' repository not found.
       Try running the command:

--- a/test/generator/command_line_test.rb
+++ b/test/generator/command_line_test.rb
@@ -4,6 +4,7 @@ module Generator
   class CommandLineTest < Minitest::Test
     FixturePaths = Paths.new(
       metadata: 'test/fixtures/metadata',
+      docs: 'test/fixtures/metadata',
       track: 'test/fixtures/ruby'
     )
 
@@ -15,7 +16,7 @@ module Generator
     end
 
     def test_invalid_metadata_repository_outputs_message_to_stderr
-      paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil)
+      paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil, docs: nil)
       expected_stderr = <<-MESSAGE.gsub(/^ {6}/, '')
       'problem-specifications' repository not found.
       Try running the command:

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -4,6 +4,7 @@ module Generator
     class MetadataFilesTest < Minitest::Test
       FixturePaths = Paths.new(
         metadata: 'test/fixtures/metadata',
+        docs: 'test/fixtures/metadata',
         track: 'test/fixtures/ruby'
       )
 

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -5,6 +5,7 @@ module Generator
     class TrackFilesTest < Minitest::Test
       FixturePaths = Paths.new(
         metadata: 'test/fixtures/metadata',
+        docs: 'test/fixtures/metadata',
         track: 'test/fixtures/ruby'
       )
 

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -4,6 +4,7 @@ module Generator
   class ImplementationTest < Minitest::Test
     FixturePaths = Paths.new(
       metadata: 'test/fixtures/metadata',
+      docs: 'test/fixtures/metadata',
       track: 'test/fixtures/ruby'
     )
 

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -4,7 +4,7 @@ module Generator
   class ImplementationTest < Minitest::Test
     FixturePaths = Paths.new(
       metadata: 'test/fixtures/metadata',
-      docs: 'test/fixtures/metadata',
+      docs: 'test/fixtures/docs/EXERCISE_README_INSERT.md',
       track: 'test/fixtures/ruby'
     )
 
@@ -97,6 +97,16 @@ TESTS_FILE
       # Don't pollute the namespace
       Object.send(:remove_const, :AlphaCase)
     end
+
+    def test_build_readme
+      expected_content = "Add two numbers together\n\n## Requirements\n\n* The numbers should be added together\n\n****\nRuby instructions on how to run tests."
+      mock_file = Minitest::Mock.new.expect :puts, expected_content.length, [expected_content]
+      exercise = Exercise.new(slug: 'alpha')
+      repository = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(repository: repository, exercise: exercise)
+      File.stub(:open, true, mock_file) { subject.build_readme }
+      mock_file.verify
+    end
   end
 
   class LoggingImplementationTest < Minitest::Test
@@ -111,6 +121,20 @@ TESTS_FILE
 
       subject = LoggingImplementation.new(implementation: mock_implementation, logger: mock_logger)
       subject.build_tests
+
+      mock_implementation.verify
+    end
+
+    def test_build_readme
+      exercise = Exercise.new(slug: 'alpha')
+      mock_implementation = Minitest::Mock.new
+      mock_implementation.expect :build_readme, nil
+      mock_implementation.expect :exercise, exercise
+      mock_logger = Minitest::Mock.new
+      mock_logger.expect :info, nil, ['Generated alpha README']
+
+      subject = LoggingImplementation.new(implementation: mock_implementation, logger: mock_logger)
+      subject.build_readme
 
       mock_implementation.verify
     end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -7,6 +7,7 @@ module Generator
       mock_exercise.expect :update_tests_version, nil
       mock_exercise.expect :update_example_solution, nil
       mock_exercise.expect :build_tests, nil
+      mock_exercise.expect :build_readme, nil
 
       subject = UpdateVersionAndGenerateTests.new(mock_exercise)
       subject.call
@@ -19,6 +20,7 @@ module Generator
     def test_call
       mock_exercise = Minitest::Mock.new
       mock_exercise.expect :build_tests, nil
+      mock_exercise.expect :build_readme, nil
 
       subject = GenerateTests.new(mock_exercise)
       subject.call


### PR DESCRIPTION
## Why?
According to the docs, README are auto-generated but that is not the case: https://github.com/exercism/ruby#readmes

Manually copy-pasting README from problem-specifications can lead to errors. This creates consistency across all READMEs. 

## What?
README is generated by combining:
1) https://github.com/exercism/problem-specifications/blob/master/exercises/accumulate/description.md
2) https://github.com/exercism/ruby/blob/master/docs/EXERCISE_README_INSERT.md

## How Has This Been Tested?
rake test
./bin/generate

## Types of changes
- [x] Add build_readme to generator
- [x] Add unit tests for generator
- [x] Run generator across all tests to create uniform READMEs

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
