### PR TITLE
Invoke configlet to create README during generate process.

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -3,18 +3,20 @@
 require_relative '../lib/helper'
 require 'generator'
 
-paths = Generator::Paths.new(track: EXERCISM_RUBY_ROOT, metadata: METADATA_REPOSITORY_PATH)
-
-generators = Generator::CommandLine.new(paths).parse(ARGV)
-exit 1 unless generators
-
-generators.map(&:call)
-
 configletPath = "#{EXERCISM_RUBY_ROOT}/bin/configlet"
 unless File.file?(configletPath)
   raise Exception.new("Unable to find configlet, fetch using bin/fetch_configlet")
 end
 
+paths = Generator::Paths.new(track: EXERCISM_RUBY_ROOT, metadata: METADATA_REPOSITORY_PATH)
+
+generators = Generator::CommandLine.new(paths).parse(ARGV)
+exit 1 unless generators
+
 generators.each do |generator|
+  # Generate tests
+  generator.call
+
+  # Generate READMEs
   system("#{configletPath} generate #{EXERCISM_RUBY_ROOT} --only=#{generator.exercise.slug}")
 end

--- a/bin/generate
+++ b/bin/generate
@@ -9,3 +9,12 @@ generators = Generator::CommandLine.new(paths).parse(ARGV)
 exit 1 unless generators
 
 generators.map(&:call)
+
+configletPath = "#{EXERCISM_RUBY_ROOT}/bin/configlet"
+unless File.file?(configletPath)
+  raise Exception.new("Unable to find configlet, fetch using bin/fetch_configlet")
+end
+
+generators.each do |generator|
+  system("#{configletPath} generate #{EXERCISM_RUBY_ROOT} --only=#{generator.exercise.slug}")
+end


### PR DESCRIPTION
## Why?
According to the docs, README are auto-generated but that is not the case: https://github.com/exercism/ruby#readmes

Manually copy-pasting README from problem-specifications can lead to errors. This creates consistency across all READMEs. 

## What?
README is generated by calling configlet command
`
./configlet generate . --only=acronym
`

## How Has This Been Tested?

1. Removal of README inside of directory
`
rm exercises/acronym/README.md 
`
2. Run bin/generate acronym -f
3. Verify README is generated for acronym

## Types of changes
- [x] Add configlet invocation to generator

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
