### PR TITLE
generator: Replace exercise_name_camel method

### DIFF
--- a/exercises/space-age/.meta/generator/test_template.erb
+++ b/exercises/space-age/.meta/generator/test_template.erb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative '<%= exercise_name %>'
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
-class <%= exercise_name_camel %>Test < Minitest::Test
+class <%= exercise_test_classname %> < Minitest::Test
   # assert_in_delta will pass if the difference
   # between the values being compared is less
   # than the allowed delta

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -17,6 +17,12 @@ module Generator
       binding
     end
 
+    def exercise_test_classname
+      exercise_name_camel + 'Test'
+    end
+
+    private
+
     def exercise_name_camel
       exercise_name.split('_').map(&:capitalize).join
     end

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative '<%= exercise_name %>'
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
-class <%= exercise_name_camel %>Test < Minitest::Test
+class <%= exercise_test_classname %> < Minitest::Test
 <% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
     <%= test_case.skipped(idx) %>

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -26,10 +26,10 @@ module Generator
       assert_equal expected_exercise_name, subject.exercise_name
     end
 
-    def test_exercise_name_camel
-      expected_exercise_name_camel = 'AlphaBeta'
+    def test_exercise_test_classname
+      expected = 'AlphaBetaTest'
       subject = TemplateValues.new(@arguments.merge(exercise_name: 'alpha_beta'))
-      assert_equal expected_exercise_name_camel, subject.exercise_name_camel
+      assert_equal expected, subject.exercise_test_classname
     end
 
     def test_test_cases


### PR DESCRIPTION
The only place it is used is in the test template:
```
class <%= exercise_name_camel %>Test < Minitest::Test
```
Replace it with a new method `exercise_test_classname` that returns the
full expected classname without having to confuse the template user with
camels.

Closes #651 