### PR TITLE
Fix template fails with configlet v3.5.1

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -1,13 +1,13 @@
 # {{ .Spec.Name }}
 
-{{ .Spec.Description -}}
-{{- with .Hints }}
+{{ .Spec.Description }}
+{{ with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
+{{ with .TrackInsert }}
 {{ . }}
 {{ end }}
-{{- with .Spec.Credits -}}
+{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}


### PR DESCRIPTION
The latest version of configlet throws an error when the template
includes `{{- -}}`

```
-> 1 error occurred:

* template: readme:3: illegal number syntax: "-"
``