### PR TITLE
guide user to create proper class and method via class instantiation in test file

### DIFF
--- a/exercises/roman-numerals/roman_numerals_test.rb
+++ b/exercises/roman-numerals/roman_numerals_test.rb
@@ -9,70 +9,87 @@ class RomanNumeralsTest < Minitest::Test
   end
 
   def test_2
+    skip
     assert_equal 'II', Numeric.new(2).to_roman
   end
 
   def test_3
+    skip
     assert_equal 'III', Numeric.new(3).to_roman
   end
 
   def test_4
+    skip
     assert_equal 'IV', Numeric.new(4).to_roman
   end
 
   def test_5
+    skip
     assert_equal 'V', Numeric.new(5).to_roman
   end
 
   def test_6
+    skip
     assert_equal 'VI', Numeric.new(6).to_roman
   end
 
   def test_9
+    skip
     assert_equal 'IX', Numeric.new(9).to_roman
   end
 
   def test_27
+    skip
     assert_equal 'XXVII', Numeric.new(27).to_roman
   end
 
   def test_48
+    skip
     assert_equal 'XLVIII', Numeric.new(48).to_roman
   end
 
   def test_59
+    skip
     assert_equal 'LIX', Numeric.new(59).to_roman
   end
 
   def test_93
+    skip
     assert_equal 'XCIII', Numeric.new(93).to_roman
   end
 
   def test_141
+    skip
     assert_equal 'CXLI', Numeric.new(141).to_roman
   end
 
   def test_163
+    skip
     assert_equal 'CLXIII', Numeric.new(163).to_roman
   end
 
   def test_402
+    skip
     assert_equal 'CDII', Numeric.new(402).to_roman
   end
 
   def test_575
+    skip
     assert_equal 'DLXXV', Numeric.new(575).to_roman
   end
 
   def test_911
+    skip
     assert_equal 'CMXI', Numeric.new(911).to_roman
   end
 
   def test_1024
+    skip
     assert_equal 'MXXIV', Numeric.new(1024).to_roman
   end
 
   def test_3000
+    skip
     assert_equal 'MMM', Numeric.new(3000).to_roman
   end
 

--- a/exercises/roman-numerals/roman_numerals_test.rb
+++ b/exercises/roman-numerals/roman_numerals_test.rb
@@ -1,96 +1,79 @@
+gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'roman_numerals'
 
 # Common test data version: 1.0.0 070e8d5
 class RomanNumeralsTest < Minitest::Test
   def test_1
-    # skip
-    assert_equal 'I', 1.to_roman
+    assert_equal 'I', Numeric.new(1).to_roman
   end
 
   def test_2
-    skip
-    assert_equal 'II', 2.to_roman
+    assert_equal 'II', Numeric.new(2).to_roman
   end
 
   def test_3
-    skip
-    assert_equal 'III', 3.to_roman
+    assert_equal 'III', Numeric.new(3).to_roman
   end
 
   def test_4
-    skip
-    assert_equal 'IV', 4.to_roman
+    assert_equal 'IV', Numeric.new(4).to_roman
   end
 
   def test_5
-    skip
-    assert_equal 'V', 5.to_roman
+    assert_equal 'V', Numeric.new(5).to_roman
   end
 
   def test_6
-    skip
-    assert_equal 'VI', 6.to_roman
+    assert_equal 'VI', Numeric.new(6).to_roman
   end
 
   def test_9
-    skip
-    assert_equal 'IX', 9.to_roman
+    assert_equal 'IX', Numeric.new(9).to_roman
   end
 
   def test_27
-    skip
-    assert_equal 'XXVII', 27.to_roman
+    assert_equal 'XXVII', Numeric.new(27).to_roman
   end
 
   def test_48
-    skip
-    assert_equal 'XLVIII', 48.to_roman
+    assert_equal 'XLVIII', Numeric.new(48).to_roman
   end
 
   def test_59
-    skip
-    assert_equal 'LIX', 59.to_roman
+    assert_equal 'LIX', Numeric.new(59).to_roman
   end
 
   def test_93
-    skip
-    assert_equal 'XCIII', 93.to_roman
+    assert_equal 'XCIII', Numeric.new(93).to_roman
   end
 
   def test_141
-    skip
-    assert_equal 'CXLI', 141.to_roman
+    assert_equal 'CXLI', Numeric.new(141).to_roman
   end
 
   def test_163
-    skip
-    assert_equal 'CLXIII', 163.to_roman
+    assert_equal 'CLXIII', Numeric.new(163).to_roman
   end
 
   def test_402
-    skip
-    assert_equal 'CDII', 402.to_roman
+    assert_equal 'CDII', Numeric.new(402).to_roman
   end
 
   def test_575
-    skip
-    assert_equal 'DLXXV', 575.to_roman
+    assert_equal 'DLXXV', Numeric.new(575).to_roman
   end
 
   def test_911
-    skip
-    assert_equal 'CMXI', 911.to_roman
+    assert_equal 'CMXI', Numeric.new(911).to_roman
   end
 
   def test_1024
-    skip
-    assert_equal 'MXXIV', 1024.to_roman
+    assert_equal 'MXXIV', Numeric.new(1024).to_roman
   end
 
   def test_3000
-    skip
-    assert_equal 'MMM', 3000.to_roman
+    assert_equal 'MMM', Numeric.new(3000).to_roman
   end
 
   # Problems in exercism evolve over time, as we find better ways to ask
@@ -111,7 +94,7 @@ class RomanNumeralsTest < Minitest::Test
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
 
   def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
+    assert_equal 3, BookKeeping::VERSION
   end
+
 end


### PR DESCRIPTION
<!--- This template is meant to help develop good habits in creating PRs. -->
<!--- Feel free to delete it if you don't find it useful. -->

<!--- Provide a general summary of your changes in the Title above -->

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is more natural to read the test with an instantiated class name. This helps guide the student into class-with-this-name contains method-with-this-name. Otherwise they will become lost.
## What?
<!--- Describe your changes in detail -->
simple really. for each
    assert_equal 'I', 1.to_roman
changed to
    assert_equal 'I', Numeric.new(1).to_roman
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran this modification against my own solution code....https://github.com/thefonso/exercism-solutions-ruby/blob/master/roman-numerals/roman_numerals.rb
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or enhancement that would cause existing functionality to change)
- [ ] Gardening (code and/or documentation cleanup)

## References and Closures
<!--- not previously mentioned -->
<!--- references #000 -->
<!--- closes #000 -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change relies on a pending issue/pull request
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
