### PR TITLE
generator: Remove underscore in test method name when canonical data has whitespace in description

### DIFF
--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -12,7 +12,7 @@ module Generator
     end
 
     def name
-      'test_%s' % canonical.description.underscore
+      'test_%s' % canonical.description.strip.underscore
     end
 
     def skipped(index)

--- a/lib/generator/underscore.rb
+++ b/lib/generator/underscore.rb
@@ -2,7 +2,7 @@ module Generator
   module Underscore
     refine String do
       def underscore
-        strip.downcase.gsub(/[- ]/, '_').gsub(/[^\w?]/, '')
+        downcase.gsub(/[- ]/, '_').gsub(/[^\w?]/, '')
       end
 
       def camel_case

--- a/lib/generator/underscore.rb
+++ b/lib/generator/underscore.rb
@@ -2,7 +2,7 @@ module Generator
   module Underscore
     refine String do
       def underscore
-        downcase.gsub(/[- ]/, '_').gsub(/[^\w?]/, '')
+        strip.downcase.gsub(/[- ]/, '_').gsub(/[^\w?]/, '')
       end
 
       def camel_case

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -7,6 +7,16 @@ module Generator
       assert_equal 'test_foo', subject.name
     end
 
+    def test_name_with_trailing_whitespace
+      subject = ExerciseCase.new(canonical: OpenStruct.new(description: 'foo '))
+      assert_equal 'test_foo', subject.name
+    end
+
+    def test_name_with_leading_whitespace
+      subject = ExerciseCase.new(canonical: OpenStruct.new(description: ' foo'))
+      assert_equal 'test_foo', subject.name
+    end
+
     def test_skipped_index_zero
       assert_equal '# skip', ExerciseCase.new(canonical: nil).skipped(0)
     end


### PR DESCRIPTION
## Why?
Remove unnecessary underscore in test method name to make it more readable

Issue: https://github.com/exercism/ruby/issues/668

## What?
Modify Underscore module to clean up leading/trailing whitespace

## How Has This Been Tested?
Updated `exercise_case_test.rb` to account for this case

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or enhancement that would cause existing functionality to change)
- [ ] Gardening (code and/or documentation cleanup)

## References and Closures
<!--- not previously mentioned -->
<!--- references #000 -->
<!--- closes #000 -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change relies on a pending issue/pull request
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
