### PR TITLE
generator: replace --freeze with --update

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ From within the ruby directory, run the following command:
 
     bin/generate --update <slug> 
 
-To regenerate tests without the updated canonical data, run the command
-without the `--update` option.
+Leaving out the --update option will cause the BookKeeping version number to remain the same.
+This can be useful when testing generators.
 
 #### Changing a Generated Exercise
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ tree -L 1 ~/code/exercism
 
 From within the ruby directory, run the following command:
 
-    bin/generate <slug>
+    bin/generate --update <slug> 
+
+To regenerate tests without the updated canonical data, run the command
+without the `--update` option.
 
 #### Changing a Generated Exercise
 

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -29,11 +29,11 @@ module Generator
     end
 
     def generator_class
-      freeze? ? GenerateTests : UpdateVersionAndGenerateTests
+      update? ? UpdateVersionAndGenerateTests : GenerateTests
     end
 
-    def freeze?
-      @options[:freeze]
+    def update?
+      @options[:update]
     end
 
     def implementation(slug)

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -33,7 +33,7 @@ module Generator
     end
 
     def freeze?
-      @options[:freeze] || @options[:all]
+      @options[:freeze]
     end
 
     def implementation(slug)

--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -3,7 +3,7 @@ require 'optparse'
 module Generator
   class GeneratorOptparser
     DEFAULT_OPTIONS = {
-      freeze: false,
+      freeze: true,
       all: false,
       verbose: false,
       slug: nil
@@ -33,8 +33,8 @@ module Generator
     def option_parser
       @option_parser ||= OptionParser.new do |parser|
         parser.banner = "Usage: #{$PROGRAM_NAME} [options] exercise-generator"
-        parser.on('-f', '--freeze', 'Don\'t update test version') { |value| options[:freeze] = value }
-        parser.on('-a', '--all', 'Regenerate all available test suites (implies freeze)') do |value|
+        parser.on('-u', '--update', 'Update test version') { |value| options[:freeze] = !value }
+        parser.on('-a', '--all', 'Regenerate all available test suites (does not update version)') do |value|
           options[:all] = value
         end
         parser.on('-h', '--help', 'Displays this help message') { |value| options[:help] = value }

--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -3,7 +3,7 @@ require 'optparse'
 module Generator
   class GeneratorOptparser
     DEFAULT_OPTIONS = {
-      freeze: true,
+      update: false,
       all: false,
       verbose: false,
       slug: nil
@@ -33,7 +33,7 @@ module Generator
     def option_parser
       @option_parser ||= OptionParser.new do |parser|
         parser.banner = "Usage: #{$PROGRAM_NAME} [options] exercise-generator"
-        parser.on('-u', '--update', 'Update test version') { |value| options[:freeze] = !value }
+        parser.on('-u', '--update', 'Update test version') { |value| options[:update] = value }
         parser.on('-a', '--all', 'Regenerate all available test suites (does not update version)') do |value|
           options[:all] = value
         end

--- a/test/generator/command_line/generator_optparser_test.rb
+++ b/test/generator/command_line/generator_optparser_test.rb
@@ -9,7 +9,7 @@ module Generator
 
     def default_options
       {
-        freeze: true,
+        update: false,
         all: false,
         verbose: false,
         slug: nil
@@ -30,7 +30,7 @@ module Generator
       args = %w(-u beta)
       Files::GeneratorCases.stub :available, %w(beta) do
         assert_equal(
-          default_options.merge(slug: 'beta', freeze: false),
+          default_options.merge(slug: 'beta', update: true),
           GeneratorOptparser.new(args, FixturePaths).options
         )
       end

--- a/test/generator/command_line/generator_optparser_test.rb
+++ b/test/generator/command_line/generator_optparser_test.rb
@@ -9,7 +9,7 @@ module Generator
 
     def default_options
       {
-        freeze: false,
+        freeze: true,
         all: false,
         verbose: false,
         slug: nil
@@ -26,11 +26,11 @@ module Generator
       end
     end
 
-    def test_frozen_option
-      args = %w(-f beta)
+    def test_update_option
+      args = %w(-u beta)
       Files::GeneratorCases.stub :available, %w(beta) do
         assert_equal(
-          default_options.merge(slug: 'beta', freeze: true),
+          default_options.merge(slug: 'beta', freeze: false),
           GeneratorOptparser.new(args, FixturePaths).options
         )
       end

--- a/test/generator/command_line_test.rb
+++ b/test/generator/command_line_test.rb
@@ -62,14 +62,14 @@ module Generator
     def test_default_options
       args = %w(beta)
       Files::GeneratorCases.stub :available, %w(beta) do
-        assert_instance_of UpdateVersionAndGenerateTests, CommandLine.new(FixturePaths).parse(args).first
+        assert_instance_of GenerateTests, CommandLine.new(FixturePaths).parse(args).first
       end
     end
 
-    def test_frozen_option
-      args = %w(-f beta)
+    def test_update_option
+      args = %w(-u beta)
       Files::GeneratorCases.stub :available, %w(beta) do
-        assert_instance_of GenerateTests, CommandLine.new(FixturePaths).parse(args).first
+        assert_instance_of UpdateVersionAndGenerateTests, CommandLine.new(FixturePaths).parse(args).first
       end
     end
 
@@ -86,7 +86,7 @@ module Generator
     def test_verbose_option
       args = %w(-v beta)
       Files::GeneratorCases.stub :available, %w(beta) do
-        assert_instance_of UpdateVersionAndGenerateTests, CommandLine.new(FixturePaths).parse(args).first
+        assert_instance_of GenerateTests, CommandLine.new(FixturePaths).parse(args).first
       end
     end
   end


### PR DESCRIPTION
## Why?
fixes #631 

## What?
Replaces the --freeze and -f options with --update and -u.
Updates default --all behaviour to not update version.
Alternative implementation could involve *adding* an update option, instead of replacing the freeze option entirely.

## Testing
`rake test:dev`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or enhancement that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
