### PR TITLE
hamming: regenerate tests

### DIFF
--- a/exercises/hamming/hamming_test.rb
+++ b/exercises/hamming/hamming_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'hamming'
 
-# Common test data version: 2.0.0 a2aff5b
+# Common test data version: 2.0.1 f79dfd7
 class HammingTest < Minitest::Test
   def test_empty_strands
     # skip
@@ -45,12 +45,12 @@ class HammingTest < Minitest::Test
 
   def test_non_unique_character_in_first_strand
     skip
-    assert_equal 1, Hamming.compute('AGA', 'AGG')
+    assert_equal 1, Hamming.compute('AAG', 'AAA')
   end
 
   def test_non_unique_character_in_second_strand
     skip
-    assert_equal 1, Hamming.compute('AGG', 'AGA')
+    assert_equal 1, Hamming.compute('AAA', 'AAG')
   end
 
   def test_same_nucleotides_in_different_positions


### PR DESCRIPTION
Update hamming tests based on updated canonical data.
Change is minor so requires no BookKeeping version increment.
