### PR TITLE
prime-factors: Prevent using built in Prime class

### DIFF
--- a/exercises/prime-factors/prime_factors_test.rb
+++ b/exercises/prime-factors/prime_factors_test.rb
@@ -1,5 +1,12 @@
 require 'minitest/autorun'
-require_relative 'prime_factors'
+Prime = nil
+class CheatError < StandardError; end
+begin
+  require_relative 'prime_factors'
+rescue TypeError => e
+  raise e unless e.message == "Prime is not a class"
+  raise CheatError, "Solve this without using Ruby's built in Prime class"
+end
 
 class PrimeFactorsTest < Minitest::Test
   def test_1


### PR DESCRIPTION
## Why?
The exercise can be sidestepped entirely by using the built in Prime class, which defeats the point.

## What?
Ensure the built in prime class cannot be used by raising an error.

## How Has This Been Tested?
Adding `require "prime"` to a working solution causes it to fail with this change.