### PR TITLE
queen-attack: Update test generator

### DIFF
--- a/exercises/queen-attack/.meta/generator/queen_attack_case.rb
+++ b/exercises/queen-attack/.meta/generator/queen_attack_case.rb
@@ -14,7 +14,7 @@ class QueenAttackCase < Generator::ExerciseCase
   end
 
   def parse_position queen
-    queen['position'].delete('() ').split(',').map{|i| i.to_i}
+    [queen['position']['row'], queen['position']['column']]
   end
 
   def create_workload

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -1,35 +1,35 @@
 require 'minitest/autorun'
 require_relative 'queen_attack'
 
-# Common test data version: 1.0.0 8adde5f
+# Common test data version: 2.0.0 44a1e12
 class QueenAttackTest < Minitest::Test
   def test_queen_with_a_valid_position
     # skip
     assert Queens.new(white: [2, 2])
   end
 
-  def test_queen_must_have_positive_rank
+  def test_queen_must_have_positive_row
     skip
     assert_raises ArgumentError do
       Queens.new(white: [-2, 2])
     end
   end
 
-  def test_queen_must_have_rank_on_board
+  def test_queen_must_have_row_on_board
     skip
     assert_raises ArgumentError do
       Queens.new(white: [8, 4])
     end
   end
 
-  def test_queen_must_have_positive_file
+  def test_queen_must_have_positive_column
     skip
     assert_raises ArgumentError do
       Queens.new(white: [2, -2])
     end
   end
 
-  def test_queen_must_have_file_on_board
+  def test_queen_must_have_column_on_board
     skip
     assert_raises ArgumentError do
       Queens.new(white: [4, 8])
@@ -42,13 +42,13 @@ class QueenAttackTest < Minitest::Test
     refute queens.attack?
   end
 
-  def test_can_attack_on_same_rank
+  def test_can_attack_on_same_row
     skip
     queens = Queens.new(white: [2, 4], black: [2, 6])
     assert queens.attack?
   end
 
-  def test_can_attack_on_same_file
+  def test_can_attack_on_same_column
     skip
     queens = Queens.new(white: [4, 5], black: [2, 5])
     assert queens.attack?


### PR DESCRIPTION
The queen-attack test generator is broken

Add proper logic to parse the position of the exercise.

* Ran `./bin/generate queen-attack`


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or enhancement that would cause existing functionality to change)
- [ ] Gardening (code and/or documentation cleanup)

Fixes #741

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change relies on a pending issue/pull request
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Add proper parsing logic for row, column coming from canonical data.