### PR TITLE
raindrops: add test for 0 as % matches everything on 0

### DIFF
--- a/exercises/raindrops/raindrops_test.rb
+++ b/exercises/raindrops/raindrops_test.rb
@@ -93,6 +93,11 @@ class RaindropsTest < Minitest::Test
     assert_equal "Plang", Raindrops.convert(3125)
   end
 
+  def test_the_sound_for_0_is_0
+    skip
+    assert_equal "0", Raindrops.convert(0)
+  end
+
   # Problems in exercism evolve over time, as we find better ways to ask
   # questions.
   # The version number refers to the version of the problem you solved,


### PR DESCRIPTION
## Why?

So I would guess this exercise should return "0" on 0 input. Only 1 out of 12 responses I reviewed would return this result.


## What?
Added a test to verify a return of  "0" on 0 input.

## How Has This Been Tested?

I ran the test with an exercise that returned "0" and one that returned "PlingPlangPlong" and it errored as appropriate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Breaking change (fix or enhancement that would cause existing functionality to change)
- [ ] Gardening (code and/or documentation cleanup)

should only break test results.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change relies on a pending issue/pull request
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


If this test performs as expected should I update book keeping to a new version?