### PR TITLE
documentation: Document test suite regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A few exercises use a custom test template:
 
 ### BookKeeping::VERSION
 
-For some, even perhaps many, of the exercises, you will find a reference to the `BookKeeping` module, but this is only included when tests have been generated; see [Generated Test Suites](#generated-test-suites).  This `VERSION` number helps make sure exercise solvers and exercise reviewers know which revision of the test suite they are talking about, and it theoretically helps avoid reviewer feedback like *"Your solution doesn't make the tests pass."*.
+For some, even perhaps many, of the exercises, you will find a reference to the `BookKeeping` module, but this is only included when tests have been generated; see [Generated Test Suites](#generated-test-suites).  This `VERSION` number helps make sure exercise solvers and exercise reviewers know which revision of the test suite they are talking about, and it theoretically helps avoid reviewer feedback like *"Your solution doesn't make the tests pass,"* if they are looking at a different version of the tests than the solver used.
 
 ### Canonical Data
 
@@ -110,21 +110,37 @@ If it's your first time cloning/contributing to the repository, you'll need to i
 bundle install
 ```
 
+Be sure that you're working on the most up-to-date version of the repo.  From the root of your copy of the repository:
+
+```bash
+# Add the exercism repo as upstream if you haven't yet:
+git remote add upstream https://github.com/exercism/ruby.git
+
+# Pull down any changes
+git fetch upstream
+
+# Merge any upstream changes with your master branch
+git checkout master
+git merge upstream/master
+```
+
+Depending on your git workflow preferences and the state of your local repo, you may want to do some rebasing.  [See the rebasing documentation for more information.](https://help.github.com/articles/about-git-rebase/)
+
 The generator also depends on the presence of Exercism's `problem-specifications` repository (see the file tree in the section above).  Make sure you've got an *up-to-date* version of the specifications in a `problem-specifications` folder that's in a parallel directory to your local copy of the `ruby` repository.
 
 To check which problems have possibly been updated, run:
 
 ```bash
-bin/generate -a
+bin/generate --all
 ```
 
-This will autogenerate all of the exercises that can be.  Use your editor, diff tool, or `git status` to find out which test files have changed.  Some exercises will update because someone updated the description or other exercise metadata.  Others will change because the actual test suite has changed.  If you find that an exercise's test suite (i.e. the actual tests, not just the line at the test data version number at the top of the tests) has changed, be sure to use `generate` to auto-increment the [BookKeeping::VERSION](#bookkeeping-version) number by running:
+This will autogenerate all of the test cases for which generators exist.  Use `git diff` (or your preferred method) to find out which test files have changed.  Some exercises will update because someone updated the description or other exercise metadata.  Others will change because the actual test suite has changed.  If you find that an exercise's test suite (i.e. the actual tests, not just the line at the test data version number at the top of the tests) has changed, be sure to use `generate` to update the [BookKeeping::VERSION](#bookkeeping-version) number by running:
 
 ```bash
-bin/generate -u <exercise-slug>
+bin/generate --update <exercise-slug>
 ```
 
-Once everything has been regenerated and updated, you're almost ready to submit your changes via pull request.  Please follow the guidelines in the [Pull Requests](#pull-requests) section, being sure to follow the pattern of `<slug>: Regenerate Tests`, where slug is the slug of the one exercise that your pull request is regenerating.
+Once everything has been regenerated and updated, you're almost ready to submit your changes via pull request.  Please be sure to only update one exercise per pull request.  Also, please follow the guidelines in the [Pull Requests](#pull-requests) section, being sure to follow the pattern of `<slug>: Regenerate Tests`, where slug is the slug of the exercise that your pull request is regenerating.
 
 #### Changing a Generated Exercise
 
@@ -276,7 +292,9 @@ are constructed using shared metadata, which lives in the [problem-specification
 ## Contributing Guide
 
 For an in-depth discussion of how exercism language tracks and exercises work, please see the
-[contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).  If you're just getting started and looking for an easy way to get involved, take a look at  [regenerating the test suites](#regenerating-a-test-suite), [porting an exercise from another language](https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md), or [creating an automated test generator](#implementing-a-generator).
+[contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).
+
+If you're just getting started and looking for a helpful way to get involved, take a look at  [regenerating the test suites](#regenerating-a-test-suite), [porting an exercise from another language](https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md), or [creating an automated test generator](#implementing-a-generator).
 
 ## Ruby icon
 The Ruby icon is the Vienna.rb logo, and is used with permission. Thanks Floor Dress :)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ A few exercises use a custom test template:
 
 ### BookKeeping::VERSION
 
-For some, even perhaps many, of the exercises, you will find a reference to the `BookKeeping` module, but this is only included when tests have been generated; see [Generated Test Suites](#generated-test-suites).  This `VERSION` number helps make sure exercise solvers and exercise reviewers know which revision of the test suite they are talking about, and it theoretically helps avoid reviewer feedback like *"Your solution doesn't make the tests pass,"* if they are looking at a different version of the tests than the solver used.
+For some, even perhaps many, of the exercises, you will find a reference
+to the `BookKeeping` module, but this is only included when tests have
+been generated; see [Generated Test Suites](#generated-test-suites).
+This `VERSION` number helps make sure exercise solvers and exercise
+reviewers know which revision of the test suite they are talking
+about, and it theoretically helps avoid reviewer feedback like 
+*"Your solution doesn't make the tests pass,"* if they are looking
+at a different version of the tests than the solver used.
 
 ### Canonical Data
 
@@ -102,15 +109,20 @@ tree -L 1 ~/code/exercism
 
 #### Regenerating a Test Suite
 
-From time to time, the [canonical data](https://github.com/exercism/problem-specifications/tree/master/exercises) for an exercise's tests changes, and we need to keep the Ruby version's tests synced up.  Regenerating these tests is a quick and easy way to help maintain the track and get involved!
+From time to time, the [canonical data](https://github.com/exercism/problem-specifications/tree/master/exercises)
+for an exercise's tests changes, and we need to keep the Ruby version's
+tests synced up.  Regenerating these tests is a quick and easy way to help
+maintain the track and get involved!
 
-If it's your first time cloning/contributing to the repository, you'll need to install any dependencies via `bundle`:
+If it's your first time cloning/contributing to the repository, you'll
+need to install any dependencies via `bundle`:
 
 ```bash
 bundle install
 ```
 
-Be sure that you're working on the most up-to-date version of the repo.  From the root of your copy of the repository:
+Be sure that you're working on the most up-to-date version of the repo.
+From the root of your copy of the repository:
 
 ```bash
 # Add the exercism repo as upstream if you haven't yet:
@@ -124,9 +136,14 @@ git checkout master
 git merge upstream/master
 ```
 
-Depending on your git workflow preferences and the state of your local repo, you may want to do some rebasing.  [See the rebasing documentation for more information.](https://help.github.com/articles/about-git-rebase/)
+Depending on your git workflow preferences and the state of your local
+repo, you may want to do some rebasing.
+[See the rebasing documentation for more information.](https://help.github.com/articles/about-git-rebase/)
 
-The generator also depends on the presence of Exercism's `problem-specifications` repository (see the file tree in the section above).  Make sure you've got an *up-to-date* version of the specifications in a `problem-specifications` folder that's in a parallel directory to your local copy of the `ruby` repository.
+The generator also depends on the presence of Exercism's `problem-specifications`
+repository (see the file tree in the section above).  Make sure you've got
+an *up-to-date* version of the specifications in a `problem-specifications`
+folder that's in a parallel directory to your local copy of the `ruby` repository.
 
 To check which problems have possibly been updated, run:
 
@@ -134,13 +151,25 @@ To check which problems have possibly been updated, run:
 bin/generate --all
 ```
 
-This will autogenerate all of the test cases for which generators exist.  Use `git diff` (or your preferred method) to find out which test files have changed.  Some exercises will update because someone updated the description or other exercise metadata.  Others will change because the actual test suite has changed.  If you find that an exercise's test suite (i.e. the actual tests, not just the line at the test data version number at the top of the tests) has changed, be sure to use `generate` to update the [BookKeeping::VERSION](#bookkeeping-version) number by running:
+This will autogenerate all of the test cases for which generators exist.
+Use `git diff` (or your preferred method) to find out which test files
+have changed.  Some exercises will update because someone updated the
+description or other exercise metadata.  Others will change because the
+actual test suite has changed.  If you find that an exercise's test suite
+(i.e. the actual tests, not just the line at the test data version number
+at the top of the tests) has changed, be sure to use `generate` to update
+the [BookKeeping::VERSION](#bookkeeping-version) number by running:
 
 ```bash
 bin/generate --update <exercise-slug>
 ```
 
-Once everything has been regenerated and updated, you're almost ready to submit your changes via pull request.  Please be sure to only update one exercise per pull request.  Also, please follow the guidelines in the [Pull Requests](#pull-requests) section, being sure to follow the pattern of `<slug>: Regenerate Tests`, where slug is the slug of the exercise that your pull request is regenerating.
+Once everything has been regenerated and updated, you're almost ready to
+submit your changes via pull request.  Please be sure to only update one
+exercise per pull request.  Also, please follow the guidelines in the
+[Pull Requests](#pull-requests) section, being sure to follow the pattern
+of `<slug>: Regenerate Tests`, where slug is the slug of the exercise that
+your pull request is regenerating.
 
 #### Changing a Generated Exercise
 
@@ -294,7 +323,10 @@ are constructed using shared metadata, which lives in the [problem-specification
 For an in-depth discussion of how exercism language tracks and exercises work, please see the
 [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).
 
-If you're just getting started and looking for a helpful way to get involved, take a look at  [regenerating the test suites](#regenerating-a-test-suite), [porting an exercise from another language](https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md), or [creating an automated test generator](#implementing-a-generator).
+If you're just getting started and looking for a helpful way to get involved,
+take a look at  [regenerating the test suites](#regenerating-a-test-suite),
+[porting an exercise from another language](https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md),
+or [creating an automated test generator](#implementing-a-generator).
 
 ## Ruby icon
 The Ruby icon is the Vienna.rb logo, and is used with permission. Thanks Floor Dress :)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ A few exercises use a custom test template:
 
 ### BookKeeping::VERSION
 
-For some, even perhaps many, of the exercises, you will find a
-reference to the `BookKeeping` module, but this is only included when
-tests have been generated; see [Generated Test Suites](#generated-test-suites).
+For some, even perhaps many, of the exercises, you will find a reference to the `BookKeeping` module, but this is only included when tests have been generated; see [Generated Test Suites](#generated-test-suites).  This `VERSION` number helps make sure exercise solvers and exercise reviewers know which revision of the test suite they are talking about, and it theoretically helps avoid reviewer feedback like *"Your solution doesn't make the tests pass."*.
 
 ### Canonical Data
 
@@ -104,12 +102,29 @@ tree -L 1 ~/code/exercism
 
 #### Regenerating a Test Suite
 
-From within the ruby directory, run the following command:
+From time to time, the [canonical data](https://github.com/exercism/problem-specifications/tree/master/exercises) for an exercise's tests changes, and we need to keep the Ruby version's tests synced up.  Regenerating these tests is a quick and easy way to help maintain the track and get involved!
 
-    bin/generate --update <slug> 
+If it's your first time cloning/contributing to the repository, you'll need to install any dependencies via `bundle`:
 
-Leaving out the --update option will cause the BookKeeping version number to remain the same.
-This can be useful when testing generators.
+```bash
+bundle install
+```
+
+The generator also depends on the presence of Exercism's `problem-specifications` repository (see the file tree in the section above).  Make sure you've got an *up-to-date* version of the specifications in a `problem-specifications` folder that's in a parallel directory to your local copy of the `ruby` repository.
+
+To check which problems have possibly been updated, run:
+
+```bash
+bin/generate -a
+```
+
+This will autogenerate all of the exercises that can be.  Use your editor, diff tool, or `git status` to find out which test files have changed.  Some exercises will update because someone updated the description or other exercise metadata.  Others will change because the actual test suite has changed.  If you find that an exercise's test suite (i.e. the actual tests, not just the line at the test data version number at the top of the tests) has changed, be sure to use `generate` to auto-increment the [BookKeeping::VERSION](#bookkeeping-version) number by running:
+
+```bash
+bin/generate -u <exercise-slug>
+```
+
+Once everything has been regenerated and updated, you're almost ready to submit your changes via pull request.  Please follow the guidelines in the [Pull Requests](#pull-requests) section, being sure to follow the pattern of `<slug>: Regenerate Tests`, where slug is the slug of the one exercise that your pull request is regenerating.
 
 #### Changing a Generated Exercise
 
@@ -260,10 +275,8 @@ are constructed using shared metadata, which lives in the [problem-specification
 
 ## Contributing Guide
 
-For an in-depth discussion of how exercism language tracks and exercises work,
-please see the
-[contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
-
+For an in-depth discussion of how exercism language tracks and exercises work, please see the
+[contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).  If you're just getting started and looking for an easy way to get involved, take a look at  [regenerating the test suites](#regenerating-a-test-suite), [porting an exercise from another language](https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md), or [creating an automated test generator](#implementing-a-generator).
 
 ## Ruby icon
 The Ruby icon is the Vienna.rb logo, and is used with permission. Thanks Floor Dress :)


### PR DESCRIPTION
Wrote some documentation explaining how to regenerate test data and other data for exercises.  I also included some changes to explain when to use `-u` to update the VERSION number as well.  Lastly, I added a section to the *Contributing* section that gives some ideas for getting started to newcomers, including the newly revamped *Regenerating Test Suites* section.

Let me know what you think.  I'm happy to do some revising to get the wording just right.

## Why?
Solves #717, as we discussed in that issue (see also some of the discussion in #757 PR.

## How Has This Been Tested?
No tests.  All I did was change the README.  However, the methodology that I wrote down is sound, because I just did it that way a couple of days ago 😄 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or enhancement that would cause existing functionality to change)
- [x] Gardening (code and/or documentation cleanup)

## References and Closures

References #757 
Closes #717 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change relies on a pending issue/pull request
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
