### PR TITLE
minesweeper: Change ValueError to ArgumentError

### DIFF
--- a/exercises/minesweeper/.meta/solutions/minesweeper.rb
+++ b/exercises/minesweeper/.meta/solutions/minesweeper.rb
@@ -64,7 +64,7 @@ class Board
   def validate_size
     len = rows.first.length
     if rows.any? { |row| row.length != len }
-      fail ValueError, 'Invalid board'
+      fail ArgumentError, 'Invalid board'
     end
   end
 
@@ -73,7 +73,7 @@ class Board
       invalid = row.chars.any? do |char|
         !VALID_BORDERS.include?(char)
       end
-      fail ValueError, 'Invalid board' if invalid
+      fail ArgumentError, 'Invalid board' if invalid
     end
   end
 
@@ -82,9 +82,7 @@ class Board
       invalid = row.chars.any? do |char|
         !VALID_DATA.include?(char)
       end
-      fail ValueError, 'Invalid board' if invalid
+      fail ArgumentError, 'Invalid board' if invalid
     end
   end
 end
-
-ValueError = Class.new(StandardError)

--- a/exercises/minesweeper/minesweeper_test.rb
+++ b/exercises/minesweeper/minesweeper_test.rb
@@ -73,7 +73,7 @@ class MinesweeperTest < Minitest::Test
   def test_different_len
     skip
     inp = ['+-+', '| |', '|*  |', '|  |', '+-+']
-    assert_raises(ValueError) do
+    assert_raises(ArgumentError) do
       Board.transform(inp)
     end
   end
@@ -81,7 +81,7 @@ class MinesweeperTest < Minitest::Test
   def test_faulty_border
     skip
     inp = ['+-----+', '*   * |', '+-- --+']
-    assert_raises(ValueError) do
+    assert_raises(ArgumentError) do
       Board.transform(inp)
     end
   end
@@ -89,7 +89,7 @@ class MinesweeperTest < Minitest::Test
   def test_invalid_char
     skip
     inp = ['+-----+', '|X  * |', '+-----+']
-    assert_raises(ValueError) do
+    assert_raises(ArgumentError) do
       Board.transform(inp)
     end
   end


### PR DESCRIPTION
Fixing #778: Minesweeper test now listens for ArgumentError instead.