### PR TITLE
bank-account: Implement exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -912,6 +912,15 @@
       "slug": "complex-numbers",
       "difficulty": 3,
       "topics": [ "Mathematics" ]
+    },
+    {
+      "uuid": "9a62f1a5-ad21-47a2-a130-b7a6e10e3fa9",
+      "slug": "bank-account",
+      "difficulty": 5,
+      "topics": [ 
+        "concurrency",
+        "logic"
+      ]
     }
   ],
   "foregone": [

--- a/exercises/bank-account/.meta/solutions/bank_account.rb
+++ b/exercises/bank-account/.meta/solutions/bank_account.rb
@@ -1,0 +1,74 @@
+module BookKeeping
+  VERSION = 1
+end
+
+class BankAccount
+  def initialize
+    @balance = 0
+    @closed = true
+    @lock = Mutex.new
+  end
+
+  def open
+    @closed = false
+  end
+
+  def close
+    @closed = true
+  end
+
+  def balance
+    closed?
+    @balance
+  end
+
+  def deposit(amount)
+    @lock.synchronize do
+      closed?
+      valid_amount?(amount)
+      @balance += amount
+    end
+  end
+
+  def withdraw(amount)
+    @lock.synchronize do
+      closed?
+      valid_amount?(amount)
+      enough_money_in_account?(amount)
+      @balance -= amount
+    end
+  end
+
+  private
+
+  def closed?
+    raise BankAccountActionInvalidError.new('Account closed') if @closed
+  end
+
+  def valid_amount?(amount)
+    if amount < 0
+      raise BankAccountActionInvalidError.new(
+        'Cannot deposit or withdraw negative amount'
+      )
+    end
+  end
+
+  def enough_money_in_account?(amount)
+    if @balance.zero?
+      raise BankAccountActionInvalidError.new(
+        'Cannot withdraw money from an empty account'
+      )
+    end
+    if amount > @balance
+      raise BankAccountActionInvalidError.new(
+        'Cannot withdraw more money than is currently in the account'
+      )
+    end
+  end
+end
+
+class BankAccountActionInvalidError < StandardError
+  def initialize(msg)
+    super
+  end
+end

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -1,0 +1,56 @@
+# Bank Account
+
+Simulate a bank account supporting opening/closing, withdrawals, and deposits
+of money. Watch out for concurrent transactions!
+
+A bank account can be accessed in multiple ways. Clients can make
+deposits and withdrawals using the internet, mobile phones, etc. Shops
+can charge against the account.
+
+Create an account that can be accessed from multiple threads/processes
+(terminology depends on your programming language).
+
+It should be possible to close an account; operations against a closed
+account must fail.
+
+## Instructions
+
+Run the test file, and fix each of the errors in turn. When you get the
+first test to pass, go to the first pending or skipped test, and make
+that pass as well. When all of the tests are passing, feel free to
+submit.
+
+Remember that passing code is just the first step. The goal is to work
+towards a solution that is as readable and expressive as you can make
+it.
+
+Have fun!
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+In order to run the test, you can run the test file from the exercise
+directory. For example, if the test suite is called
+`hello_world_test.rb`, you can run the following command:
+
+    ruby hello_world_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride hello_world_test.rb
+
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bank-account/bank_account_test.rb
+++ b/exercises/bank-account/bank_account_test.rb
@@ -9,17 +9,20 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_newly_opened_account_has_empty_balance
+    # skip
     bank_account.open
     assert_equal 0, bank_account.balance
   end
 
   def test_can_deposit_money
+    skip
     bank_account.open
     bank_account.deposit(10)
     assert_equal 10, bank_account.balance
   end
 
   def test_can_deposit_money_sequentially
+    skip
     bank_account.open
     bank_account.deposit(5)
     bank_account.deposit(23)
@@ -27,6 +30,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_can_withdraw_money
+    skip
     bank_account.open
     bank_account.deposit(10)
     bank_account.withdraw(5)
@@ -34,6 +38,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_can_withdraw_money_sequentially
+    skip
     bank_account.open
     bank_account.deposit(23)
     bank_account.withdraw(10)
@@ -42,6 +47,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_withdraw_money_from_empty_account
+    skip
     bank_account.open
     err = assert_raises(BankAccountActionInvalidError) do
       bank_account.withdraw(5)
@@ -50,6 +56,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_withdraw_more_money_than_you_have
+    skip
     bank_account.open
     bank_account.deposit(6)
     err = assert_raises(BankAccountActionInvalidError) do
@@ -62,6 +69,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_deposit_negative_amount
+    skip
     bank_account.open
     err = assert_raises(BankAccountActionInvalidError) do
       bank_account.deposit(-1)
@@ -70,6 +78,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_withdraw_negative_amount
+    skip
     bank_account.open
     err = assert_raises(BankAccountActionInvalidError) do
       bank_account.withdraw(-5)
@@ -78,6 +87,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_get_balance_of_closed_account
+    skip
     bank_account.open
     bank_account.deposit(10)
     bank_account.close
@@ -88,6 +98,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_deposit_money_into_closed_account
+    skip
     bank_account.open
     bank_account.close
     err = assert_raises(BankAccountActionInvalidError) do
@@ -97,6 +108,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_cannot_withdraw_money_from_closed_account
+    skip
     bank_account.open
     bank_account.deposit(20)
     bank_account.close
@@ -107,6 +119,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_bank_account_is_closed_before_it_is_open
+    skip
     err = assert_raises(BankAccountActionInvalidError) do
       bank_account.balance
     end
@@ -114,6 +127,7 @@ class BankAccountTest < Minitest::Test
   end
 
   def test_can_adjust_balance_concurrently
+    skip
     bank_account.open
     bank_account.deposit(1000)
 

--- a/exercises/bank-account/bank_account_test.rb
+++ b/exercises/bank-account/bank_account_test.rb
@@ -1,0 +1,155 @@
+require 'minitest/autorun'
+require_relative 'bank_account'
+
+class BankAccountTest < Minitest::Test
+  attr_reader :bank_account
+
+  def setup
+    @bank_account = BankAccount.new
+  end
+
+  def test_newly_opened_account_has_empty_balance
+    bank_account.open
+    assert_equal 0, bank_account.balance
+  end
+
+  def test_can_deposit_money
+    bank_account.open
+    bank_account.deposit(10)
+    assert_equal 10, bank_account.balance
+  end
+
+  def test_can_deposit_money_sequentially
+    bank_account.open
+    bank_account.deposit(5)
+    bank_account.deposit(23)
+    assert_equal 28, bank_account.balance
+  end
+
+  def test_can_withdraw_money
+    bank_account.open
+    bank_account.deposit(10)
+    bank_account.withdraw(5)
+    assert_equal 5, bank_account.balance
+  end
+
+  def test_can_withdraw_money_sequentially
+    bank_account.open
+    bank_account.deposit(23)
+    bank_account.withdraw(10)
+    bank_account.withdraw(13)
+    assert_equal 0, bank_account.balance
+  end
+
+  def test_cannot_withdraw_money_from_empty_account
+    bank_account.open
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.withdraw(5)
+    end
+    assert_equal 'Cannot withdraw money from an empty account', err.message
+  end
+
+  def test_cannot_withdraw_more_money_than_you_have
+    bank_account.open
+    bank_account.deposit(6)
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.withdraw(7)
+    end
+    assert_equal(
+      'Cannot withdraw more money than is currently in the account',
+      err.message
+    )
+  end
+
+  def test_cannot_deposit_negative_amount
+    bank_account.open
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.deposit(-1)
+    end
+    assert_equal 'Cannot deposit or withdraw negative amount', err.message
+  end
+
+  def test_cannot_withdraw_negative_amount
+    bank_account.open
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.withdraw(-5)
+    end
+    assert_equal 'Cannot deposit or withdraw negative amount', err.message
+  end
+
+  def test_cannot_get_balance_of_closed_account
+    bank_account.open
+    bank_account.deposit(10)
+    bank_account.close
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.balance
+    end
+    assert_equal 'Account closed', err.message
+  end
+
+  def test_cannot_deposit_money_into_closed_account
+    bank_account.open
+    bank_account.close
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.deposit(5)
+    end
+    assert_equal 'Account closed', err.message
+  end
+
+  def test_cannot_withdraw_money_from_closed_account
+    bank_account.open
+    bank_account.deposit(20)
+    bank_account.close
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.withdraw(5)
+    end
+    assert_equal 'Account closed', err.message
+  end
+
+  def test_bank_account_is_closed_before_it_is_open
+    err = assert_raises(BankAccountActionInvalidError) do
+      bank_account.balance
+    end
+    assert_equal 'Account closed', err.message
+  end
+
+  def test_can_adjust_balance_concurrently
+    bank_account.open
+    bank_account.deposit(1000)
+
+    10.times { adjust_balance_concurrently }
+  end
+
+  def adjust_balance_concurrently
+    threads = Array.new(1000).map do
+      Thread.new do
+        bank_account.deposit(5)
+        sleep(Random.rand(1..10) / 1000)
+        bank_account.withdraw(5)
+      end
+    end
+
+    threads.each(&:join)
+    assert_equal 1000, bank_account.balance
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module.
+  #  In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    assert_equal 1, BookKeeping::VERSION
+  end
+end


### PR DESCRIPTION
I saw this was attempted [here](https://github.com/exercism/ruby/pull/341) but never finished. I didn't see a followup issue so I attempted to implement it. I basically copied the test suite from the java track, found [here](https://github.com/exercism/java/blob/master/exercises/bank-account/src/test/java/BankAccountTest.java).

I was wondering if anyone could help me create a test to that would ensure that balance would get messed up if a mutex was not used in the solution. I copied the concurrency test from the java track, but that doesn't seem to do the trick. Also, there is probably a better way to format that test instead of putting another method after it without test in the method name, but I wasn't sure what the best way to do that was.

I also can't seem to get rubocop working within the project directory. I ended up pulling my solution out into other folder to develop it and run rubocop against it. I am probably missing something. I tried running it with ruby 2.4.2 and 2.1.0. I installed the gem correctly on each ruby version before proceeding.

These are the errors that occur after I ran
```
rubocop -D
```
In specific exercise folder or in the root of the project:

```
.rubocop.yml: Lint/Eval has the wrong namespace - should be Security
.rubocop.yml: Style/AccessModifierIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/AccessorMethodName has the wrong namespace - should be Naming
.rubocop.yml: Style/AlignArray has the wrong namespace - should be Layout
.rubocop.yml: Style/AlignHash has the wrong namespace - should be Layout
.rubocop.yml: Style/AlignParameters has the wrong namespace - should be Layout
.rubocop.yml: Style/AsciiIdentifiers has the wrong namespace - should be Naming
.rubocop.yml: Style/BlockEndNewline has the wrong namespace - should be Layout
.rubocop.yml: Style/CaseIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/ClassAndModuleCamelCase has the wrong namespace - should be Naming
.rubocop.yml: Style/ClosingParenthesisIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/CommentIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/ConstantName has the wrong namespace - should be Naming
.rubocop.yml: Style/DotPosition has the wrong namespace - should be Layout
.rubocop.yml: Style/ElseAlignment has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLineBetweenDefs has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLines has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLinesAroundAccessModifier has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLinesAroundBlockBody has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLinesAroundClassBody has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLinesAroundMethodBody has the wrong namespace - should be Layout
.rubocop.yml: Style/EmptyLinesAroundModuleBody has the wrong namespace - should be Layout
.rubocop.yml: Style/EndOfLine has the wrong namespace - should be Layout
.rubocop.yml: Style/ExtraSpacing has the wrong namespace - should be Layout
.rubocop.yml: Style/FileName has the wrong namespace - should be Naming
.rubocop.yml: Style/FirstArrayElementLineBreak has the wrong namespace - should be Layout
.rubocop.yml: Style/FirstHashElementLineBreak has the wrong namespace - should be Layout
.rubocop.yml: Style/FirstMethodArgumentLineBreak has the wrong namespace - should be Layout
.rubocop.yml: Style/FirstMethodParameterLineBreak has the wrong namespace - should be Layout
.rubocop.yml: Style/FirstParameterIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/IndentArray has the wrong namespace - should be Layout
.rubocop.yml: Style/IndentAssignment has the wrong namespace - should be Layout
.rubocop.yml: Style/IndentHash has the wrong namespace - should be Layout
.rubocop.yml: Style/IndentationConsistency has the wrong namespace - should be Layout
.rubocop.yml: Style/IndentationWidth has the wrong namespace - should be Layout
.rubocop.yml: Style/InitialIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/LeadingCommentSpace has the wrong namespace - should be Layout
.rubocop.yml: Style/MethodName has the wrong namespace - should be Naming
.rubocop.yml: Style/MultilineArrayBraceLayout has the wrong namespace - should be Layout
.rubocop.yml: Style/MultilineAssignmentLayout has the wrong namespace - should be Layout
.rubocop.yml: Style/MultilineBlockLayout has the wrong namespace - should be Layout
.rubocop.yml: Style/MultilineMethodCallIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/MultilineOperationIndentation has the wrong namespace - should be Layout
.rubocop.yml: Style/PredicateName has the wrong namespace - should be Naming
.rubocop.yml: Style/RescueEnsureAlignment has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAfterColon has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAfterComma has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAfterMethodName has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAfterNot has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAfterSemicolon has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAroundBlockParameters has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAroundEqualsInParameterDefault has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceAroundOperators has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceBeforeBlockBraces has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceBeforeComma has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceBeforeComment has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceBeforeFirstArg has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceBeforeSemicolon has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceInsideBlockBraces has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceInsideBrackets has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceInsideHashLiteralBraces has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceInsideParens has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceInsideRangeLiteral has the wrong namespace - should be Layout
.rubocop.yml: Style/SpaceInsideStringInterpolation has the wrong namespace - should be Layout
.rubocop.yml: Style/Tab has the wrong namespace - should be Layout
.rubocop.yml: Style/TrailingBlankLines has the wrong namespace - should be Layout
.rubocop.yml: Style/TrailingWhitespace has the wrong namespace - should be Layout
.rubocop.yml: Style/VariableName has the wrong namespace - should be Naming
Error: The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/SpaceAfterControlKeyword` cop has been removed. Please use `Layout/SpaceAroundKeyword` instead.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/SpaceBeforeModifierKeyword` cop has been removed. Please use `Layout/SpaceAroundKeyword` instead.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/MethodCallParentheses` cop has been renamed to `Style/MethodCallWithoutArgsParentheses`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/DeprecatedHashMethods` cop has been renamed to `Style/PreferredHashMethods`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/OpMethod` cop has been renamed and moved to `Naming/BinaryOperatorParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
obsolete parameter EnforcedStyle (for Style/Encoding) found in .rubocop.yml
Style/Encoding no longer supports styles. The "never" behavior is always assumed.
obsolete parameter SupportedStyles (for Style/Encoding) found in .rubocop.yml
Style/Encoding no longer supports styles. The "never" behavior is always assumed.
obsolete parameter AutoCorrectEncodingComment (for Style/Encoding) found in .rubocop.yml
Style/Encoding no longer supports styles. The "never" behavior is always assumed.
obsolete parameter IndentWhenRelativeTo (for Layout/CaseIndentation) found in .rubocop.yml
`IndentWhenRelativeTo` has been renamed to `EnforcedStyle`
obsolete parameter AlignWith (for Lint/EndAlignment) found in .rubocop.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
obsolete parameter AlignWith (for Lint/DefEndAlignment) found in .rubocop.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
```