### PR TITLE
800 Remove dependency on require_all

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'minitest'
 gem 'rake'
-gem 'require_all'
 gem 'rubocop', '0.36.0'
 gem 'simplecov'

--- a/bin/generate
+++ b/bin/generate
@@ -2,6 +2,7 @@
 
 require_relative '../lib/helper'
 require 'generator'
+require 'generator/command_line'
 
 paths = Generator::Paths.new(track: EXERCISM_RUBY_ROOT, metadata: METADATA_REPOSITORY_PATH)
 

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -1,5 +1,4 @@
-require 'require_all'
-require_rel 'generator' # Include everything in the 'generator' subdirectory
+require 'generator/implementation'
 
 module Generator
   # Immutable value object for storing paths

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -1,4 +1,6 @@
 require 'logger'
+require 'generator/command_line/generator_optparser'
+require 'generator/repository'
 
 module Generator
   class CommandLine

--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'generator/files/generator_cases'
 
 module Generator
   class GeneratorOptparser

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -1,4 +1,7 @@
 require 'ostruct'
+require 'generator/exercise_case/assertion'
+require 'generator/exercise_case/case_helpers'
+require 'generator/underscore'
 
 module Generator
   class ExerciseCase

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -1,3 +1,5 @@
+require 'generator/files'
+
 module Generator
   module Files
     module MetadataFiles

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'generator/files'
 
 module Generator
   module Files

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -1,5 +1,6 @@
 require 'delegate'
 require 'forwardable'
+require_relative 'template_values'
 
 module Generator
   class Implementation

--- a/lib/generator/repository.rb
+++ b/lib/generator/repository.rb
@@ -1,3 +1,6 @@
+require 'generator/files/metadata_files'
+require 'generator/files/track_files'
+
 module Generator
   class Repository
     include Files::TrackFiles

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -1,4 +1,6 @@
 require_relative '../test_helper'
+require 'generator/exercise_case'
+require 'generator/case_values'
 
 module Generator
   class ComplexCase < ExerciseCase

--- a/test/generator/command_line_test.rb
+++ b/test/generator/command_line_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require 'generator/command_line'
 
 module Generator
   class CommandLineTest < Minitest::Test

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -1,4 +1,6 @@
 require_relative '../../test_helper.rb'
+require 'generator/files/metadata_files'
+
 module Generator
   module Files
     class MetadataFilesTest < Minitest::Test

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -1,4 +1,5 @@
 require_relative '../../test_helper.rb'
+require 'generator/files/track_files'
 
 module Generator
   module Files

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require 'generator/git_command'
 
 module Generator
   class ImplementationTest < Minitest::Test

--- a/test/tasks/exercise_test.rb
+++ b/test/tasks/exercise_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require 'generator/exercise'
 require 'tmpdir'
 
 class ExerciseTest < Minitest::Test

--- a/test/tasks/exercise_test_tasks_test.rb
+++ b/test/tasks/exercise_test_tasks_test.rb
@@ -1,4 +1,6 @@
 require_relative '../test_helper'
+require 'tasks/exercise'
+require 'tasks/exercise_test_tasks'
 
 class ExerciseTestTasksTest < Minitest::Test
   def test_all_exercises_task

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 
-require 'require_all'
-
 unless ENV['CI']
   require 'simplecov'
 
@@ -31,4 +29,4 @@ end
 require 'minitest/autorun'
 
 # So we can be sure we have coverage on the whole lib directory:
-require_all 'lib'
+Dir.glob('lib/*.rb').each { |file| require file.gsub(%r{(^lib\/|\.rb$)}, '') }


### PR DESCRIPTION
From require_all's changelog:
  2.0.0:
  Merged PR #24 (https://github.com/jarmo/require_all/pull/24) Prior to
  version 2, RequireAll attempted to automatically resolve dependencies
  between files, thus allowing them to be required in any order. Whilst
  convenient, the approach used (of rescuing NameErrors and later retrying
  files that failed to load) was fundamentally unsafe and can result in
  incorrect behaviour (for example issue #8, plus more detail and
  discussion in #21).

  Thanks to Joe Horsnell (@joehorsnell)

This commit removes the dependency on the require_all gem by using
Ruby's `#require` method wherever it is needed.