### PR TITLE
Use progression from Go

### DIFF
--- a/config.json
+++ b/config.json
@@ -1076,10 +1076,10 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-          "recursion",
-          "type_conversion",
-          "lists",
-          "functional_programming"
+        "functional_programming",
+        "lists",
+        "recursion",
+        "type_conversion"
       ]
     },
     {
@@ -1150,13 +1150,13 @@
       "deprecated": true
     },
     {
-      "uuid": "239b8e79-2983-4ce0-9dda-9bb999e79d11",
       "slug": "zipper",
+      "uuid": "239b8e79-2983-4ce0-9dda-9bb999e79d11",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-        "Data Structures"
+        "data_structures"
       ]
     }
   ]

--- a/config.json
+++ b/config.json
@@ -848,6 +848,20 @@
       ]
     },
     {
+      "slug": "kindergarten-garden",
+      "uuid": "04bde625-e363-4d8b-880f-db7bf86286eb",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 3,
+      "topics": [
+        "parsing",
+        "records",
+        "searching",
+        "strings",
+        "structs"
+      ]
+    },
+    {
       "slug": "simple-cipher",
       "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
       "core": false,
@@ -1114,6 +1128,47 @@
       "difficulty": 0,
       "topics": null,
       "deprecated": true
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "d1267415-aff5-411d-b267-49a4a2c8fda2",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "cryptography",
+        "mathematics",
+        "strings"
+      ]
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "d75bd7c0-52c5-44f2-a046-f63cb332425f",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "89bd3d71-000f-4cd9-9a84-ad1b22ddbd33",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "uuid": "239b8e79-2983-4ce0-9dda-9bb999e79d11",
+      "slug": "zipper",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
+      "topics": [
+        "Data Structures"
+      ]
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -120,17 +120,6 @@
       ]
     },
     {
-      "slug": "reverse-string",
-      "uuid": "e2df2756-7a48-4b45-b601-91be91027dbd",
-      "core": false,
-      "unlocked_by": "isogram",
-      "difficulty": 2,
-      "topics": [
-        "sequences",
-        "strings"
-      ]
-    },
-    {
       "slug": "difference-of-squares",
       "uuid": "f1e4ee0c-8718-43f2-90a5-fb1e915288da",
       "core": true,

--- a/config.json
+++ b/config.json
@@ -6,39 +6,6 @@
   "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "exercises": [
     {
-      "slug": "gigasecond",
-      "uuid": "0fb594a1-193b-4ccf-8de2-eb6a81708b29",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "time"
-      ]
-    },
-    {
-      "slug": "bob",
-      "uuid": "70fec82e-3038-468f-96ef-bfb48ce03ef3",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "conditionals",
-        "strings"
-      ]
-    },
-    {
-      "slug": "acronym",
-      "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "regular_expressions",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
       "slug": "hello-world",
       "uuid": "4fe19484-4414-471b-a106-73c776c61388",
       "core": true,
@@ -46,29 +13,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings"
-      ]
-    },
-    {
-      "slug": "space-age",
-      "uuid": "c971a2b5-ccd4-4e55-9fc7-33e991bc0676",
-      "core": false,
-      "unlocked_by": "hello-world",
-      "difficulty": 2,
-      "topics": [
-        "floating_point_numbers",
-        "if_else_statements",
-        "mathematics"
-      ]
-    },
-    {
-      "slug": "two-fer",
-      "uuid": "1304b188-6d08-4361-be40-c6b1b88e5e54",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
         "strings"
       ]
     },
@@ -85,6 +29,27 @@
       ]
     },
     {
+      "slug": "gigasecond",
+      "uuid": "0fb594a1-193b-4ccf-8de2-eb6a81708b29",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "time"
+      ]
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "41f66d2a-1883-4a2c-875f-663c46fa88aa",
+      "core": false,
+      "unlocked_by": "hamming",
+      "difficulty": 2,
+      "topics": [
+        "maps",
+        "transforming"
+      ]
+    },
+    {
       "slug": "raindrops",
       "uuid": "efad2cea-1e0b-4fb8-a452-a8e91be73638",
       "core": true,
@@ -93,29 +58,6 @@
       "topics": [
         "conditionals",
         "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "scrabble-score",
-      "uuid": "d934ebce-9ac3-4a41-bcb8-d70480170438",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "loops",
-        "maps",
-        "strings"
-      ]
-    },
-    {
-      "slug": "isogram",
-      "uuid": "a79eb8cd-d2db-48f5-a7dc-055039dcee62",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "sequences",
         "strings"
       ]
     },
@@ -131,15 +73,64 @@
       ]
     },
     {
-      "slug": "luhn",
-      "uuid": "bee97539-b8c1-460e-aa14-9336008df2b6",
-      "core": true,
-      "unlocked_by": null,
+      "slug": "pangram",
+      "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
+      "core": false,
+      "unlocked_by": "isogram",
       "difficulty": 2,
+      "topics": [
+        "loops",
+        "strings"
+      ]
+    },
+    {
+      "slug": "sieve",
+      "uuid": "80f9af5a-ea29-4937-9333-b4494aaf2446",
+      "core": false,
+      "unlocked_by": "grains",
+      "difficulty": 3,
       "topics": [
         "algorithms",
         "integers",
-        "strings"
+        "loops",
+        "mathematics",
+        "sorting"
+      ]
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "b7ca9519-c33b-418b-a4ef-858a3d4d6855",
+      "core": false,
+      "unlocked_by": "raindrops",
+      "difficulty": 2,
+      "topics": [
+        "numbers",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "16baef71-6234-4928-a2d4-a19eb8e110b8",
+      "core": false,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "integers",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "leap",
+      "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
+      "core": false,
+      "unlocked_by": "two-fer",
+      "difficulty": 1,
+      "topics": [
+        "booleans",
+        "conditionals",
+        "integers",
+        "logic"
       ]
     },
     {
@@ -157,6 +148,231 @@
       ]
     },
     {
+      "slug": "word-count",
+      "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 3,
+      "topics": [
+        "sorting",
+        "strings"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "70fec82e-3038-468f-96ef-bfb48ce03ef3",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "conditionals",
+        "strings"
+      ]
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "9d6a8c89-41c1-4c4e-b24c-476ba0dfa5f9",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 4,
+      "topics": [
+        "parsing",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "binary",
+      "uuid": "43bc27ed-d2fa-4173-8665-4459b71c9a3a",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "2c71fc3a-2c93-402b-b091-697b795ce3ba",
+      "core": false,
+      "unlocked_by": "raindrops",
+      "difficulty": 1,
+      "topics": [
+        "lists"
+      ]
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "4fc25295-5d6a-4d13-9b87-064167d8980e",
+      "core": false,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 5,
+      "topics": [
+        "loops",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "lists",
+        "sorting",
+        "structs"
+      ]
+    },
+    {
+      "slug": "series",
+      "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "arrays",
+        "refactoring",
+        "strings"
+      ]
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "b68665d5-14ef-4351-ac4a-c28a80c27b3d",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 3,
+      "topics": [
+        "conditionals",
+        "regular_expressions",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "a18daa31-88d3-45ba-84ca-f1d52fe23a79",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "integers",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "strain",
+      "uuid": "ac0966a9-822b-45be-91d9-36f6706ea76f",
+      "core": false,
+      "unlocked_by": "raindrops",
+      "difficulty": 2,
+      "topics": [
+        "arrays",
+        "filtering",
+        "loops"
+      ]
+    },
+    {
+      "slug": "etl",
+      "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
+      "core": false,
+      "unlocked_by": "scrabble-score",
+      "difficulty": 1,
+      "topics": [
+        "loops",
+        "maps",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "trinary",
+      "uuid": "f6735416-4be6-4eb8-b6b9-cb61671ce25e",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "50c34698-7767-42b3-962f-21c735e49787",
+      "core": false,
+      "unlocked_by": "twelve-days",
+      "difficulty": 3,
+      "topics": [
+        "loops",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "bowling",
+      "uuid": "051f0825-8357-4ca6-b24f-40a373deac19",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals"
+      ]
+    },
+    {
+      "slug": "space-age",
+      "uuid": "c971a2b5-ccd4-4e55-9fc7-33e991bc0676",
+      "core": false,
+      "unlocked_by": "hello-world",
+      "difficulty": 2,
+      "topics": [
+        "floating_point_numbers",
+        "if_else_statements",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "anagram",
+      "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 3,
+      "topics": [
+        "filtering",
+        "parsing",
+        "sorting",
+        "strings"
+      ]
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "recursion",
+        "searching",
+        "sorting",
+        "structs",
+        "trees"
+      ]
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "86f8e33d-31b7-43e3-8ea3-2e391133704a",
+      "core": false,
+      "unlocked_by": "luhn",
+      "difficulty": 3,
+      "topics": [
+        "cryptography",
+        "filtering",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
       "slug": "clock",
       "uuid": "f95ebf09-0f32-4e60-867d-60cb81dd9a62",
       "core": true,
@@ -170,6 +386,117 @@
       ]
     },
     {
+      "slug": "alphametics",
+      "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "mathematics",
+        "searching"
+      ]
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "loops",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "acronym",
+      "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "d934ebce-9ac3-4a41-bcb8-d70480170438",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "loops",
+        "maps",
+        "strings"
+      ]
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "8ad2bffd-1d79-4e1f-8ef3-ece0214d2804",
+      "core": false,
+      "unlocked_by": "hamming",
+      "difficulty": 2,
+      "topics": [
+        "maps",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "arrays",
+        "recursion"
+      ]
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "6984cc14-91f8-47a7-b7e2-4b210a5dbc5c",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "slug": "say",
+      "uuid": "2a410923-6445-41fc-9cf3-a60209e1c1c2",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 7,
+      "topics": [
+        "numbers",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "meetup",
+      "uuid": "8120e133-9561-4f82-8081-10c19f7f6ba3",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 3,
+      "topics": [
+        "dates",
+        "time",
+        "transforming",
+        "type_conversion"
+      ]
+    },
+    {
       "slug": "robot-name",
       "uuid": "76a0fd0a-cc65-4be3-acc8-7348bb67ad5a",
       "core": true,
@@ -180,31 +507,51 @@
       ]
     },
     {
-      "slug": "tournament",
-      "uuid": "486becee-9d85-4139-ab89-db254d385ade",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
+      "slug": "queen-attack",
+      "uuid": "2ce9b158-e730-4c86-8639-bd08af9f80f4",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
       "topics": [
-        "integers",
-        "parsing",
-        "records",
-        "sorting",
-        "strings",
-        "text_formatting",
-        "transforming"
+        "booleans",
+        "errors",
+        "games",
+        "logic",
+        "mathematics"
       ]
     },
     {
-      "slug": "twelve-days",
-      "uuid": "eeb64dda-b79f-4920-8fa3-04810e8d37ab",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 4,
+      "slug": "palindrome-products",
+      "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 6,
       "topics": [
         "algorithms",
-        "pattern_recognition",
-        "sequences",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "bracket-push",
+      "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
+      "topics": [
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "6f0919eb-2160-4cca-8504-286acc2ae9c8",
+      "core": false,
+      "unlocked_by": "twelve-days",
+      "difficulty": 4,
+      "topics": [
+        "conditionals",
+        "loops",
+        "recursion",
         "strings",
         "text_formatting"
       ]
@@ -224,37 +571,16 @@
       ]
     },
     {
-      "slug": "flatten-array",
-      "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
+      "slug": "saddle-points",
+      "uuid": "38bb4ac6-a5ec-4448-8b86-cdaff13a8be3",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
       "topics": [
         "arrays",
-        "recursion"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
-      "core": false,
-      "unlocked_by": "two-fer",
-      "difficulty": 1,
-      "topics": [
-        "booleans",
-        "conditionals",
         "integers",
-        "logic"
-      ]
-    },
-    {
-      "slug": "accumulate",
-      "uuid": "2c71fc3a-2c93-402b-b091-697b795ce3ba",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 1,
-      "topics": [
-        "lists"
+        "matrices",
+        "searching"
       ]
     },
     {
@@ -270,15 +596,16 @@
       ]
     },
     {
-      "slug": "secret-handshake",
-      "uuid": "c1ebad1b-d5aa-465a-b5ef-9e717ab5db9e",
+      "slug": "atbash-cipher",
+      "uuid": "1e737640-9785-4a47-866a-46298104d891",
       "core": false,
-      "unlocked_by": "grains",
-      "difficulty": 5,
+      "unlocked_by": "luhn",
+      "difficulty": 3,
       "topics": [
-        "arrays",
-        "bitwise_operations",
-        "integers"
+        "algorithms",
+        "cryptography",
+        "strings",
+        "transforming"
       ]
     },
     {
@@ -294,115 +621,141 @@
       ]
     },
     {
-      "slug": "pascals-triangle",
-      "uuid": "4ff8b056-f27d-4bdf-b7af-214448db4260",
+      "slug": "secret-handshake",
+      "uuid": "c1ebad1b-d5aa-465a-b5ef-9e717ab5db9e",
       "core": false,
-      "unlocked_by": "tournament",
-      "difficulty": 4,
+      "unlocked_by": "grains",
+      "difficulty": 5,
       "topics": [
-        "algorithms",
         "arrays",
-        "mathematics",
-        "recursion"
+        "bitwise_operations",
+        "integers"
       ]
     },
     {
-      "slug": "series",
-      "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
+      "slug": "proverb",
+      "uuid": "3c5193ab-6471-4be2-9d24-1d2b51ad822a",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
+      "unlocked_by": "two-fer",
+      "difficulty": 4,
       "topics": [
         "arrays",
-        "refactoring",
+        "loops",
         "strings"
       ]
     },
     {
-      "slug": "queen-attack",
-      "uuid": "2ce9b158-e730-4c86-8639-bd08af9f80f4",
+      "slug": "ocr-numbers",
+      "uuid": "dd13bb29-589c-497d-9580-3f288f353fb2",
       "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 5,
+      "unlocked_by": "tournament",
+      "difficulty": 7,
       "topics": [
-        "booleans",
-        "errors",
-        "games",
-        "logic",
-        "mathematics"
+        "parsing",
+        "pattern_recognition"
       ]
     },
     {
-      "slug": "etl",
-      "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
+      "slug": "pig-latin",
+      "uuid": "efc0e498-891a-4e91-a6aa-fae635573a83",
       "core": false,
-      "unlocked_by": "scrabble-score",
-      "difficulty": 1,
+      "unlocked_by": "clock",
+      "difficulty": 4,
       "topics": [
-        "loops",
-        "maps",
+        "conditionals",
+        "strings",
         "transforming"
       ]
     },
     {
-      "slug": "sum-of-multiples",
-      "uuid": "4fc25295-5d6a-4d13-9b87-064167d8980e",
+      "slug": "simple-linked-list",
+      "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
       "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 5,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
-        "loops",
-        "mathematics"
+        "arrays",
+        "loops"
       ]
     },
     {
-      "slug": "pythagorean-triplet",
-      "uuid": "43aad536-0e24-464c-9554-cbc2699d0543",
-      "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "mathematics"
-      ]
-    },
-    {
-      "slug": "pangram",
-      "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
-      "core": false,
-      "unlocked_by": "isogram",
+      "slug": "luhn",
+      "uuid": "bee97539-b8c1-460e-aa14-9336008df2b6",
+      "core": true,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "loops",
+        "algorithms",
+        "integers",
         "strings"
       ]
     },
     {
-      "slug": "crypto-square",
-      "uuid": "86f8e33d-31b7-43e3-8ea3-2e391133704a",
+      "slug": "simple-cipher",
+      "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
       "core": false,
       "unlocked_by": "luhn",
       "difficulty": 3,
       "topics": [
+        "algorithms",
         "cryptography",
-        "filtering",
+        "interfaces",
         "strings",
-        "text_formatting",
         "transforming"
       ]
     },
     {
-      "slug": "food-chain",
-      "uuid": "6f0919eb-2160-4cca-8504-286acc2ae9c8",
+      "slug": "wordy",
+      "uuid": "cb58e4cf-e3af-469c-9f2d-02557b9f61ed",
       "core": false,
-      "unlocked_by": "twelve-days",
-      "difficulty": 4,
+      "unlocked_by": "robot-name",
+      "difficulty": 3,
       "topics": [
         "conditionals",
-        "loops",
-        "recursion",
+        "integers",
+        "parsing",
         "strings",
-        "text_formatting"
+        "type_conversion"
+      ]
+    },
+    {
+      "slug": "allergies",
+      "uuid": "b306bdaa-438e-46a2-ba54-82cb2c0be882",
+      "core": false,
+      "unlocked_by": "grains",
+      "difficulty": 4,
+      "topics": [
+        "bitwise_operations",
+        "enumeration"
+      ]
+    },
+    {
+      "slug": "poker",
+      "uuid": "9a59ba44-34f5-410b-a1e6-9a5c47c52d9e",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 5,
+      "topics": [
+        "equality",
+        "games",
+        "parsing",
+        "pattern_matching",
+        "sequences",
+        "strings"
+      ]
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "04bde625-e363-4d8b-880f-db7bf86286eb",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 3,
+      "topics": [
+        "parsing",
+        "records",
+        "searching",
+        "strings",
+        "structs"
       ]
     },
     {
@@ -418,25 +771,11 @@
       ]
     },
     {
-      "slug": "sieve",
-      "uuid": "80f9af5a-ea29-4937-9333-b4494aaf2446",
+      "slug": "pythagorean-triplet",
+      "uuid": "43aad536-0e24-464c-9554-cbc2699d0543",
       "core": false,
-      "unlocked_by": "grains",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "integers",
-        "loops",
-        "mathematics",
-        "sorting"
-      ]
-    },
-    {
-      "slug": "palindrome-products",
-      "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
-      "core": false,
-      "unlocked_by": "robot-name",
-      "difficulty": 6,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 5,
       "topics": [
         "algorithms",
         "mathematics"
@@ -479,100 +818,14 @@
       ]
     },
     {
-      "slug": "bracket-push",
-      "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
-      "core": false,
+      "slug": "isogram",
+      "uuid": "a79eb8cd-d2db-48f5-a7dc-055039dcee62",
+      "core": true,
       "unlocked_by": null,
-      "difficulty": 7,
-      "topics": [
-        "parsing",
-        "strings"
-      ]
-    },
-    {
-      "slug": "anagram",
-      "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
-      "core": false,
-      "unlocked_by": "isogram",
-      "difficulty": 3,
-      "topics": [
-        "filtering",
-        "parsing",
-        "sorting",
-        "strings"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
-      "core": false,
-      "unlocked_by": "isogram",
-      "difficulty": 3,
-      "topics": [
-        "sorting",
-        "strings"
-      ]
-    },
-    {
-      "slug": "allergies",
-      "uuid": "b306bdaa-438e-46a2-ba54-82cb2c0be882",
-      "core": false,
-      "unlocked_by": "grains",
-      "difficulty": 4,
-      "topics": [
-        "bitwise_operations",
-        "enumeration"
-      ]
-    },
-    {
-      "slug": "rail-fence-cipher",
-      "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "cryptography",
-        "loops",
-        "sorting",
-        "strings",
-        "text_formatting",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "rna-transcription",
-      "uuid": "41f66d2a-1883-4a2c-875f-663c46fa88aa",
-      "core": false,
-      "unlocked_by": "hamming",
       "difficulty": 2,
       "topics": [
-        "maps",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "roman-numerals",
-      "uuid": "b7ca9519-c33b-418b-a4ef-858a3d4d6855",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 2,
-      "topics": [
-        "numbers",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "say",
-      "uuid": "2a410923-6445-41fc-9cf3-a60209e1c1c2",
-      "core": false,
-      "unlocked_by": "robot-name",
-      "difficulty": 7,
-      "topics": [
-        "numbers",
-        "strings",
-        "text_formatting",
-        "transforming"
+        "sequences",
+        "strings"
       ]
     },
     {
@@ -613,66 +866,17 @@
       ]
     },
     {
-      "slug": "atbash-cipher",
-      "uuid": "1e737640-9785-4a47-866a-46298104d891",
-      "core": false,
-      "unlocked_by": "luhn",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "cryptography",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "phone-number",
-      "uuid": "b68665d5-14ef-4351-ac4a-c28a80c27b3d",
-      "core": false,
-      "unlocked_by": "clock",
-      "difficulty": 3,
-      "topics": [
-        "conditionals",
-        "regular_expressions",
-        "strings",
-        "text_formatting",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "strain",
-      "uuid": "ac0966a9-822b-45be-91d9-36f6706ea76f",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "filtering",
-        "loops"
-      ]
-    },
-    {
-      "slug": "pig-latin",
-      "uuid": "efc0e498-891a-4e91-a6aa-fae635573a83",
-      "core": false,
-      "unlocked_by": "clock",
+      "slug": "twelve-days",
+      "uuid": "eeb64dda-b79f-4920-8fa3-04810e8d37ab",
+      "core": true,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "conditionals",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "prime-factors",
-      "uuid": "a18daa31-88d3-45ba-84ca-f1d52fe23a79",
-      "core": false,
-      "unlocked_by": "clock",
-      "difficulty": 3,
-      "topics": [
         "algorithms",
-        "integers",
-        "mathematics"
+        "pattern_recognition",
+        "sequences",
+        "strings",
+        "text_formatting"
       ]
     },
     {
@@ -688,113 +892,16 @@
       ]
     },
     {
-      "slug": "nth-prime",
-      "uuid": "16baef71-6234-4928-a2d4-a19eb8e110b8",
-      "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "integers",
-        "mathematics"
-      ]
-    },
-    {
-      "slug": "beer-song",
-      "uuid": "50c34698-7767-42b3-962f-21c735e49787",
-      "core": false,
-      "unlocked_by": "twelve-days",
-      "difficulty": 3,
-      "topics": [
-        "loops",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "ocr-numbers",
-      "uuid": "dd13bb29-589c-497d-9580-3f288f353fb2",
+      "slug": "pascals-triangle",
+      "uuid": "4ff8b056-f27d-4bdf-b7af-214448db4260",
       "core": false,
       "unlocked_by": "tournament",
-      "difficulty": 7,
-      "topics": [
-        "parsing",
-        "pattern_recognition"
-      ]
-    },
-    {
-      "slug": "wordy",
-      "uuid": "cb58e4cf-e3af-469c-9f2d-02557b9f61ed",
-      "core": false,
-      "unlocked_by": "robot-name",
-      "difficulty": 3,
-      "topics": [
-        "conditionals",
-        "integers",
-        "parsing",
-        "strings",
-        "type_conversion"
-      ]
-    },
-    {
-      "slug": "nucleotide-count",
-      "uuid": "8ad2bffd-1d79-4e1f-8ef3-ece0214d2804",
-      "core": false,
-      "unlocked_by": "hamming",
-      "difficulty": 2,
-      "topics": [
-        "maps",
-        "parsing",
-        "strings"
-      ]
-    },
-    {
-      "slug": "grade-school",
-      "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "lists",
-        "sorting",
-        "structs"
-      ]
-    },
-    {
-      "slug": "saddle-points",
-      "uuid": "38bb4ac6-a5ec-4448-8b86-cdaff13a8be3",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 5,
-      "topics": [
-        "arrays",
-        "integers",
-        "matrices",
-        "searching"
-      ]
-    },
-    {
-      "slug": "meetup",
-      "uuid": "8120e133-9561-4f82-8081-10c19f7f6ba3",
-      "core": false,
-      "unlocked_by": "clock",
-      "difficulty": 3,
-      "topics": [
-        "dates",
-        "time",
-        "transforming",
-        "type_conversion"
-      ]
-    },
-    {
-      "slug": "simple-linked-list",
-      "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
-      "core": false,
-      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+        "algorithms",
         "arrays",
-        "loops"
+        "mathematics",
+        "recursion"
       ]
     },
     {
@@ -822,45 +929,18 @@
       ]
     },
     {
-      "slug": "binary-search-tree",
-      "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
-      "core": false,
+      "slug": "tournament",
+      "uuid": "486becee-9d85-4139-ab89-db254d385ade",
+      "core": true,
       "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "recursion",
-        "searching",
-        "sorting",
-        "structs",
-        "trees"
-      ]
-    },
-    {
-      "slug": "kindergarten-garden",
-      "uuid": "04bde625-e363-4d8b-880f-db7bf86286eb",
-      "core": false,
-      "unlocked_by": "tournament",
       "difficulty": 3,
       "topics": [
+        "integers",
         "parsing",
         "records",
-        "searching",
+        "sorting",
         "strings",
-        "structs"
-      ]
-    },
-    {
-      "slug": "simple-cipher",
-      "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
-      "core": false,
-      "unlocked_by": "luhn",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "cryptography",
-        "interfaces",
-        "strings",
+        "text_formatting",
         "transforming"
       ]
     },
@@ -876,6 +956,17 @@
         "loops",
         "matrices",
         "transforming"
+      ]
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "1304b188-6d08-4361-be40-c6b1b88e5e54",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "strings"
       ]
     },
     {
@@ -919,21 +1010,6 @@
       ]
     },
     {
-      "slug": "poker",
-      "uuid": "9a59ba44-34f5-410b-a1e6-9a5c47c52d9e",
-      "core": false,
-      "unlocked_by": "tournament",
-      "difficulty": 5,
-      "topics": [
-        "equality",
-        "games",
-        "parsing",
-        "pattern_matching",
-        "sequences",
-        "strings"
-      ]
-    },
-    {
       "slug": "change",
       "uuid": "dc6c3e44-1027-4d53-9653-ba06824f8bcf",
       "core": false,
@@ -945,30 +1021,6 @@
         "loops",
         "mathematics",
         "searching"
-      ]
-    },
-    {
-      "slug": "bowling",
-      "uuid": "051f0825-8357-4ca6-b24f-40a373deac19",
-      "core": false,
-      "unlocked_by": "tournament",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "arrays",
-        "conditionals"
-      ]
-    },
-    {
-      "slug": "run-length-encoding",
-      "uuid": "9d6a8c89-41c1-4c4e-b24c-476ba0dfa5f9",
-      "core": false,
-      "unlocked_by": "isogram",
-      "difficulty": 4,
-      "topics": [
-        "parsing",
-        "strings",
-        "transforming"
       ]
     },
     {
@@ -1011,18 +1063,6 @@
       ]
     },
     {
-      "slug": "proverb",
-      "uuid": "3c5193ab-6471-4be2-9d24-1d2b51ad822a",
-      "core": false,
-      "unlocked_by": "two-fer",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "loops",
-        "strings"
-      ]
-    },
-    {
       "slug": "isbn-verifier",
       "uuid": "a0aac827-8f7a-4065-9d05-a57009f5668d",
       "core": false,
@@ -1041,19 +1081,6 @@
       "topics": [
         "algorithms",
         "arrays",
-        "searching"
-      ]
-    },
-    {
-      "slug": "alphametics",
-      "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "arrays",
-        "mathematics",
         "searching"
       ]
     },
@@ -1083,35 +1110,8 @@
       ]
     },
     {
-      "slug": "binary",
-      "uuid": "43bc27ed-d2fa-4173-8665-4459b71c9a3a",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
-    },
-    {
-      "slug": "hexadecimal",
-      "uuid": "6984cc14-91f8-47a7-b7e2-4b210a5dbc5c",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
-    },
-    {
       "slug": "octal",
       "uuid": "cae4e000-3aac-41f7-b727-f9cce12d058d",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
-    },
-    {
-      "slug": "trinary",
-      "uuid": "f6735416-4be6-4eb8-b6b9-cb61671ce25e",
       "core": false,
       "unlocked_by": null,
       "difficulty": 0,

--- a/config.json
+++ b/config.json
@@ -227,7 +227,7 @@
       "slug": "flatten-array",
       "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "arrays",
@@ -310,7 +310,7 @@
       "slug": "series",
       "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
       "core": false,
-      "unlocked_by": "parallel-letter-frequency",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "arrays",
@@ -482,7 +482,7 @@
       "slug": "bracket-push",
       "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
       "core": false,
-      "unlocked_by": "tree-building",
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "parsing",
@@ -528,7 +528,7 @@
       "slug": "rail-fence-cipher",
       "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
       "core": false,
-      "unlocked_by": "tree-building",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "algorithms",
@@ -579,7 +579,7 @@
       "slug": "circular-buffer",
       "uuid": "f3419fe3-a5f5-4bc9-bc40-49f450b8981e",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "queues",
@@ -604,7 +604,7 @@
       "slug": "custom-set",
       "uuid": "4f74b3cd-f995-4b8c-9b57-23f073261d0e",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "filtering",
@@ -752,7 +752,7 @@
       "slug": "grade-school",
       "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
       "core": false,
-      "unlocked_by": "bank-account",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "lists",
@@ -790,7 +790,7 @@
       "slug": "simple-linked-list",
       "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "arrays",
@@ -801,7 +801,7 @@
       "slug": "linked-list",
       "uuid": "92c9aafc-791d-4aaf-a136-9bee14f6ff95",
       "core": false,
-      "unlocked_by": "tree-building",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "data_structure",
@@ -812,7 +812,7 @@
       "slug": "binary-search",
       "uuid": "b1ba445d-4908-4922-acc0-de3a0ec92c53",
       "core": false,
-      "unlocked_by": "tree-building",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -825,7 +825,7 @@
       "slug": "binary-search-tree",
       "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
       "core": false,
-      "unlocked_by": "tree-building",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -882,7 +882,7 @@
       "slug": "robot-simulator",
       "uuid": "724e6a6e-2e6e-45a9-ab0e-0d8d50a06085",
       "core": false,
-      "unlocked_by": "bank-account",
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "concurrency",
@@ -937,7 +937,7 @@
       "slug": "change",
       "uuid": "dc6c3e44-1027-4d53-9653-ba06824f8bcf",
       "core": false,
-      "unlocked_by": "bank-account",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -988,7 +988,7 @@
       "slug": "book-store",
       "uuid": "0ec96460-08be-49a0-973a-4336f21b763c",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "algorithms",
@@ -1036,7 +1036,7 @@
       "slug": "dominoes",
       "uuid": "705f3eb6-55a9-476c-b3f2-e9f3cb0bbe37",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "algorithms",
@@ -1048,7 +1048,7 @@
       "slug": "alphametics",
       "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
       "core": false,
-      "unlocked_by": "error-handling",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -1061,7 +1061,7 @@
       "slug": "two-bucket",
       "uuid": "e5a2d445-437d-46a8-889b-fbcd62c70fa9",
       "core": false,
-      "unlocked_by": "tree-building",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",

--- a/config.json
+++ b/config.json
@@ -6,148 +6,13 @@
   "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "exercises": [
     {
-      "slug": "hello-world",
-      "uuid": "4fe19484-4414-471b-a106-73c776c61388",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings"
-      ]
-    },
-    {
-      "slug": "hamming",
-      "uuid": "d33dec8a-e2b4-40bc-8be9-3f49de084d43",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings",
-        "control_flow_conditionals"
-      ]
-    },
-    {
       "slug": "gigasecond",
       "uuid": "0fb594a1-193b-4ccf-8de2-eb6a81708b29",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "time",
-        "mathematics"
-      ]
-    },
-    {
-      "slug": "rna-transcription",
-      "uuid": "41f66d2a-1883-4a2c-875f-663c46fa88aa",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "raindrops",
-      "uuid": "efad2cea-1e0b-4fb8-a452-a8e91be73638",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "mathematics"
-      ]
-    },
-    {
-      "slug": "difference-of-squares",
-      "uuid": "f1e4ee0c-8718-43f2-90a5-fb1e915288da",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "integers",
-        "mathematics",
-        "algorithms"
-      ]
-    },
-    {
-      "slug": "pangram",
-      "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings",
-        "control_flow_conditionals"
-      ]
-    },
-    {
-      "slug": "sieve",
-      "uuid": "80f9af5a-ea29-4937-9333-b4494aaf2446",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "mathematics",
-        "integers",
-        "algorithms"
-      ]
-    },
-    {
-      "slug": "roman-numerals",
-      "uuid": "b7ca9519-c33b-418b-a4ef-858a3d4d6855",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops"
-      ]
-    },
-    {
-      "slug": "nth-prime",
-      "uuid": "16baef71-6234-4928-a2d4-a19eb8e110b8",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "mathematics",
-        "algorithms",
-        "control_flow_loops"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "integers",
-        "mathematics",
-        "control_flow_conditionals"
-      ]
-    },
-    {
-      "slug": "grains",
-      "uuid": "22519f53-4516-43bc-915e-07d58e48f617",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "word-count",
-      "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings",
-        "algorithms"
+        "time"
       ]
     },
     {
@@ -155,581 +20,953 @@
       "uuid": "70fec82e-3038-468f-96ef-bfb48ce03ef3",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
-        "regular_expressions",
-        "strings",
-        "control_flow_conditionals"
+        "conditionals",
+        "strings"
       ]
-    },
-    {
-      "slug": "run-length-encoding",
-      "uuid": "9d6a8c89-41c1-4c4e-b24c-476ba0dfa5f9",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "binary",
-      "uuid": "43bc27ed-d2fa-4173-8665-4459b71c9a3a",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "accumulate",
-      "uuid": "2c71fc3a-2c93-402b-b091-697b795ce3ba",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "sum-of-multiples",
-      "uuid": "4fc25295-5d6a-4d13-9b87-064167d8980e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "grade-school",
-      "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "series",
-      "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "phone-number",
-      "uuid": "b68665d5-14ef-4351-ac4a-c28a80c27b3d",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings",
-        "parsing"
-      ]
-    },
-    {
-      "slug": "prime-factors",
-      "uuid": "a18daa31-88d3-45ba-84ca-f1d52fe23a79",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "mathematics",
-        "integers"
-      ]
-    },
-    {
-      "slug": "strain",
-      "uuid": "ac0966a9-822b-45be-91d9-36f6706ea76f",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "etl",
-      "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "trinary",
-      "uuid": "f6735416-4be6-4eb8-b6b9-cb61671ce25e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "beer-song",
-      "uuid": "50c34698-7767-42b3-962f-21c735e49787",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings",
-        "control_flow_loops"
-      ]
-    },
-    {
-      "slug": "bowling",
-      "uuid": "051f0825-8357-4ca6-b24f-40a373deac19",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "space-age",
-      "uuid": "c971a2b5-ccd4-4e55-9fc7-33e991bc0676",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "anagram",
-      "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "binary-search-tree",
-      "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "crypto-square",
-      "uuid": "86f8e33d-31b7-43e3-8ea3-2e391133704a",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "clock",
-      "uuid": "f95ebf09-0f32-4e60-867d-60cb81dd9a62",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "alphametics",
-      "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "rail-fence-cipher",
-      "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
     },
     {
       "slug": "acronym",
       "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
       "core": false,
       "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "hello-world",
+      "uuid": "4fe19484-4414-471b-a106-73c776c61388",
+      "core": true,
+      "auto_approve": true,
+      "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "strings"
+      ]
+    },
+    {
+      "slug": "space-age",
+      "uuid": "c971a2b5-ccd4-4e55-9fc7-33e991bc0676",
+      "core": false,
+      "unlocked_by": "hello-world",
+      "difficulty": 2,
+      "topics": [
+        "floating_point_numbers",
+        "if_else_statements",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "1304b188-6d08-4361-be40-c6b1b88e5e54",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "strings"
+      ]
+    },
+    {
+      "slug": "hamming",
+      "uuid": "d33dec8a-e2b4-40bc-8be9-3f49de084d43",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "equality",
+        "loops",
+        "strings"
+      ]
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "efad2cea-1e0b-4fb8-a452-a8e91be73638",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "filtering",
+        "strings"
+      ]
     },
     {
       "slug": "scrabble-score",
       "uuid": "d934ebce-9ac3-4a41-bcb8-d70480170438",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "loops",
+        "maps",
+        "strings"
+      ]
     },
     {
-      "slug": "nucleotide-count",
-      "uuid": "8ad2bffd-1d79-4e1f-8ef3-ece0214d2804",
-      "core": false,
+      "slug": "isogram",
+      "uuid": "a79eb8cd-d2db-48f5-a7dc-055039dcee62",
+      "core": true,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "difficulty": 2,
+      "topics": [
+        "sequences",
+        "strings"
+      ]
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "e2df2756-7a48-4b45-b601-91be91027dbd",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 2,
+      "topics": [
+        "sequences",
+        "strings"
+      ]
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "f1e4ee0c-8718-43f2-90a5-fb1e915288da",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "algorithms",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "luhn",
+      "uuid": "bee97539-b8c1-460e-aa14-9336008df2b6",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "algorithms",
+        "integers",
+        "strings"
+      ]
+    },
+    {
+      "slug": "grains",
+      "uuid": "22519f53-4516-43bc-915e-07d58e48f617",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "bitwise_operations",
+        "if_else_statements",
+        "integers",
+        "mathematics",
+        "type_conversion"
+      ]
+    },
+    {
+      "slug": "clock",
+      "uuid": "f95ebf09-0f32-4e60-867d-60cb81dd9a62",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "equality",
+        "mathematics",
+        "text_formatting",
+        "time"
+      ]
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "76a0fd0a-cc65-4be3-acc8-7348bb67ad5a",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "randomness"
+      ]
+    },
+    {
+      "slug": "tournament",
+      "uuid": "486becee-9d85-4139-ab89-db254d385ade",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "integers",
+        "parsing",
+        "records",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "eeb64dda-b79f-4920-8fa3-04810e8d37ab",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "pattern_recognition",
+        "sequences",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "matrix",
+      "uuid": "3de21c18-a533-4150-8a73-49df8fcb8c61",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "exception_handling",
+        "matrices",
+        "strings",
+        "type_conversion"
+      ]
     },
     {
       "slug": "flatten-array",
       "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "error-handling",
+      "difficulty": 3,
+      "topics": [
+        "arrays",
+        "recursion"
+      ]
     },
     {
-      "slug": "hexadecimal",
-      "uuid": "6984cc14-91f8-47a7-b7e2-4b210a5dbc5c",
+      "slug": "leap",
+      "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "two-fer",
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "booleans",
+        "conditionals",
+        "integers",
+        "logic"
+      ]
     },
     {
-      "slug": "say",
-      "uuid": "2a410923-6445-41fc-9cf3-a60209e1c1c2",
+      "slug": "accumulate",
+      "uuid": "2c71fc3a-2c93-402b-b091-697b795ce3ba",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "raindrops",
       "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "meetup",
-      "uuid": "8120e133-9561-4f82-8081-10c19f7f6ba3",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "robot-name",
-      "uuid": "76a0fd0a-cc65-4be3-acc8-7348bb67ad5a",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 6,
-      "topics": null
-    },
-    {
-      "slug": "queen-attack",
-      "uuid": "2ce9b158-e730-4c86-8639-bd08af9f80f4",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "palindrome-products",
-      "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "bracket-push",
-      "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "food-chain",
-      "uuid": "6f0919eb-2160-4cca-8504-286acc2ae9c8",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "matrix",
-      "uuid": "3de21c18-a533-4150-8a73-49df8fcb8c61",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "saddle-points",
-      "uuid": "38bb4ac6-a5ec-4448-8b86-cdaff13a8be3",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "topics": [
+        "lists"
+      ]
     },
     {
       "slug": "triangle",
       "uuid": "5c797eb2-155d-47ca-8f85-2ba5803f9713",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "atbash-cipher",
-      "uuid": "1e737640-9785-4a47-866a-46298104d891",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "house",
-      "uuid": "df5d771a-e57b-4a96-8a29-9bd4ce7f88d2",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "two-fer",
+      "difficulty": 3,
+      "topics": [
+        "booleans",
+        "conditionals",
+        "logic"
+      ]
     },
     {
       "slug": "secret-handshake",
       "uuid": "c1ebad1b-d5aa-465a-b5ef-9e717ab5db9e",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "grains",
+      "difficulty": 5,
+      "topics": [
+        "arrays",
+        "bitwise_operations",
+        "integers"
+      ]
     },
     {
-      "slug": "proverb",
-      "uuid": "3c5193ab-6471-4be2-9d24-1d2b51ad822a",
+      "slug": "house",
+      "uuid": "df5d771a-e57b-4a96-8a29-9bd4ce7f88d2",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "ocr-numbers",
-      "uuid": "dd13bb29-589c-497d-9580-3f288f353fb2",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "pig-latin",
-      "uuid": "efc0e498-891a-4e91-a6aa-fae635573a83",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "simple-linked-list",
-      "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "luhn",
-      "uuid": "bee97539-b8c1-460e-aa14-9336008df2b6",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "simple-cipher",
-      "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "wordy",
-      "uuid": "cb58e4cf-e3af-469c-9f2d-02557b9f61ed",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "allergies",
-      "uuid": "b306bdaa-438e-46a2-ba54-82cb2c0be882",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "poker",
-      "uuid": "9a59ba44-34f5-410b-a1e6-9a5c47c52d9e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "kindergarten-garden",
-      "uuid": "04bde625-e363-4d8b-880f-db7bf86286eb",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "linked-list",
-      "uuid": "92c9aafc-791d-4aaf-a136-9bee14f6ff95",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "pythagorean-triplet",
-      "uuid": "43aad536-0e24-464c-9554-cbc2699d0543",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "robot-simulator",
-      "uuid": "724e6a6e-2e6e-45a9-ab0e-0d8d50a06085",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "twelve-days",
-      "uuid": "eeb64dda-b79f-4920-8fa3-04810e8d37ab",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "circular-buffer",
-      "uuid": "f3419fe3-a5f5-4bc9-bc40-49f450b8981e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "largest-series-product",
-      "uuid": "7cb55328-1b11-4544-94c0-945444d9a6a4",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "binary-search",
-      "uuid": "b1ba445d-4908-4922-acc0-de3a0ec92c53",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
-    },
-    {
-      "slug": "two-bucket",
-      "uuid": "e5a2d445-437d-46a8-889b-fbcd62c70fa9",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "twelve-days",
+      "difficulty": 4,
+      "topics": [
+        "recursion",
+        "strings",
+        "text_formatting"
+      ]
     },
     {
       "slug": "pascals-triangle",
       "uuid": "4ff8b056-f27d-4bdf-b7af-214448db4260",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "tournament",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "mathematics",
+        "recursion"
+      ]
     },
     {
-      "slug": "custom-set",
-      "uuid": "4f74b3cd-f995-4b8c-9b57-23f073261d0e",
+      "slug": "series",
+      "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "parallel-letter-frequency",
+      "difficulty": 3,
+      "topics": [
+        "arrays",
+        "refactoring",
+        "strings"
+      ]
     },
     {
-      "slug": "minesweeper",
-      "uuid": "9d6808fb-d367-4df9-a1f0-47ff83b75544",
+      "slug": "queen-attack",
+      "uuid": "2ce9b158-e730-4c86-8639-bd08af9f80f4",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
+      "topics": [
+        "booleans",
+        "errors",
+        "games",
+        "logic",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "etl",
+      "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
+      "core": false,
+      "unlocked_by": "scrabble-score",
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "loops",
+        "maps",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "4fc25295-5d6a-4d13-9b87-064167d8980e",
+      "core": false,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 5,
+      "topics": [
+        "loops",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "43aad536-0e24-464c-9554-cbc2699d0543",
+      "core": false,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "pangram",
+      "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 2,
+      "topics": [
+        "loops",
+        "strings"
+      ]
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "86f8e33d-31b7-43e3-8ea3-2e391133704a",
+      "core": false,
+      "unlocked_by": "luhn",
+      "difficulty": 3,
+      "topics": [
+        "cryptography",
+        "filtering",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "6f0919eb-2160-4cca-8504-286acc2ae9c8",
+      "core": false,
+      "unlocked_by": "twelve-days",
+      "difficulty": 4,
+      "topics": [
+        "conditionals",
+        "loops",
+        "recursion",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "7cb55328-1b11-4544-94c0-945444d9a6a4",
+      "core": false,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "integers",
+        "sequences"
+      ]
+    },
+    {
+      "slug": "sieve",
+      "uuid": "80f9af5a-ea29-4937-9333-b4494aaf2446",
+      "core": false,
+      "unlocked_by": "grains",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "integers",
+        "loops",
+        "mathematics",
+        "sorting"
+      ]
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 6,
+      "topics": [
+        "algorithms",
+        "mathematics"
+      ]
     },
     {
       "slug": "scale-generator",
       "uuid": "4134d491-8ec5-480b-aa61-37a02689db1f",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "difficulty": 3,
+      "topics": [
+        "pattern_matching",
+        "strings"
+      ]
     },
     {
       "slug": "protein-translation",
       "uuid": "00c6f623-2e54-4f90-ae3f-07e493f93c7c",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "scrabble-score",
+      "difficulty": 3,
+      "topics": [
+        "filtering",
+        "maps",
+        "sequences"
+      ]
     },
     {
       "slug": "perfect-numbers",
       "uuid": "76ad732a-6e58-403b-ac65-9091d355241f",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "grains",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "filtering",
+        "integers",
+        "mathematics"
+      ]
     },
     {
-      "slug": "connect",
-      "uuid": "538a6768-bae5-437c-9cdf-765d73a79643",
+      "slug": "bracket-push",
+      "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "tree-building",
+      "difficulty": 7,
+      "topics": [
+        "parsing",
+        "strings"
+      ]
     },
     {
-      "slug": "list-ops",
-      "uuid": "f62e8acb-8370-46e1-ad7f-a6a2644f8602",
+      "slug": "anagram",
+      "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "isogram",
+      "difficulty": 3,
+      "topics": [
+        "filtering",
+        "parsing",
+        "sorting",
+        "strings"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 3,
+      "topics": [
+        "sorting",
+        "strings"
+      ]
+    },
+    {
+      "slug": "allergies",
+      "uuid": "b306bdaa-438e-46a2-ba54-82cb2c0be882",
+      "core": false,
+      "unlocked_by": "grains",
+      "difficulty": 4,
+      "topics": [
+        "bitwise_operations",
+        "enumeration"
+      ]
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
+      "core": false,
+      "unlocked_by": "tree-building",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "loops",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "41f66d2a-1883-4a2c-875f-663c46fa88aa",
+      "core": false,
+      "unlocked_by": "hamming",
+      "difficulty": 2,
+      "topics": [
+        "maps",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "b7ca9519-c33b-418b-a4ef-858a3d4d6855",
+      "core": false,
+      "unlocked_by": "raindrops",
+      "difficulty": 2,
+      "topics": [
+        "numbers",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "say",
+      "uuid": "2a410923-6445-41fc-9cf3-a60209e1c1c2",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 7,
+      "topics": [
+        "numbers",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "f3419fe3-a5f5-4bc9-bc40-49f450b8981e",
+      "core": false,
+      "unlocked_by": "error-handling",
+      "difficulty": 5,
+      "topics": [
+        "queues",
+        "structs"
+      ]
     },
     {
       "slug": "diamond",
       "uuid": "c55c75fb-6140-4042-967a-39c75b7781bd",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "tournament",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting"
+      ]
     },
     {
-      "slug": "all-your-base",
-      "uuid": "3ce4bd3e-0380-498a-8d0a-b79cf3fedc10",
+      "slug": "custom-set",
+      "uuid": "4f74b3cd-f995-4b8c-9b57-23f073261d0e",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "error-handling",
+      "difficulty": 4,
+      "topics": [
+        "filtering",
+        "loops",
+        "sets"
+      ]
     },
     {
-      "slug": "isogram",
-      "uuid": "a79eb8cd-d2db-48f5-a7dc-055039dcee62",
+      "slug": "atbash-cipher",
+      "uuid": "1e737640-9785-4a47-866a-46298104d891",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "luhn",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "b68665d5-14ef-4351-ac4a-c28a80c27b3d",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 3,
+      "topics": [
+        "conditionals",
+        "regular_expressions",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "strain",
+      "uuid": "ac0966a9-822b-45be-91d9-36f6706ea76f",
+      "core": false,
+      "unlocked_by": "raindrops",
+      "difficulty": 2,
+      "topics": [
+        "arrays",
+        "filtering",
+        "loops"
+      ]
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "efc0e498-891a-4e91-a6aa-fae635573a83",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 4,
+      "topics": [
+        "conditionals",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "a18daa31-88d3-45ba-84ca-f1d52fe23a79",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "integers",
+        "mathematics"
+      ]
     },
     {
       "slug": "transpose",
       "uuid": "4a6bc7d3-5d3b-4ad8-96ae-783e17af7c32",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "matrix",
+      "difficulty": 5,
+      "topics": [
+        "loops",
+        "strings",
+        "transforming"
+      ]
     },
     {
-      "slug": "tournament",
-      "uuid": "486becee-9d85-4139-ab89-db254d385ade",
+      "slug": "nth-prime",
+      "uuid": "16baef71-6234-4928-a2d4-a19eb8e110b8",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "integers",
+        "mathematics"
+      ]
     },
     {
-      "slug": "dominoes",
-      "uuid": "705f3eb6-55a9-476c-b3f2-e9f3cb0bbe37",
+      "slug": "beer-song",
+      "uuid": "50c34698-7767-42b3-962f-21c735e49787",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": null
+      "unlocked_by": "twelve-days",
+      "difficulty": 3,
+      "topics": [
+        "loops",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "dd13bb29-589c-497d-9580-3f288f353fb2",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 7,
+      "topics": [
+        "parsing",
+        "pattern_recognition"
+      ]
+    },
+    {
+      "slug": "wordy",
+      "uuid": "cb58e4cf-e3af-469c-9f2d-02557b9f61ed",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 3,
+      "topics": [
+        "conditionals",
+        "integers",
+        "parsing",
+        "strings",
+        "type_conversion"
+      ]
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "8ad2bffd-1d79-4e1f-8ef3-ece0214d2804",
+      "core": false,
+      "unlocked_by": "hamming",
+      "difficulty": 2,
+      "topics": [
+        "maps",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
+      "core": false,
+      "unlocked_by": "bank-account",
+      "difficulty": 5,
+      "topics": [
+        "lists",
+        "sorting",
+        "structs"
+      ]
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "38bb4ac6-a5ec-4448-8b86-cdaff13a8be3",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
+      "topics": [
+        "arrays",
+        "integers",
+        "matrices",
+        "searching"
+      ]
+    },
+    {
+      "slug": "meetup",
+      "uuid": "8120e133-9561-4f82-8081-10c19f7f6ba3",
+      "core": false,
+      "unlocked_by": "clock",
+      "difficulty": 3,
+      "topics": [
+        "dates",
+        "time",
+        "transforming",
+        "type_conversion"
+      ]
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
+      "core": false,
+      "unlocked_by": "error-handling",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "loops"
+      ]
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "92c9aafc-791d-4aaf-a136-9bee14f6ff95",
+      "core": false,
+      "unlocked_by": "tree-building",
+      "difficulty": 4,
+      "topics": [
+        "data_structure",
+        "pointer"
+      ]
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "b1ba445d-4908-4922-acc0-de3a0ec92c53",
+      "core": false,
+      "unlocked_by": "tree-building",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "searching",
+        "sorting"
+      ]
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
+      "core": false,
+      "unlocked_by": "tree-building",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "recursion",
+        "searching",
+        "sorting",
+        "structs",
+        "trees"
+      ]
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
+      "core": false,
+      "unlocked_by": "luhn",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "interfaces",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "9d6808fb-d367-4df9-a1f0-47ff83b75544",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
+      "topics": [
+        "arrays",
+        "games",
+        "loops",
+        "matrices",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "724e6a6e-2e6e-45a9-ab0e-0d8d50a06085",
+      "core": false,
+      "unlocked_by": "bank-account",
+      "difficulty": 6,
+      "topics": [
+        "concurrency",
+        "loops",
+        "sequences",
+        "strings",
+        "structs"
+      ]
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "3ce4bd3e-0380-498a-8d0a-b79cf3fedc10",
+      "core": false,
+      "unlocked_by": "grains",
+      "difficulty": 3,
+      "topics": [
+        "integers",
+        "mathematics",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "connect",
+      "uuid": "538a6768-bae5-437c-9cdf-765d73a79643",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 9,
+      "topics": [
+        "arrays",
+        "games",
+        "graphs",
+        "loops",
+        "searching"
+      ]
+    },
+    {
+      "slug": "poker",
+      "uuid": "9a59ba44-34f5-410b-a1e6-9a5c47c52d9e",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 5,
+      "topics": [
+        "equality",
+        "games",
+        "parsing",
+        "pattern_matching",
+        "sequences",
+        "strings"
+      ]
+    },
+    {
+      "slug": "change",
+      "uuid": "dc6c3e44-1027-4d53-9653-ba06824f8bcf",
+      "core": false,
+      "unlocked_by": "bank-account",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "loops",
+        "mathematics",
+        "searching"
+      ]
+    },
+    {
+      "slug": "bowling",
+      "uuid": "051f0825-8357-4ca6-b24f-40a373deac19",
+      "core": false,
+      "unlocked_by": "tournament",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals"
+      ]
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "9d6a8c89-41c1-4c4e-b24c-476ba0dfa5f9",
+      "core": false,
+      "unlocked_by": "isogram",
+      "difficulty": 4,
+      "topics": [
+        "parsing",
+        "strings",
+        "transforming"
+      ]
     },
     {
       "slug": "collatz-conjecture",
@@ -738,50 +975,127 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "algorithms",
-        "control_flow_conditionals",
+        "conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
-        "recursion"
+        "mathematics"
+      ]
+    },
+    {
+      "slug": "book-store",
+      "uuid": "0ec96460-08be-49a0-973a-4336f21b763c",
+      "core": false,
+      "unlocked_by": "error-handling",
+      "difficulty": 8,
+      "topics": [
+        "algorithms",
+        "floating_point_numbers",
+        "integers",
+        "lists",
+        "mathematics"
       ]
     },
     {
       "slug": "rotational-cipher",
       "uuid": "af5ccf14-eff2-4dc6-b1db-e209cddca62a",
       "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
+      "unlocked_by": "luhn",
+      "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "logic",
+        "cryptography",
+        "integers",
         "strings"
       ]
     },
     {
-      "slug": "change",
-      "uuid": "dc6c3e44-1027-4d53-9653-ba06824f8bcf",
+      "slug": "proverb",
+      "uuid": "3c5193ab-6471-4be2-9d24-1d2b51ad822a",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "two-fer",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "loops",
+        "strings"
+      ]
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "a0aac827-8f7a-4065-9d05-a57009f5668d",
+      "core": false,
+      "unlocked_by": "difference-of-squares",
+      "difficulty": 2,
+      "topics": [
+        "arrays"
+      ]
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "705f3eb6-55a9-476c-b3f2-e9f3cb0bbe37",
+      "core": false,
+      "unlocked_by": "error-handling",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "searching"
+      ]
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
+      "core": false,
+      "unlocked_by": "error-handling",
       "difficulty": 5,
       "topics": [
         "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "logic"
+        "arrays",
+        "mathematics",
+        "searching"
       ]
     },
     {
-      "slug": "two-fer",
-      "uuid": "1304b188-6d08-4361-be40-c6b1b88e5e54",
+      "slug": "two-bucket",
+      "uuid": "e5a2d445-437d-46a8-889b-fbcd62c70fa9",
+      "core": false,
+      "unlocked_by": "tree-building",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "searching"
+      ]
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "f62e8acb-8370-46e1-ad7f-a6a2644f8602",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
-        "strings"
+          "recursion",
+          "type_conversion",
+          "lists",
+          "functional_programming"
       ]
+    },
+    {
+      "slug": "binary",
+      "uuid": "43bc27ed-d2fa-4173-8665-4459b71c9a3a",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "6984cc14-91f8-47a7-b7e2-4b210a5dbc5c",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
     },
     {
       "slug": "octal",
@@ -793,68 +1107,13 @@
       "deprecated": true
     },
     {
-      "slug": "point-mutations",
-      "uuid": "89bd3d71-000f-4cd9-9a84-ad1b22ddbd33",
+      "slug": "trinary",
+      "uuid": "f6735416-4be6-4eb8-b6b9-cb61671ce25e",
       "core": false,
       "unlocked_by": null,
       "difficulty": 0,
       "topics": null,
       "deprecated": true
-    },
-    {
-      "slug": "complex-numbers",
-      "uuid": "d75bd7c0-52c5-44f2-a046-f63cb332425f",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "mathematics"
-      ]
-    },
-    {
-      "slug": "isbn-verifier",
-      "uuid": "a0aac827-8f7a-4065-9d05-a57009f5668d",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "logic",
-        "strings"
-      ]
-    },
-    {
-      "slug": "book-store",
-      "uuid": "0ec96460-08be-49a0-973a-4336f21b763c",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 6,
-      "topics": [
-        "arrays",
-        "logic",
-        "loops"
-      ]
-    },
-    {
-      "uuid": "239b8e79-2983-4ce0-9dda-9bb999e79d11",
-      "slug": "zipper",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 7,
-      "topics": [
-        "Data Structures"
-      ]
-    },
-    {
-      "slug": "affine-cipher",
-      "uuid": "d1267415-aff5-411d-b267-49a4a2c8fda2",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "cryptography",
-        "mathematics",
-        "strings"
-      ]
     }
   ]
 }


### PR DESCRIPTION
This is an attempt at setting up the Ruby track as a nextercism track.

As suggested in #815 I have cloned the Go tracks progression, removing exercises that are Go-specific, preserving Ruby-only exercises as bonus exercises.

After this changes the progression tree looks like this:

```
Ruby
====

core
----
├─ hello-world
│  └─ space-age
│
├─ two-fer
│  ├─ leap
│  ├─ triangle
│  └─ proverb
│
├─ hamming
│  ├─ rna-transcription
│  └─ nucleotide-count
│
├─ raindrops
│  ├─ accumulate
│  ├─ roman-numerals
│  └─ strain
│
├─ scrabble-score
│  ├─ etl
│  └─ protein-translation
│
├─ isogram
│  ├─ pangram
│  ├─ anagram
│  ├─ word-count
│  └─ run-length-encoding
│
├─ difference-of-squares
│  ├─ sum-of-multiples
│  ├─ pythagorean-triplet
│  ├─ largest-series-product
│  ├─ nth-prime
│  └─ isbn-verifier
│
├─ luhn
│  ├─ crypto-square
│  ├─ atbash-cipher
│  ├─ simple-cipher
│  └─ rotational-cipher
│
├─ grains
│  ├─ secret-handshake
│  ├─ sieve
│  ├─ perfect-numbers
│  ├─ allergies
│  └─ all-your-base
│
├─ clock
│  ├─ phone-number
│  ├─ pig-latin
│  ├─ prime-factors
│  └─ meetup
│
├─ robot-name
│  ├─ palindrome-products
│  ├─ say
│  └─ wordy
│
├─ tournament
│  ├─ pascals-triangle
│  ├─ diamond
│  ├─ ocr-numbers
│  ├─ kindergarten-garden
│  ├─ poker
│  └─ bowling
│
├─ twelve-days
│  ├─ house
│  ├─ food-chain
│  └─ beer-song
│
├─ matrix
│  ├─ queen-attack
│  ├─ transpose
│  ├─ saddle-points
│  ├─ minesweeper
│  └─ connect

bonus
-----
gigasecond
bob
acronym
flatten-array
series
scale-generator
bracket-push
rail-fence-cipher
circular-buffer
custom-set
grade-school
simple-linked-list
linked-list
binary-search
binary-search-tree
robot-simulator
change
collatz-conjecture
book-store
dominoes
alphametics
two-bucket
list-ops
affine-cipher
complex-numbers
zipper
```

The diff is probably slightly more complex than it needs to be as the order of exercises in the configs across Ruby and Go were slightly different. 