### PR TITLE
Removes BookKeeping::VERSION

### DIFF
--- a/exercises/accumulate/.meta/solutions/accumulate.rb
+++ b/exercises/accumulate/.meta/solutions/accumulate.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Array
   def accumulate
     result = []

--- a/exercises/accumulate/accumulate_test.rb
+++ b/exercises/accumulate/accumulate_test.rb
@@ -43,25 +43,4 @@ class ArrayTest < Minitest::Test
     original.accumulate { |n| n * n }
     assert_equal copy, original
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module.
-  #  In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/acronym/.meta/solutions/acronym.rb
+++ b/exercises/acronym/.meta/solutions/acronym.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 class Acronym
   def self.abbreviate(phrase)
     [].tap do |letters|

--- a/exercises/acronym/acronym_test.rb
+++ b/exercises/acronym/acronym_test.rb
@@ -32,26 +32,4 @@ class AcronymTest < Minitest::Test
     skip
     assert_equal "CMOS", Acronym.abbreviate('Complementary metal-oxide semiconductor')
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/affine-cipher/.meta/solutions/affine_cipher.rb
+++ b/exercises/affine-cipher/.meta/solutions/affine_cipher.rb
@@ -1,9 +1,5 @@
 # encryption formula is E(x) = (a * x - b) % m
 # decryption formula is D(E(x)) = a^-1(E(x) - b) % m
-module BookKeeping
-  VERSION = 1
-end
-
 class Affine
 
 attr_reader :key

--- a/exercises/affine-cipher/affine_cipher_test.rb
+++ b/exercises/affine-cipher/affine_cipher_test.rb
@@ -124,26 +124,4 @@ class AffineCipherTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Affine.new(13, 5) }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/all-your-base/.meta/solutions/all_your_base.rb
+++ b/exercises/all-your-base/.meta/solutions/all_your_base.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class BaseConverter
   def self.convert(base_from, number_array, base_to)
     fail ArgumentError if invalid_inputs?(base_from, number_array, base_to)

--- a/exercises/all-your-base/all_your_base_test.rb
+++ b/exercises/all-your-base/all_your_base_test.rb
@@ -269,26 +269,4 @@ class AllYourBaseTest < Minitest::Test
       BaseConverter.convert(input_base, digits, output_base)
     end
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/allergies/.meta/solutions/allergies.rb
+++ b/exercises/allergies/.meta/solutions/allergies.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Allergies
   ALLERGENS = %w(eggs peanuts shellfish strawberries tomatoes chocolate pollen cats)
 

--- a/exercises/allergies/allergies_test.rb
+++ b/exercises/allergies/allergies_test.rb
@@ -78,26 +78,4 @@ class AllergiesTest < Minitest::Test
     allergies = Allergies.new(509)
     assert_equal %w(eggs shellfish strawberries tomatoes chocolate pollen cats), allergies.list
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/alphametics/.meta/generator/test_template.erb
+++ b/exercises/alphametics/.meta/generator/test_template.erb
@@ -11,11 +11,4 @@ class AlphameticsTest < Minitest::Test
     <%= test_case.workload %>
   end
 <% end %>
-
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 end

--- a/exercises/alphametics/.meta/solutions/alphametics.rb
+++ b/exercises/alphametics/.meta/solutions/alphametics.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 class Alphametics
 
   def self.solve(equation)

--- a/exercises/alphametics/alphametics_test.rb
+++ b/exercises/alphametics/alphametics_test.rb
@@ -70,26 +70,4 @@ class AlphameticsTest < Minitest::Test
                  'S' => 6, 'T' => 9 }
     assert_equal expected, Alphametics.solve(input)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/anagram/.meta/solutions/anagram.rb
+++ b/exercises/anagram/.meta/solutions/anagram.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class Anagram
   attr_reader :subject
   def initialize(word)

--- a/exercises/anagram/anagram_test.rb
+++ b/exercises/anagram/anagram_test.rb
@@ -130,26 +130,4 @@ class AnagramTest < Minitest::Test
     expected = []
     assert_equal expected, anagrams
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/beer-song/.meta/solutions/beer_song.rb
+++ b/exercises/beer-song/.meta/solutions/beer_song.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class BeerSong
   def verses(upper_bound, lower_bound)
     upper_bound.downto(lower_bound).map { |i| verse(i) }.join("\n")

--- a/exercises/beer-song/beer_song_test.rb
+++ b/exercises/beer-song/beer_song_test.rb
@@ -380,26 +380,4 @@ Go to the store and buy some more, 99 bottles of beer on the wall.
 TEXT
     assert_equal expected, BeerSong.new.verses(99, 0)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/binary-search-tree/.meta/solutions/binary_search_tree.rb
+++ b/exercises/binary-search-tree/.meta/solutions/binary_search_tree.rb
@@ -41,7 +41,3 @@ class Bst
     end
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/binary-search-tree/binary_search_tree_test.rb
+++ b/exercises/binary-search-tree/binary_search_tree_test.rb
@@ -98,26 +98,4 @@ class BstTest < Minitest::Test
 
     assert_raises(StopIteration) { each_enumerator.next }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/binary/.meta/solutions/binary.rb
+++ b/exercises/binary/.meta/solutions/binary.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class Binary
   def self.to_decimal binary
     fail ArgumentError.new("invalid binary input #{binary}") if invalid?(binary)

--- a/exercises/binary/binary_test.rb
+++ b/exercises/binary/binary_test.rb
@@ -77,26 +77,4 @@ class BinaryTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Binary.to_decimal('001 nope') }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/bob/.meta/solutions/bob.rb
+++ b/exercises/bob/.meta/solutions/bob.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 module Bob
   def hey(drivel)
     answer Phrase.new(drivel)

--- a/exercises/bob/bob_test.rb
+++ b/exercises/bob/bob_test.rb
@@ -152,26 +152,4 @@ class BobTest < Minitest::Test
     remark = "This is a statement ending with whitespace      "
     assert_equal "Whatever.", Bob.hey(remark), %q{Bob hears "This is a statement ending with whitespace      ", and..}
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/book-store/.meta/solutions/book_store.rb
+++ b/exercises/book-store/.meta/solutions/book_store.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 0
-end
-
 class BookStore
 
   GROUP_DISCOUNTS = [0, 0.05, 0.1, 0.2, 0.25]

--- a/exercises/book-store/book_store_test.rb
+++ b/exercises/book-store/book_store_test.rb
@@ -72,26 +72,4 @@ class BookStoreTest < Minitest::Test
     skip
     assert_equal 102.4, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5])
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 0, BookKeeping::VERSION
-  end
 end

--- a/exercises/bowling/.meta/generator/test_template.erb
+++ b/exercises/bowling/.meta/generator/test_template.erb
@@ -18,9 +18,4 @@ class BowlingTest < Minitest::Test
   end
 
 <% end %>
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 end

--- a/exercises/bowling/.meta/solutions/bowling.rb
+++ b/exercises/bowling/.meta/solutions/bowling.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class Game
   PINS = { MIN: 0, MAX: 10 }.freeze
   at_exit { public :roll, :score }

--- a/exercises/bowling/bowling_test.rb
+++ b/exercises/bowling/bowling_test.rb
@@ -204,25 +204,4 @@ class BowlingTest < Minitest::Test
       @game.score
     end
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/bracket-push/.meta/solutions/bracket_push.rb
+++ b/exercises/bracket-push/.meta/solutions/bracket_push.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 module Brackets
 
   BRACKETS = {

--- a/exercises/bracket-push/bracket_push_test.rb
+++ b/exercises/bracket-push/bracket_push_test.rb
@@ -74,26 +74,4 @@ class BracketPushTest < Minitest::Test
           '\mathrm{e}^{x} &... x^2 \end{array}\right)'
     assert Brackets.paired?(str)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/change/.meta/solutions/change.rb
+++ b/exercises/change/.meta/solutions/change.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class Change
   attr_reader :coins, :target
 
@@ -28,7 +24,7 @@ class Change
   attr_accessor :total_change
 
   def calculate_change(current_coins, current_change, current_value)
-    available_coins = current_coins.reject {|d| d > current_value } 
+    available_coins = current_coins.reject {|d| d > current_value }
 
     save_change(current_change) if current_value.zero?
 

--- a/exercises/change/change_test.rb
+++ b/exercises/change/change_test.rb
@@ -57,26 +57,4 @@ class ChangeTest < Minitest::Test
     skip
     assert_equal -1, Change.generate([1, 2, 5], -5)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/clock/.meta/solutions/clock.rb
+++ b/exercises/clock/.meta/solutions/clock.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 # Clock without dates exercise
 class Clock
 

--- a/exercises/clock/clock_test.rb
+++ b/exercises/clock/clock_test.rb
@@ -298,26 +298,4 @@ class ClockTest < Minitest::Test
     clock2 = Clock.new(hour: -54, minute: -11513)
     assert clock1 == clock2
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/collatz-conjecture/.meta/solutions/collatz_conjecture.rb
+++ b/exercises/collatz-conjecture/.meta/solutions/collatz_conjecture.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 module CollatzConjecture
   def self.steps(num)
     raise ArgumentError if num < 1
@@ -18,5 +14,3 @@ module CollatzConjecture
     steps
   end
 end
-
-

--- a/exercises/collatz-conjecture/collatz_conjecture_test.rb
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.rb
@@ -32,26 +32,4 @@ class CollatzConjectureTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { CollatzConjecture.steps(-15) }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/complex-numbers/.meta/solutions/complex_numbers.rb
+++ b/exercises/complex-numbers/.meta/solutions/complex_numbers.rb
@@ -43,7 +43,3 @@ class ComplexNumber
    self.class.new(Math.exp(@real)) * self.class.new(Math.cos(@imaginary), Math.sin(@imaginary))
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/complex-numbers/complex_numbers_test.rb
+++ b/exercises/complex-numbers/complex_numbers_test.rb
@@ -182,26 +182,4 @@ class ComplexNumberTest < Minitest::Test
     expected = ComplexNumber.new(Math::E, 0)
     assert_equal expected, ComplexNumber.new(1, 0).exp
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/connect/.meta/generator/test_template.erb
+++ b/exercises/connect/.meta/generator/test_template.erb
@@ -10,9 +10,4 @@ class ConnectTest < Minitest::Test
   end
 
 <% end %>
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 end

--- a/exercises/connect/.meta/solutions/connect.rb
+++ b/exercises/connect/.meta/solutions/connect.rb
@@ -1,6 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
 Position = Struct.new(:x, :y)
 class Board
   DIRECTIONS = [[1, 0], [-1, 0], [0, 1], [0, -1], [-1, 1], [1, -1]].freeze

--- a/exercises/connect/connect_test.rb
+++ b/exercises/connect/connect_test.rb
@@ -127,25 +127,4 @@ class ConnectTest < Minitest::Test
     game = Board.new(board)
     assert_equal 'X', game.winner, 'X wins using a spiral path'
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/crypto-square/.meta/solutions/crypto_square.rb
+++ b/exercises/crypto-square/.meta/solutions/crypto_square.rb
@@ -38,7 +38,3 @@ class Crypto
   end
 
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/crypto-square/crypto_square_test.rb
+++ b/exercises/crypto-square/crypto_square_test.rb
@@ -44,26 +44,4 @@ class CryptoSquareTest < Minitest::Test
     plaintext = 'If man was meant to stay on the ground, god would have given us roots.'
     assert_equal "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ", Crypto.new(plaintext).ciphertext
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/custom-set/.meta/solutions/custom_set.rb
+++ b/exercises/custom-set/.meta/solutions/custom_set.rb
@@ -94,7 +94,3 @@ class Node
     @datum = input_datum
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/custom-set/custom_set_test.rb
+++ b/exercises/custom-set/custom_set_test.rb
@@ -272,26 +272,4 @@ class CustomSetTest < Minitest::Test
     expected = CustomSet.new [3, 2, 1]
     assert_equal expected, set1.union(set2)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/diamond/.meta/solutions/diamond.rb
+++ b/exercises/diamond/.meta/solutions/diamond.rb
@@ -1,6 +1,3 @@
-module Bookkeeping
-  VERSION = 1
-end
 class Diamond
   def self.make_diamond(letter)
     script = ""

--- a/exercises/diamond/diamond_test.rb
+++ b/exercises/diamond/diamond_test.rb
@@ -32,9 +32,4 @@ class DiamondTest < Minitest::Test
              "    A    \n"
     assert_equal string, answer
   end
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, Bookkeeping::VERSION
-  end
 end

--- a/exercises/difference-of-squares/.meta/solutions/difference_of_squares.rb
+++ b/exercises/difference-of-squares/.meta/solutions/difference_of_squares.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 class Squares
   attr_reader :max
 

--- a/exercises/difference-of-squares/difference_of_squares_test.rb
+++ b/exercises/difference-of-squares/difference_of_squares_test.rb
@@ -47,26 +47,4 @@ class DifferenceOfSquaresTest < Minitest::Test
     skip
     assert_equal 25_164_150, Squares.new(100).difference
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/dominoes/.meta/generator/test_template.erb
+++ b/exercises/dominoes/.meta/generator/test_template.erb
@@ -10,11 +10,6 @@ class DominoesTest < Minitest::Test
   end
 
 <% end %>
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 
   # It's infeasible to use example-based tests for this exercise,
   # because the list of acceptable answers for a given input can be quite large.

--- a/exercises/dominoes/.meta/solutions/dominoes.rb
+++ b/exercises/dominoes/.meta/solutions/dominoes.rb
@@ -31,7 +31,3 @@ module Dominoes
     nil
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/dominoes/dominoes_test.rb
+++ b/exercises/dominoes/dominoes_test.rb
@@ -87,27 +87,6 @@ class DominoesTest < Minitest::Test
     assert_correct_chain(input_dominoes, output_chain)
   end
 
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
-
   # It's infeasible to use example-based tests for this exercise,
   # because the list of acceptable answers for a given input can be quite large.
   # Instead, we verify certain properties of a correct chain.

--- a/exercises/etl/.meta/solutions/etl.rb
+++ b/exercises/etl/.meta/solutions/etl.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class ETL
   def self.transform(old)
     data = {}

--- a/exercises/etl/etl_test.rb
+++ b/exercises/etl/etl_test.rb
@@ -85,26 +85,4 @@ class EtlTest < Minitest::Test
     }
     assert_equal expected, ETL.transform(old)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/flatten-array/.meta/solutions/flatten_array.rb
+++ b/exercises/flatten-array/.meta/solutions/flatten_array.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class FlattenArray
   def self.flatten(arr)
     arr.flatten.compact

--- a/exercises/flatten-array/flatten_array_test.rb
+++ b/exercises/flatten-array/flatten_array_test.rb
@@ -38,26 +38,4 @@ class FlattenArrayTest < Minitest::Test
     fa = FlattenArray.flatten([nil, [[[nil]]], nil, nil, [[nil, nil], nil], nil])
     assert_equal [], fa
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/food-chain/.meta/solutions/food_chain.rb
+++ b/exercises/food-chain/.meta/solutions/food_chain.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 module FoodChain
   def self.song
     verses(1, 8)

--- a/exercises/food-chain/food_chain_test.rb
+++ b/exercises/food-chain/food_chain_test.rb
@@ -34,19 +34,6 @@ class FoodChainTest < Minitest::Test
       assert_raises(NoCheating) { FoodChain.send :class_eval, trigger }
     end
   end
-
-  # Problems in exercism evolve over time,
-  # as we find better ways to ask questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of BookKeeping.
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-  def test_version
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end
 
 module RestrictedClasses

--- a/exercises/gigasecond/.meta/solutions/gigasecond.rb
+++ b/exercises/gigasecond/.meta/solutions/gigasecond.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 6
-end
-
 class Gigasecond
   SECONDS = 10**9
 

--- a/exercises/gigasecond/gigasecond_test.rb
+++ b/exercises/gigasecond/gigasecond_test.rb
@@ -27,26 +27,4 @@ class GigasecondTest < Minitest::Test
     skip
     assert_equal Time.utc(2046, 10, 3, 1, 46, 39), Gigasecond.from(Time.utc(2015, 1, 24, 23, 59, 59))
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 6, BookKeeping::VERSION
-  end
 end

--- a/exercises/grade-school/.meta/solutions/grade_school.rb
+++ b/exercises/grade-school/.meta/solutions/grade_school.rb
@@ -20,7 +20,3 @@ class School
     { grade: level, students: students(level) }
   end
 end
-
-module BookKeeping
-  VERSION = 3
-end

--- a/exercises/grade-school/grade_school_test.rb
+++ b/exercises/grade-school/grade_school_test.rb
@@ -86,26 +86,4 @@ class SchoolTest < Minitest::Test
       { grade: 3, students: %w(Deemee Eeemee) }
     ]
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 2 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/grains/.meta/solutions/grains.rb
+++ b/exercises/grains/.meta/solutions/grains.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 module Grains
   def self.square(number)
     fail ArgumentError if number <= 0 || number > 64

--- a/exercises/grains/grains_test.rb
+++ b/exercises/grains/grains_test.rb
@@ -57,26 +57,4 @@ class GrainsTest < Minitest::Test
     skip
     assert_equal 18_446_744_073_709_551_615, Grains.total
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/hamming/.meta/solutions/hamming.rb
+++ b/exercises/hamming/.meta/solutions/hamming.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class Hamming
   def self.compute(strand1, strand2)
     strand1.length == strand2.length ||

--- a/exercises/hamming/hamming_test.rb
+++ b/exercises/hamming/hamming_test.rb
@@ -77,26 +77,4 @@ class HammingTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Hamming.compute('ATA', 'AGTG') }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/isbn-verifier/.meta/solutions/isbn_verifier.rb
+++ b/exercises/isbn-verifier/.meta/solutions/isbn_verifier.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class IsbnVerifier
   def self.valid?(str)
     return false unless /\A\d-?\d{3}-?\d{5}-?[\dX]\z/.match(str)

--- a/exercises/isbn-verifier/isbn_verifier_test.rb
+++ b/exercises/isbn-verifier/isbn_verifier_test.rb
@@ -80,26 +80,4 @@ class IsbnVerifierTest < Minitest::Test
     string = "3-598-21515-X"
     refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/isogram/.meta/solutions/isogram.rb
+++ b/exercises/isogram/.meta/solutions/isogram.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 class Isogram
   def self.isogram?(str)
     letters = str.downcase.gsub(/[[:punct:]]| /, '').chars

--- a/exercises/isogram/isogram_test.rb
+++ b/exercises/isogram/isogram_test.rb
@@ -56,26 +56,4 @@ class IsogramTest < Minitest::Test
     input = "accentor"
     refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/largest-series-product/.meta/solutions/largest_series_product.rb
+++ b/exercises/largest-series-product/.meta/solutions/largest_series_product.rb
@@ -1,8 +1,5 @@
 # see also https://gist.github.com/blairand/5237976
 # see also https://gist.github.com/burtlo/89b0b817fdccf6bdf20f
-module BookKeeping
-  VERSION = 3
-end
 
 class Series
   attr_reader :digits

--- a/exercises/largest-series-product/largest_series_product_test.rb
+++ b/exercises/largest-series-product/largest_series_product_test.rb
@@ -77,26 +77,4 @@ class LargestSeriesProductTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Series.new('12345').largest_product(-1) }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/leap/.meta/generator/test_template.erb
+++ b/exercises/leap/.meta/generator/test_template.erb
@@ -19,10 +19,4 @@ class YearTest < Minitest::Test
   end
 
 <% end %>
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 end

--- a/exercises/leap/.meta/solutions/leap.rb
+++ b/exercises/leap/.meta/solutions/leap.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class Year
   attr_reader :number
 

--- a/exercises/leap/leap_test.rb
+++ b/exercises/leap/leap_test.rb
@@ -31,26 +31,4 @@ class YearTest < Minitest::Test
     skip
     assert Year.leap?(2000), "Expected 'true', 2000 is a leap year."
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/list-ops/.meta/solutions/list_ops.rb
+++ b/exercises/list-ops/.meta/solutions/list_ops.rb
@@ -61,7 +61,3 @@ class ListOps
     total
   end
 end
-
-module BookKeeping
-  VERSION = 2
-end

--- a/exercises/list-ops/list_ops_test.rb
+++ b/exercises/list-ops/list_ops_test.rb
@@ -102,9 +102,4 @@ class ListOpsTest < Minitest::Test
     input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     assert_equal 3_628_800, ListOps.factorial_reducer(input)
   end
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/luhn/.meta/solutions/luhn.rb
+++ b/exercises/luhn/.meta/solutions/luhn.rb
@@ -24,7 +24,3 @@ class Luhn
     @string.match(/^\d{2,}$/)
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/luhn/luhn_test.rb
+++ b/exercises/luhn/luhn_test.rb
@@ -67,26 +67,4 @@ class LuhnTest < Minitest::Test
     skip
     assert Luhn.valid?("091")
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/meetup/.meta/solutions/meetup.rb
+++ b/exercises/meetup/.meta/solutions/meetup.rb
@@ -1,9 +1,5 @@
 require 'date'
 
-module BookKeeping
-  VERSION = 1
-end
-
 class Meetup
   def self.days_of_week
     [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday]

--- a/exercises/meetup/meetup_test.rb
+++ b/exercises/meetup/meetup_test.rb
@@ -572,26 +572,4 @@ class MeetupTest < Minitest::Test
     assert_equal Date.new(2012, 12, 7),
       Meetup.new(12, 2012).day(:friday, :first)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/nth-prime/.meta/solutions/nth_prime.rb
+++ b/exercises/nth-prime/.meta/solutions/nth_prime.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Prime
   def self.nth(n)
     if n < 1

--- a/exercises/nth-prime/nth_prime_test.rb
+++ b/exercises/nth-prime/nth_prime_test.rb
@@ -27,26 +27,4 @@ class NthPrimeTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Prime.nth(0) }
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/ocr-numbers/.meta/solutions/ocr_numbers.rb
+++ b/exercises/ocr-numbers/.meta/solutions/ocr_numbers.rb
@@ -55,7 +55,3 @@ class OcrNumbers
     @first_row_width ||= rows.first.size
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/ocr-numbers/ocr_numbers_test.rb
+++ b/exercises/ocr-numbers/ocr_numbers_test.rb
@@ -87,26 +87,4 @@ class OcrNumbersTest < Minitest::Test
     skip
     assert_equal "123,456,789", OcrNumbers.convert("    _  _ \n  | _| _|\n  ||_  _|\n         \n    _  _ \n|_||_ |_ \n  | _||_|\n         \n _  _  _ \n  ||_||_|\n  ||_| _|\n         ")
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/pangram/.meta/solutions/pangram.rb
+++ b/exercises/pangram/.meta/solutions/pangram.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 6
-end
-
 class Pangram
   def self.pangram?(str)
     downcased_str = str.downcase

--- a/exercises/pangram/pangram_test.rb
+++ b/exercises/pangram/pangram_test.rb
@@ -72,26 +72,4 @@ class PangramTest < Minitest::Test
     result = Pangram.pangram?(phrase)
     refute result, "Expected false, got: #{result.inspect}. #{phrase.inspect} is NOT a pangram"
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 6, BookKeeping::VERSION
-  end
 end

--- a/exercises/perfect-numbers/.meta/solutions/perfect_numbers.rb
+++ b/exercises/perfect-numbers/.meta/solutions/perfect_numbers.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class PerfectNumber
   def self.classify(num)
     raise 'not a natural number' if num < 0

--- a/exercises/perfect-numbers/perfect_numbers_test.rb
+++ b/exercises/perfect-numbers/perfect_numbers_test.rb
@@ -19,8 +19,4 @@ class PerfectNumberTest < Minitest::Test
   def test_classify_abundant
     assert_equal 'abundant', PerfectNumber.classify(12)
   end
-
-  def test_bookkeeping
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/phone-number/.meta/solutions/phone_number.rb
+++ b/exercises/phone-number/.meta/solutions/phone_number.rb
@@ -23,7 +23,3 @@ module PhoneNumber
     matches.names.map(&:to_sym).zip(matches.captures).to_h if matches
   end
 end
-
-module BookKeeping
-  VERSION = 2
-end

--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -62,26 +62,4 @@ class PhoneNumberTest < Minitest::Test
     skip
     assert_nil PhoneNumber.clean("(223) 056-7890")
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/pig-latin/.meta/solutions/pig_latin.rb
+++ b/exercises/pig-latin/.meta/solutions/pig_latin.rb
@@ -27,7 +27,3 @@ class PigLatin
     word.scan(/\A([^aeiou]?qu|[^aeiou]+(?=y)|[^aeiou]+)(.*)/).first
   end
 end
-
-module BookKeeping
-  VERSION = 2
-end

--- a/exercises/pig-latin/pig_latin_test.rb
+++ b/exercises/pig-latin/pig_latin_test.rb
@@ -112,26 +112,4 @@ class PigLatinTest < Minitest::Test
     skip
     assert_equal "ickquay astfay unray", PigLatin.translate("quick fast run")
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/poker/.meta/solutions/poker.rb
+++ b/exercises/poker/.meta/solutions/poker.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class Poker
 
   def initialize(hand_arrays)

--- a/exercises/poker/poker_test.rb
+++ b/exercises/poker/poker_test.rb
@@ -193,8 +193,4 @@ class PokerTest < Minitest::Test
     game = Poker.new(hands)
     assert_equal [spade_straight_to_9, diamond_straight_to_9], game.best_hand
   end
-
-  def test_bookkeeping
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/queen-attack/.meta/solutions/queen_attack.rb
+++ b/exercises/queen-attack/.meta/solutions/queen_attack.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class Queens
   attr_reader :white, :black
   def initialize(positions = {})

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -77,26 +77,4 @@ class QueenAttackTest < Minitest::Test
     queens = Queens.new(white: [2, 2], black: [5, 5])
     assert queens.attack?
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/rail-fence-cipher/.meta/solutions/rail_fence_cipher.rb
+++ b/exercises/rail-fence-cipher/.meta/solutions/rail_fence_cipher.rb
@@ -1,7 +1,5 @@
 # rubocop:enable all
 class RailFenceCipher
-  VERSION = 1
-
   def self.encode(message, rails)
     return message if message.empty? || rails == 1
     empty_fences = create_empty_fences_array(message, rails)

--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
@@ -58,9 +58,4 @@ class RailFenceCipherTest < Minitest::Test
     assert_equal 'THEDEVILISINTHEDETAILS',
                  RailFenceCipher.decode('TEITELHDVLSNHDTISEIIEA', 3)
   end
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, RailFenceCipher::VERSION
-  end
 end

--- a/exercises/raindrops/.meta/solutions/raindrops.rb
+++ b/exercises/raindrops/.meta/solutions/raindrops.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class Raindrops
   def self.convert(i)
     new(i).convert

--- a/exercises/raindrops/raindrops_test.rb
+++ b/exercises/raindrops/raindrops_test.rb
@@ -92,26 +92,4 @@ class RaindropsTest < Minitest::Test
     skip
     assert_equal "Plang", Raindrops.convert(3125)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/rna-transcription/.meta/solutions/rna_transcription.rb
+++ b/exercises/rna-transcription/.meta/solutions/rna_transcription.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 module Complement
   def self.of_dna(strand)
     strand =~ /[^CGTA]/ ? '' : strand.tr('CGTA', 'GCAU')

--- a/exercises/rna-transcription/rna_transcription_test.rb
+++ b/exercises/rna-transcription/rna_transcription_test.rb
@@ -42,26 +42,4 @@ class RnaTranscriptionTest < Minitest::Test
     skip
     assert_equal '', Complement.of_dna('ACGTXXXCTTAA')
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/robot-name/.meta/solutions/robot_name.rb
+++ b/exercises/robot-name/.meta/solutions/robot_name.rb
@@ -15,7 +15,3 @@ class Robot
     @name = @@name_enumerator.next
   end
 end
-
-module BookKeeping
-  VERSION = 3
-end

--- a/exercises/robot-name/robot_name_test.rb
+++ b/exercises/robot-name/robot_name_test.rb
@@ -87,8 +87,4 @@ class RobotTest < Minitest::Test
     assert seen_names.values.all? { |count| count == 1 }, "Some names used more than once"
     assert seen_names.keys.all? { |name| name.match(NAME_REGEXP) }, "Not all names match #{NAME_REGEXP}"
   end
-
-  def test_version
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/roman-numerals/.meta/solutions/roman_numerals.rb
+++ b/exercises/roman-numerals/.meta/solutions/roman_numerals.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class Integer
   def to_roman
     i = self

--- a/exercises/roman-numerals/roman_numerals_test.rb
+++ b/exercises/roman-numerals/roman_numerals_test.rb
@@ -92,26 +92,4 @@ class RomanNumeralsTest < Minitest::Test
     skip
     assert_equal 'MMM', 3000.to_roman
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/rotational-cipher/.meta/solutions/rotational_cipher.rb
+++ b/exercises/rotational-cipher/.meta/solutions/rotational_cipher.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class RotationalCipher
   SMALL_LETTERS_RANGE = (97..122)
   BIG_LETTERS_RANGE   = (65..90)

--- a/exercises/rotational-cipher/rotational_cipher_test.rb
+++ b/exercises/rotational-cipher/rotational_cipher_test.rb
@@ -52,26 +52,4 @@ class RotationalCipherTest < Minitest::Test
     skip
     assert_equal "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.", RotationalCipher.rotate("The quick brown fox jumps over the lazy dog.", 13)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/run-length-encoding/.meta/solutions/run_length_encoding.rb
+++ b/exercises/run-length-encoding/.meta/solutions/run_length_encoding.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class RunLengthEncoding
   def self.encode(str)
     str.chars.chunk { |char| char }.each_with_object('') do |chunk, out|

--- a/exercises/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/run-length-encoding/run_length_encoding_test.rb
@@ -94,26 +94,4 @@ class RunLengthEncodingTest < Minitest::Test
     assert_equal output,
                  RunLengthEncoding.decode(RunLengthEncoding.encode(input))
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/say/.meta/solutions/say.rb
+++ b/exercises/say/.meta/solutions/say.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Chunk
   attr_reader :value, :magnitude
   def initialize(value, magnitude = nil)

--- a/exercises/say/say_test.rb
+++ b/exercises/say/say_test.rb
@@ -96,26 +96,4 @@ class SayTest < Minitest::Test
       Say.new(question).in_english
     end
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/scale-generator/.meta/solutions/scale_generator.rb
+++ b/exercises/scale-generator/.meta/solutions/scale_generator.rb
@@ -34,7 +34,3 @@ class Scale
     chromatic_scale[index..-1] + chromatic_scale[0..index - 1]
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/scale-generator/scale_generator_test.rb
+++ b/exercises/scale-generator/scale_generator_test.rb
@@ -144,26 +144,4 @@ class ScaleGeneratorTest < Minitest::Test
     actual = enigmatic.pitches
     assert_equal expected, actual
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/sieve/.meta/solutions/sieve.rb
+++ b/exercises/sieve/.meta/solutions/sieve.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Sieve
   attr_reader :range
   def initialize(limit)

--- a/exercises/sieve/sieve_test.rb
+++ b/exercises/sieve/sieve_test.rb
@@ -43,26 +43,4 @@ class SieveTest < Minitest::Test
     ]
     assert_equal expected, Sieve.new(1000).primes
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/simple-linked-list/.meta/solutions/simple_linked_list.rb
+++ b/exercises/simple-linked-list/.meta/solutions/simple_linked_list.rb
@@ -53,7 +53,3 @@ class SimpleLinkedList
     array.each { |value| push(Element.new(value)) }
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/simple-linked-list/simple_linked_list_test.rb
+++ b/exercises/simple-linked-list/simple_linked_list_test.rb
@@ -139,25 +139,4 @@ class LinkedListTest < Minitest::Test
     expected = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     assert_equal expected, list.to_a
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module.
-  #  In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/space-age/.meta/generator/test_template.erb
+++ b/exercises/space-age/.meta/generator/test_template.erb
@@ -15,10 +15,4 @@ class <%= exercise_test_classname %> < Minitest::Test
   end
 
 <% end %>
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 end

--- a/exercises/space-age/.meta/solutions/space_age.rb
+++ b/exercises/space-age/.meta/solutions/space_age.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class SpaceAge
   attr_reader :seconds
 
@@ -23,6 +19,5 @@ class SpaceAge
     define_method("on_#{planet}") do
       seconds / orbital_period
     end
-
   end
 end

--- a/exercises/space-age/space_age_test.rb
+++ b/exercises/space-age/space_age_test.rb
@@ -55,26 +55,4 @@ class SpaceAgeTest < Minitest::Test
     age = SpaceAge.new(8_210_123_456)
     assert_in_delta 1.58, age.on_neptune, DELTA
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/sum-of-multiples/.meta/solutions/sum_of_multiples.rb
+++ b/exercises/sum-of-multiples/.meta/solutions/sum_of_multiples.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class SumOfMultiples
   attr_reader :multiples
   def initialize(*multiples)

--- a/exercises/sum-of-multiples/sum_of_multiples_test.rb
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.rb
@@ -67,26 +67,4 @@ class SumOfMultiplesTest < Minitest::Test
     skip
     assert_equal 0, SumOfMultiples.new().to(10000)
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/tournament/.meta/solutions/tournament.rb
+++ b/exercises/tournament/.meta/solutions/tournament.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 3
-end
-
 class Tournament
   def self.tally(input)
     teams = Hash.new { |h, k| h[k] = Hash.new { |h, k| h[k] = 0 } }

--- a/exercises/tournament/tournament_test.rb
+++ b/exercises/tournament/tournament_test.rb
@@ -178,26 +178,4 @@ Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
 TALLY
     assert_equal expected, actual
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 3, BookKeeping::VERSION
-  end
 end

--- a/exercises/transpose/.meta/solutions/transpose.rb
+++ b/exercises/transpose/.meta/solutions/transpose.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Transpose
   def self.transpose(input)
     lines = input.split("\n")

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -69,7 +69,7 @@ INPUT
       g
       l
       e
-       
+
       l
       i
       n
@@ -90,13 +90,13 @@ INPUT
       TT
       hh
       ee
-        
+
       ff
       oi
       uf
       rt
       th
-      h 
+      h
        l
       li
       in
@@ -118,14 +118,14 @@ INPUT
       TT
       hh
       ee
-        
+
       fs
       ie
       rc
       so
       tn
        d
-      l 
+      l
       il
       ni
       en
@@ -223,49 +223,49 @@ INPUT
       hnrhr hohnhshh
       o oeopotedi ea
       rfmrmash  cn t
-      .a e ie fthow 
+      .a e ie fthow
        ia fr weh,whh
       Trnco miae  ie
       w ciroitr btcr
       oVivtfshfcuhhe
-       eeih a uote  
+       eeih a uote
       hrnl sdtln  is
       oot ttvh tttfh
       un bhaeepihw a
       saglernianeoyl
       e,ro -trsui ol
-      h uofcu sarhu 
+      h uofcu sarhu
       owddarrdan o m
       lhg to'egccuwi
       deemasdaeehris
       sr als t  ists
       ,ebk 'phool'h,
-        reldi ffd   
+        reldi ffd
       bweso tb  rtpo
       oea ileutterau
       t kcnoorhhnatr
-      hl isvuyee'fi 
+      hl isvuyee'fi
        atv es iisfet
       ayoior trr ino
       l  lfsoh  ecti
       ion   vedpn  l
-      kuehtteieadoe 
+      kuehtteieadoe
       erwaharrar,fas
          nekt te  rh
       ismdsehphnnosa
       ncuse ra-tau l
        et  tormsural
-      dniuthwea'g t 
+      dniuthwea'g t
       iennwesnr hsts
       g,ycoi tkrttet
       n ,l r s'a anr
       i  ef  'dgcgdi
       t  aol   eoe,v
       y  nei sl,u; e
-      ,  .sf to l   
+      ,  .sf to l
            e rv d  t
            ; ie    o
-             f, r   
+             f, r
              e  e  m
              .  m  e
                 o  n
@@ -274,27 +274,5 @@ INPUT
                 ,
 EXPECTED
     assert_equal expected.strip, actual
-  end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
   end
 end

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -69,7 +69,7 @@ INPUT
       g
       l
       e
-
+       
       l
       i
       n
@@ -90,13 +90,13 @@ INPUT
       TT
       hh
       ee
-
+        
       ff
       oi
       uf
       rt
       th
-      h
+      h 
        l
       li
       in
@@ -118,14 +118,14 @@ INPUT
       TT
       hh
       ee
-
+        
       fs
       ie
       rc
       so
       tn
        d
-      l
+      l 
       il
       ni
       en
@@ -223,49 +223,49 @@ INPUT
       hnrhr hohnhshh
       o oeopotedi ea
       rfmrmash  cn t
-      .a e ie fthow
+      .a e ie fthow 
        ia fr weh,whh
       Trnco miae  ie
       w ciroitr btcr
       oVivtfshfcuhhe
-       eeih a uote
+       eeih a uote  
       hrnl sdtln  is
       oot ttvh tttfh
       un bhaeepihw a
       saglernianeoyl
       e,ro -trsui ol
-      h uofcu sarhu
+      h uofcu sarhu 
       owddarrdan o m
       lhg to'egccuwi
       deemasdaeehris
       sr als t  ists
       ,ebk 'phool'h,
-        reldi ffd
+        reldi ffd   
       bweso tb  rtpo
       oea ileutterau
       t kcnoorhhnatr
-      hl isvuyee'fi
+      hl isvuyee'fi 
        atv es iisfet
       ayoior trr ino
       l  lfsoh  ecti
       ion   vedpn  l
-      kuehtteieadoe
+      kuehtteieadoe 
       erwaharrar,fas
          nekt te  rh
       ismdsehphnnosa
       ncuse ra-tau l
        et  tormsural
-      dniuthwea'g t
+      dniuthwea'g t 
       iennwesnr hsts
       g,ycoi tkrttet
       n ,l r s'a anr
       i  ef  'dgcgdi
       t  aol   eoe,v
       y  nei sl,u; e
-      ,  .sf to l
+      ,  .sf to l   
            e rv d  t
            ; ie    o
-             f, r
+             f, r   
              e  e  m
              .  m  e
                 o  n

--- a/exercises/triangle/.meta/solutions/triangle.rb
+++ b/exercises/triangle/.meta/solutions/triangle.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Triangle
   attr_reader :sides
 

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -104,26 +104,4 @@ class TriangleTest < Minitest::Test
     triangle = Triangle.new([0.5, 0.4, 0.6])
     assert triangle.scalene?, "Expected 'true', triangle [0.5, 0.4, 0.6] is scalene."
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/trinary/.meta/solutions/trinary.rb
+++ b/exercises/trinary/.meta/solutions/trinary.rb
@@ -15,7 +15,3 @@ class Trinary
     decimal
   end
 end
-
-module BookKeeping
-  VERSION = 1
-end

--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -60,24 +60,4 @@ class TrinaryTest < Minitest::Test
     skip
     assert_equal 0, Trinary.new('4').to_decimal
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module.
-  #  In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.htm
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/twelve-days/.meta/solutions/twelve_days.rb
+++ b/exercises/twelve-days/.meta/solutions/twelve_days.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 2
-end
-
 module TwelveDays
   def self.song
     verses(1, 12)

--- a/exercises/twelve-days/twelve_days_test.rb
+++ b/exercises/twelve-days/twelve_days_test.rb
@@ -15,16 +15,4 @@ class TwelveDaysTest < Minitest::Test
     expected = IO.read(song_file)
     assert_equal expected, TwelveDays.song
   end
-
-  # Problems in exercism evolve over time,
-  # as we find better ways to ask questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of TwelveDays.
-  # If you're curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-  def test_version
-    assert_equal 2, BookKeeping::VERSION
-  end
 end

--- a/exercises/two-bucket/.meta/solutions/two_bucket.rb
+++ b/exercises/two-bucket/.meta/solutions/two_bucket.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 4
-end
-
 class TwoBucket
   attr_reader :goal_bucket, :other_bucket
 

--- a/exercises/two-bucket/two_bucket_test.rb
+++ b/exercises/two-bucket/two_bucket_test.rb
@@ -50,26 +50,4 @@ class TwoBucketTest < Minitest::Test
     assert_equal 'two', two_bucket.goal_bucket
     assert_equal 2, two_bucket.other_bucket
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 4, BookKeeping::VERSION
-  end
 end

--- a/exercises/two-fer/.meta/solutions/two_fer.rb
+++ b/exercises/two-fer/.meta/solutions/two_fer.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class TwoFer
   def self.two_fer(name = 'you')
     "One for #{name}, one for me."

--- a/exercises/two-fer/two_fer_test.rb
+++ b/exercises/two-fer/two_fer_test.rb
@@ -17,26 +17,4 @@ class TwoFerTest < Minitest::Test
     skip
     assert_equal "One for Bob, one for me.", TwoFer.two_fer("Bob")
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/word-count/.meta/solutions/word_count.rb
+++ b/exercises/word-count/.meta/solutions/word_count.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class Phrase
   def initialize(source)
     @source = source

--- a/exercises/word-count/word_count_test.rb
+++ b/exercises/word-count/word_count_test.rb
@@ -72,26 +72,4 @@ class WordCountTest < Minitest::Test
     counts = {"joe"=>1, "can't"=>1, "tell"=>1, "between"=>1, "large"=>2, "and"=>1}
     assert_equal counts, phrase.word_count
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/wordy/.meta/solutions/wordy.rb
+++ b/exercises/wordy/.meta/solutions/wordy.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 1
-end
-
 class WordProblem
   attr_reader :question
   def initialize(question)

--- a/exercises/wordy/wordy_test.rb
+++ b/exercises/wordy/wordy_test.rb
@@ -104,26 +104,4 @@ class WordyTest < Minitest::Test
       WordProblem.new(question).answer
     end
   end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 1, BookKeeping::VERSION
-  end
 end

--- a/exercises/zipper/.meta/solutions/zipper.rb
+++ b/exercises/zipper/.meta/solutions/zipper.rb
@@ -1,7 +1,3 @@
-module BookKeeping
-  VERSION = 71
-end
-
 Node = Struct.new(:value, :left, :right)
 
 Crumb = Struct.new(:direction, :value, :tree)

--- a/exercises/zipper/zipper_test.rb
+++ b/exercises/zipper/zipper_test.rb
@@ -17,7 +17,7 @@ class ZipperTest < Minitest::Test
           nil))
     zipper = Zipper.from_tree(tree)
     value = zipper.to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(2,
           nil,
@@ -80,7 +80,7 @@ class ZipperTest < Minitest::Test
           nil))
     zipper = Zipper.from_tree(tree)
     value = zipper.left.right.to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(2,
           nil,
@@ -143,7 +143,7 @@ class ZipperTest < Minitest::Test
           nil))
     zipper = Zipper.from_tree(tree)
     value = zipper.left.set_value(5).to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(5,
           nil,
@@ -170,7 +170,7 @@ class ZipperTest < Minitest::Test
           nil))
     zipper = Zipper.from_tree(tree)
     value = zipper.left.right.up.set_value(5).to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(5,
           nil,
@@ -200,7 +200,7 @@ class ZipperTest < Minitest::Test
       Node.new(5,
         nil,
         nil)).to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(2,
           Node.new(5,
@@ -229,7 +229,7 @@ class ZipperTest < Minitest::Test
           nil))
     zipper = Zipper.from_tree(tree)
     value = zipper.left.set_right(nil).to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(2,
           nil,
@@ -261,7 +261,7 @@ class ZipperTest < Minitest::Test
         Node.new(8,
           nil,
           nil))).to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(2,
           nil,
@@ -292,7 +292,7 @@ class ZipperTest < Minitest::Test
           nil))
     zipper = Zipper.from_tree(tree)
     value = zipper.left.right.set_value(5).to_tree
-    expected = 
+    expected =
       Node.new(1,
         Node.new(2,
           nil,
@@ -332,27 +332,5 @@ class ZipperTest < Minitest::Test
     expected_zipper = Zipper.from_tree(expected_tree)
     expected = expected_zipper.right
     assert_equal expected, value
-  end
-
-  # Problems in exercism evolve over time, as we find better ways to ask
-  # questions.
-  # The version number refers to the version of the problem you solved,
-  # not your solution.
-  #
-  # Define a constant named VERSION inside of the top level BookKeeping
-  # module, which may be placed near the end of your file.
-  #
-  # In your file, it will look like this:
-  #
-  # module BookKeeping
-  #   VERSION = 1 # Where the version number matches the one in the test.
-  # end
-  #
-  # If you are curious, read more about constants on RubyDoc:
-  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
-
-  def test_bookkeeping
-    skip
-    assert_equal 71, BookKeeping::VERSION
   end
 end


### PR DESCRIPTION
This removes all instances of `BookKeeping::VERSION`, its assertions, and generation in test files.

Closes #836 