### PR TITLE
generator: Report on broken generators

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -9,4 +9,19 @@ paths = Generator::Paths.new(track: EXERCISM_RUBY_ROOT, metadata: METADATA_REPOS
 generators = Generator::CommandLine.new(paths).parse(ARGV)
 exit 1 unless generators
 
-generators.map(&:call)
+broken_generator_slugs = []
+
+generators.each do |generator|
+  begin
+    generator.call
+  rescue
+    raise if generators.size == 1
+    broken_generator_slugs << generator.slug
+  end
+end
+
+unless broken_generator_slugs.empty?
+  puts "\n\nBroken generators: (Run these individually to see the error raised.)\n\n"
+  puts broken_generator_slugs
+end
+

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -16,6 +16,10 @@ module Generator
 
     attr_reader :repository, :exercise
 
+    def slug
+      exercise.slug
+    end
+
     def version
       tests_version.to_i
     end

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -8,6 +8,13 @@ module Generator
       track: 'test/fixtures/ruby'
     )
 
+    def test_slug
+      exercise = Minitest::Mock.new.expect :slug, 'alpha'
+      repository = nil
+      subject = Implementation.new(repository: repository, exercise: exercise)
+      assert_equal 'alpha', subject.slug
+    end
+
     def test_version
       exercise = Minitest::Mock.new.expect :slug, 'alpha'
       repository = Repository.new(paths: FixturePaths, slug: 'alpha')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,4 +29,4 @@ end
 require 'minitest/autorun'
 
 # So we can be sure we have coverage on the whole lib directory:
-Dir.glob('lib/*.rb').each { |file| require file.gsub(%r{(^lib\/|\.rb$)}, '') }
+Dir.glob('lib/**/*.rb').each { |file| require file.gsub(%r{(^lib\/|\.rb$)}, '') }


### PR DESCRIPTION
When running `bin/generate --all` when a generator failed by raising an error it stopped the process. This change rescues the error, remembers the failure and continues on to the next generator.

At the end of the run a list of the broken generators is reported:
```
$ bin/generate --all
Generated affine-cipher tests version 1
...
Generated zipper tests version 71

Broken generators: (Run these individually to see the error raised.)

acronym
all-your-base
...
```

If a single generator is run the error will be raised and reported as normal:
```
$ bin/generate acronym
.../lib/generator/exercise_case.rb:27:in `method_missing': undefined local variable or method `phrase' for #<AcronymCase:0x00000000020edec0> (NameError)
...
```
