### PR TITLE
travis config: Move Rubocop check after test run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 install:
   - bundle install --quiet
 script:
-  - rubocop -fs -D
   - rake test
+  - rubocop -fs -D
   - bin/fetch-configlet
   - bin/configlet lint .


### PR DESCRIPTION
Move Rubocop check after test run so that any failure message is visible
at the end of the log and not buried by all the test output.