### PR TITLE
transpose: Regenerate tests

### DIFF
--- a/exercises/transpose/.meta/generator/transpose_case.rb
+++ b/exercises/transpose/.meta/generator/transpose_case.rb
@@ -3,7 +3,7 @@ require 'generator/exercise_case'
 class TransposeCase < Generator::ExerciseCase
 
   def workload
-    %Q(input = #{indent_heredoc(input, 'INPUT', 6, delimiter_mod)}\n) +
+    %Q(input = #{indent_heredoc(input_lines, 'INPUT', 6, delimiter_mod)}\n) +
       %Q(    actual = Transpose.transpose(input)\n) +
       %Q(    expected = #{indent_heredoc(expected, 'EXPECTED', 6, delimiter_mod)}\n) +
     '    assert_equal expected.strip, actual'

--- a/exercises/transpose/.meta/solutions/transpose.rb
+++ b/exercises/transpose/.meta/solutions/transpose.rb
@@ -1,10 +1,17 @@
 class Transpose
   def self.transpose(input)
     lines = input.split("\n")
-    max_line_length = lines.map(&:length).max
+    longest = lines.map(&:length).max || 0
 
-    lines
-      .map { |line| line.ljust(max_line_length).chars }
-      .transpose.map(&:join).join("\n").strip
+    padding_array = [nil] * longest
+    equal_length_arrays = lines.map { |line| (line.chars + padding_array).take(longest) }
+    # Transpose.
+    transposed = equal_length_arrays.transpose
+    # strip trailing nils (remove right padding)
+    no_trailing_nils = transposed.map { |row| row.reverse.drop_while(&:nil?).reverse }
+    # replace remaining nils with spaces (add left padding)
+    correctly_padded = no_trailing_nils.map { |row| row.map { |c| c.nil? ? ' ' : c } }
+    # turn it back into a string
+    correctly_padded.map(&:join).join("\n")
   end
 end

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'transpose'
 
-# Common test data version: 1.0.0 6dba022
+# Common test data version: 1.1.0 92bc877
 class TransposeTest < Minitest::Test
   def test_empty_string
     # skip
@@ -135,6 +135,37 @@ EXPECTED
     assert_equal expected.strip, actual
   end
 
+  def test_mixed_line_length
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      The longest line.
+      A long line.
+      A longer line.
+      A line.
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      TAAA
+      h   
+      elll
+       ooi
+      lnnn
+      ogge
+      n e.
+      glr
+      ei 
+      snl
+      tei
+       .n
+      l e
+      i .
+      n
+      e
+      .
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
   def test_square
     skip
     input = <<-INPUT.gsub(/^ {6}/, '')
@@ -199,80 +230,4 @@ EXPECTED
     assert_equal expected.strip, actual
   end
 
-  def test_many_lines
-    skip
-    input = <<-INPUT.gsub(/^ {6}/, '')
-      Chor. Two households, both alike in dignity,
-      In fair Verona, where we lay our scene,
-      From ancient grudge break to new mutiny,
-      Where civil blood makes civil hands unclean.
-      From forth the fatal loins of these two foes
-      A pair of star-cross'd lovers take their life;
-      Whose misadventur'd piteous overthrows
-      Doth with their death bury their parents' strife.
-      The fearful passage of their death-mark'd love,
-      And the continuance of their parents' rage,
-      Which, but their children's end, naught could remove,
-      Is now the two hours' traffic of our stage;
-      The which if you with patient ears attend,
-      What here shall miss, our toil shall strive to mend.
-INPUT
-    actual = Transpose.transpose(input)
-    expected = <<-EXPECTED.gsub(/^ {6}/, '')
-      CIFWFAWDTAWITW
-      hnrhr hohnhshh
-      o oeopotedi ea
-      rfmrmash  cn t
-      .a e ie fthow 
-       ia fr weh,whh
-      Trnco miae  ie
-      w ciroitr btcr
-      oVivtfshfcuhhe
-       eeih a uote  
-      hrnl sdtln  is
-      oot ttvh tttfh
-      un bhaeepihw a
-      saglernianeoyl
-      e,ro -trsui ol
-      h uofcu sarhu 
-      owddarrdan o m
-      lhg to'egccuwi
-      deemasdaeehris
-      sr als t  ists
-      ,ebk 'phool'h,
-        reldi ffd   
-      bweso tb  rtpo
-      oea ileutterau
-      t kcnoorhhnatr
-      hl isvuyee'fi 
-       atv es iisfet
-      ayoior trr ino
-      l  lfsoh  ecti
-      ion   vedpn  l
-      kuehtteieadoe 
-      erwaharrar,fas
-         nekt te  rh
-      ismdsehphnnosa
-      ncuse ra-tau l
-       et  tormsural
-      dniuthwea'g t 
-      iennwesnr hsts
-      g,ycoi tkrttet
-      n ,l r s'a anr
-      i  ef  'dgcgdi
-      t  aol   eoe,v
-      y  nei sl,u; e
-      ,  .sf to l   
-           e rv d  t
-           ; ie    o
-             f, r   
-             e  e  m
-             .  m  e
-                o  n
-                v  d
-                e  .
-                ,
-EXPECTED
-    assert_equal expected.strip, actual
-  end
 end


### PR DESCRIPTION
Update `transpose` tests to Common test data version: 1.1.0 92bc877

Updated example solution to pass.

Updated generator to work with new canonical_data format. 
