### PR TITLE
Add Rubocop rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,17 @@ require 'rake/testtask'
 
 require_relative 'lib/tasks/exercise_test_tasks'
 
-task default: 'test'
+task default: [:test, :rubocop]
 
 desc 'Run individual exercises or run all development and exercise tests'
 task :test do
   Rake::Task['test:dev'].invoke
   Rake::Task['test:exercises'].invoke
+end
+
+desc 'Run Rubocop'
+task :rubocop do
+  system('rubocop --display-cop-names')
 end
 
 namespace :test do

--- a/bin/generate
+++ b/bin/generate
@@ -24,4 +24,3 @@ unless broken_generator_slugs.empty?
   puts "\n\nBroken generators: (Run these individually to see the error raised.)\n\n"
   puts broken_generator_slugs
 end
-

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -3,13 +3,11 @@ module Generator
     class Canonical < OpenStruct
       def method_missing(sym, *args, &block)
         # `input` and `expected` are required key names
-        if key = key_variant(:input, sym)
-          return input[key]
-        end
+        input_key = key_variant(:input, sym)
+        return input[input_key] if input_key
 
-        if key = key_variant(:expected, sym)
-          return expected[key]
-        end
+        expected_key = key_variant(:expected, sym)
+        return expected[expected_key] if expected_key
 
         super(sym, *args, &block)
       end
@@ -34,7 +32,7 @@ module Generator
       end
 
       def camel_case(string)
-        string.gsub(/_([a-z])/) { $1.upcase }
+        string.gsub(/_([a-z])/) { Regexp.last_match(1).upcase }
       end
     end
 

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -65,17 +65,17 @@ module Generator
       end
 
       def test_respond_to_via_input
-        subject = Canonical.new( input: { 'somevalue' => true } )
+        subject = Canonical.new(input: { 'somevalue' => true })
         assert subject.respond_to?(:somevalue)
       end
 
       def test_respond_to_via_expected
-        subject = Canonical.new( expected: { 'somevalue' => true } )
+        subject = Canonical.new(expected: { 'somevalue' => true })
         assert subject.respond_to?(:somevalue)
       end
 
       def test_respond_to_via_super
-        subject = Canonical.new( expected: { 'somevalue' => true } )
+        subject = Canonical.new(expected: { 'somevalue' => true })
         assert subject.respond_to?(:object_id)
       end
     end


### PR DESCRIPTION
Adds a Rubocop rake task.
It will run by default after the tests.

Also fix the things that Rubocop complained about.