### PR TITLE
bin/generator: Write slug of last run generator to a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/configlet
 bin/configlet.exe
 Gemfile.lock
 coverage/
+.last_generator_run

--- a/bin/generate
+++ b/bin/generate
@@ -13,6 +13,7 @@ broken_generator_slugs = []
 
 generators.each do |generator|
   begin
+    File.write('.last_generator_run', generator.slug)
     generator.call
   rescue
     raise if generators.size == 1


### PR DESCRIPTION
When running the bin/generator script, the name of the generator will be written to a `.last_generator_run` file.

This is useful for scripting and recovering from generator failures.

Add `.last_generator_run` to `.gitignore` because we don't want to check it in.
