### PR TITLE
Fix broken link to ruby resources in readme.

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -7,7 +7,7 @@
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -46,7 +46,7 @@ end
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -10,7 +10,7 @@ like Portable Network Graphics to its acronym (PNG).
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -72,7 +72,7 @@ harder to guess things based on word boundaries.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -69,18 +69,6 @@ harder to guess things based on word boundaries.
     - `15 * 7 mod 26 = 105 mod 26 = 1`
     - `7` is the MMI of `15 mod 26`
 
-## Advanced
-
-For more fun and learning you can implement this initially with both a full
-encription and decription method utilizing the mathematical functions
-introduced above.
-
-Then as a second implementation, focusing on speed and readability, you
-can simply make an encrypted copy of the alphabet and translate between
-the pair to bypass implementation of the decription function:
-
-- `D(y) = a^-1(u - b) mod m` 
-
 * * * *
 
 For installation and learning resources, refer to the

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -34,7 +34,7 @@ I think you got the idea!
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -32,7 +32,7 @@ score is 257, your program should only report the eggs (1) allergy.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -34,7 +34,7 @@ Write a function to solve alphametics puzzles.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -9,7 +9,7 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -31,7 +31,7 @@ things based on word boundaries.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -323,7 +323,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -56,7 +56,7 @@ And if we then added 1, 5, and 7, it would look like this
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -37,7 +37,7 @@ A binary search is a dichotomic divide and conquer search algorithm.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -33,7 +33,7 @@ So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -18,7 +18,7 @@ Bob's conversational partner is a purist when it comes to written communication 
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -13,6 +13,8 @@ anything.
 
 He answers 'Whatever.' to anything else.
 
+Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
+
 * * * *
 
 For installation and learning resources, refer to the

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -70,7 +70,7 @@ And $51.20 is the price with the biggest discount.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -63,7 +63,7 @@ support two operations:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -1,7 +1,8 @@
 # Bracket Push
 
-Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
-verify that all the pairs are matched and nested correctly.
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
+or any combination thereof, verify that any and all pairs are matched
+and nested correctly.
 
 * * * *
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -7,7 +7,7 @@ and nested correctly.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -19,7 +19,7 @@ that the sum of the coins' value would equal the correct amount of change.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -6,9 +6,9 @@ that the sum of the coins' value would equal the correct amount of change.
 ## For example
 
 - An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
-  and one dime (10) or [0, 1, 1, 0, 0]
+  and one dime (10) or [5, 10]
 - An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
-  and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]
+  and one dime (10) and one quarter (25) or [5, 10, 25]
 
 ## Edge cases
 

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -53,7 +53,7 @@ the buffer is once again full.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -9,7 +9,7 @@ Two clocks that represent the same time should be equal to each other.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -29,7 +29,7 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -19,10 +19,7 @@ The reciprocal of a non-zero complex number is
 Dividing a complex number `a + i * b` by another `c + i * d` gives:
 `(a + i * b) / (c + i * d) = (a * c + b * d)/(c^2 + d^2) + (b * c - a * d)/(c^2 + d^2) * i`.
 
-Exponent of a complex number can be expressed as
-`exp(a + i * b) = exp(a) * exp(i * b)`,
-and the last term is given by Euler's formula `exp(i * b) = cos(b) + i * sin(b)`.
-
+Raising e to a complex exponent can be expressed as `e^(a + i * b) = e^a * e^(i * b)`, the last term of which is given by Euler's formula `e^(i * b) = cos(b) + i * sin(b)`.
 
 Implement the following operations:
  - addition, subtraction, multiplication and division of two complex numbers,

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -31,7 +31,7 @@ Assume the programming language you are using does not have an implementation of
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -33,7 +33,7 @@ won since `O` didn't connect top and bottom.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -75,7 +75,7 @@ ciphertext back in to the original message:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -12,11 +12,15 @@ regarded as forming a rectangle when printed with intervening newlines.
 
 For example, the sentence
 
-> If man was meant to stay on the ground, god would have given us roots.
+```text
+"If man was meant to stay on the ground, god would have given us roots."
+```
 
 is normalized to:
 
-> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+```text
+"ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots"
+```
 
 The plaintext should be organized in to a rectangle.  The size of the
 rectangle (`r x c`) should be decided by the length of the message,
@@ -27,13 +31,13 @@ Our normalized text is 54 characters long, dictating a rectangle with
 `c = 8` and `r = 7`:
 
 ```text
-ifmanwas
-meanttos
-tayonthe
-groundgo
-dwouldha
-vegivenu
-sroots
+"ifmanwas"
+"meanttos"
+"tayonthe"
+"groundgo"
+"dwouldha"
+"vegivenu"
+"sroots  "
 ```
 
 The coded message is obtained by reading down the columns going left to
@@ -42,31 +46,30 @@ right.
 The message above is coded as:
 
 ```text
-imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+"imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau"
 ```
 
-Output the encoded text in chunks.  Phrases that fill perfect rectangles
-`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
-Phrases that do not fill perfect rectangles will have `n` empty spaces.
-Those spaces should be distributed evenly, added to the end of the last
-`n` chunks.
+Output the encoded text in chunks that fill perfect rectangles `(r X c)`,
+with `c` chunks of `r` length, separated by spaces. For phrases that are
+`n` characters short of the perfect rectangle, pad each of the last `n`
+chunks with a single trailing space.
 
 ```text
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
+"imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
 ```
 
 Notice that were we to stack these, we could visually decode the
-cyphertext back in to the original message:
+ciphertext back in to the original message:
 
 ```text
-imtgdvs
-fearwer
-mayoogo
-anouuio
-ntnnlvt
-wttddes
-aohghn
-sseoau
+"imtgdvs"
+"fearwer"
+"mayoogo"
+"anouuio"
+"ntnnlvt"
+"wttddes"
+"aohghn "
+"sseoau "
 ```
 
 * * * *

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -10,7 +10,7 @@ unique elements.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -55,7 +55,7 @@ E·······E
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -15,7 +15,7 @@ natural numbers is 3025 - 385 = 2640.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -4,8 +4,8 @@ Make a chain of dominoes.
 
 Compute a way to order a given set of dominoes in such a way that they form a
 correct domino chain (the dots on one half of a stone match the dots on the
-neighbouring half of an adjacent stone) and that dots on the halfs of the stones
-which don't have a neighbour (the first and last stone) match each other.
+neighbouring half of an adjacent stone) and that dots on the halves of the
+stones which don't have a neighbour (the first and last stone) match each other.
 
 For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -17,7 +17,7 @@ Some test cases may use duplicate stones in a chain solution, assume that multip
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -49,7 +49,7 @@ game while being scored at 4 in the Hawaiian-language version.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -13,7 +13,7 @@ output: [1,2,3,4,5]
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -66,7 +66,7 @@ She's dead, of course!
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -7,7 +7,7 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -37,7 +37,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -29,7 +29,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -39,7 +39,7 @@ exception vs returning a special value) may differ between languages.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -31,9 +31,10 @@ The Hamming distance between these two DNA strands is 7.
 
 # Implementation notes
 
-The Hamming distance is only defined for sequences of equal length. This means
-that based on the definition, each language could deal with getting sequences
-of equal length differently.
+The Hamming distance is only defined for sequences of equal length, so
+an attempt to calculate it between sequences of different lengths should
+not work. The general handling of this situation (e.g., raising an
+exception vs returning a special value) may differ between languages.
 
 * * * *
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -17,7 +17,7 @@ If everything goes well, you will be ready to fetch your first real exercise.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -10,7 +10,7 @@ The program should handle invalid hexadecimal strings.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -108,7 +108,7 @@ that lay in the house that Jack built.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -43,7 +43,7 @@ Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (represen
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -16,7 +16,7 @@ The word *isograms*, however, is not an isogram, because the s repeats.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -62,7 +62,7 @@ While asking for Bob's plants would yield:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -16,7 +16,7 @@ the largest product for a series of 6 digits is 23520.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -29,7 +29,7 @@ phenomenon, go watch [this youtube video][video].
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -30,7 +30,7 @@ If you want to know more about linked lists, check [Wikipedia](https://en.wikipe
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -9,7 +9,7 @@ without using existing functions.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -67,7 +67,7 @@ Sum the digits
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -43,7 +43,7 @@ And its columns:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -29,7 +29,7 @@ descriptor calculate the date of the actual meetup.  For example, if given
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -29,7 +29,7 @@ into this:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -11,7 +11,7 @@ numbers, pretend they don't exist and implement them yourself.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -15,7 +15,7 @@ Here is an analogy:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -81,7 +81,7 @@ Is converted to "123,456,789"
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -49,7 +49,7 @@ So:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -35,7 +35,7 @@ The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -11,7 +11,7 @@ insensitive. Input will not contain non-ASCII symbols.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -17,7 +17,7 @@ the right and left of the current position in the previous row.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -20,7 +20,7 @@ Implement a way to determine whether a given number is **perfect**. Depending on
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -31,7 +31,7 @@ should all produce the output
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -7,10 +7,10 @@ confusing. It obeys a few simple rules (below), but when it's spoken
 quickly it's really difficult for non-children (and non-native speakers)
 to understand.
 
-- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to
-  the end of the word.
-- **Rule 2**: If a word begins with a consonant sound, move it to the
-  end of the word, and then add an "ay" sound to the end of the word.
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to the end of the word. Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").
+- **Rule 2**: If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word. Consonant sounds can be made up of multiple consonants, a.k.a. a consonant cluster (e.g. "chair" -> "airchay").
+- **Rule 3**: If a word starts with a consonant sound followed by "qu", move it to the end of the word, and then add an "ay" sound to the end of the word (e.g. "square" -> "aresquay").
+- **Rule 4**: If a word contains a "y" after a consonant cluster or as the second letter in a two letter word it makes a vowel sound (e.g. "rhythm" -> "ythmrhay", "my" -> "ymay").
 
 There are a few more rules for edge cases, and there are regional
 variants too.

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -20,7 +20,7 @@ See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -37,7 +37,7 @@ distance function.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -8,7 +8,7 @@ overview of poker hands.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -32,7 +32,7 @@ You can check this yourself:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -44,7 +44,7 @@ Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -20,11 +20,11 @@ All subsequent codons after are ignored, like this:
 
 RNA: `"AUGUUUUCUUAAAUG"` =>
 
-Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` =>
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -19,7 +19,7 @@ Note that the list of inputs may vary; your solution should be able to handle li
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -20,7 +20,7 @@ Find the product a * b * c.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -29,7 +29,7 @@ share a diagonal.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -61,7 +61,7 @@ If you now read along the zig-zag shape you can read the original message.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -20,7 +20,7 @@ Convert a number to a string, the contents of which depend on the number's facto
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -43,7 +43,7 @@ To include color from the command line:
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -21,7 +21,7 @@ each nucleotide with its complement:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -27,7 +27,7 @@ Bonus points if this method does not need to do anything for your solution.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -30,7 +30,7 @@ direction it is pointing.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -45,7 +45,7 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -33,7 +33,7 @@ Ciphertext is written out in the same formatting as the input including spaces a
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -26,7 +26,7 @@ be decoded always represent the count for the following character.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -23,6 +23,8 @@ A matrix may have zero or more saddle points.
 Your code should be able to provide the (possibly empty) list of all the
 saddle points for any given matrix.
 
+The matrix can have a different number of rows and columns (Non square).
+
 Note that you may find other definitions of matrix saddle points online,
 but the tests for this exercise follow the above unambiguous definition.
 

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -31,7 +31,7 @@ but the tests for this exercise follow the above unambiguous definition.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -24,7 +24,7 @@ Some good test cases for this program are:
 ### Extension
 
 If you're on a Mac, shell out to Mac OS X's `say` program to talk out
-loud.
+loud. If you're on Linux or Windows, eSpeakNG may be available with the command `espeak`.
 
 ## Step 2
 

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -65,7 +65,7 @@ Use _and_ (correctly) when spelling out the number in English:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -4,13 +4,13 @@ Given a tonic, or starting note, and a set of intervals, generate
 the musical scale starting with the tonic and following the
 specified interval pattern.
 
-Scales in Western music are based on the chromatic (12-note) scale.This
+Scales in Western music are based on the chromatic (12-note) scale. This
 scale can be expressed as the following group of pitches:
 
 A, A#, B, C, C#, D, D#, E, F, F#, G, G#
 
-A given sharp note (indicated by a #), can also be expressed as the flat
-of the note above it (indicated by a b), so the chromatic scale can also be
+A given sharp note (indicated by a #) can also be expressed as the flat
+of the note above it (indicated by a b) so the chromatic scale can also be
 written like this:
 
 A, Bb, B, C, Db, D, Eb, E, F, Gb, G, Ab
@@ -20,9 +20,9 @@ collection. They have seven pitches, and are called diatonic scales.
 The collection of notes in these scales is written with either sharps or
 flats, depending on the tonic. Here is a list of which are which:
 
-No Accidentals:
+No Sharps or Flats:
 C major
-A minor
+a minor
 
 Use Sharps:
 G, D, A, E, B, F# major
@@ -43,17 +43,10 @@ a "whole step" or "major second" (written as an upper-case "M"). The
 diatonic scales are built using only these two intervals between
 adjacent notes.
 
-Non-diatonic scales can contain the same letter twice, and can contain other intervals.
-Sometimes they may be smaller than usual (diminished, written "D"), or larger
-(augmented, written "A").  Intervals larger than an augmented second have other names.
-
-Here is a table of pitches with the names of their interval distance from the tonic (A).
-
-|   A    |    A#   |    B    |    C    |    C#   |    D    |    D#   |    E    |    F    |    F#   |    G    |    G#   |    A   |
-|:------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:------:|
-| Unison | Min 2nd | Maj 2nd | Min 3rd | Maj 3rd | Per 4th | Tritone | Per 5th | Min 6th | Maj 6th | Min 7th | Maj 7th | Octave |
-|        |         | Dim 3rd | Aug 2nd | Dim 4th |         | Aug 4th | Dim 5th | Aug 5th | Dim 7th | Aug 6th | Dim 8ve |        |
-|        |         |         |         |         |         | Dim 5th |         |         |         |         |         |        |
+Non-diatonic scales can contain other intervals.  An "augmented first"
+interval, written "A", has two interceding notes (e.g., from A to C or
+Db to E). There are also smaller and larger intervals, but they will not
+figure into this exercise.
 
 * * * *
 

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -51,7 +51,7 @@ figure into this exercise.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -42,7 +42,7 @@ And to total:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -31,7 +31,7 @@ has caused the array to be reversed.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,18 +1,18 @@
 # Series
 
 Given a string of digits, output all the contiguous substrings of length `n` in
-that string.
+that string in the order that they appear.
 
 For example, the string "49142" has the following 3-digit series:
 
-- 491
-- 914
-- 142
+- "491"
+- "914"
+- "142"
 
 And the following 4-digit series:
 
-- 4914
-- 9142
+- "4914"
+- "9142"
 
 And if you ask for a 6-digit series from a 5-digit string, you deserve
 whatever you get.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -23,7 +23,7 @@ in the input; the digits need not be *numerically consecutive*.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -5,8 +5,8 @@ number.
 
 The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
 prime numbers up to any given limit. It does so by iteratively marking as
-composite (i.e. not prime) the multiples of each prime,
-starting with the multiples of 2.
+composite (i.e. not prime) the multiples of each prime, starting with the
+multiples of 2. It does not use any division or remainder operation.
 
 Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
 
@@ -25,7 +25,9 @@ https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
 
 Notice that this is a very specific algorithm, and the tests don't check
 that you've implemented the algorithm, only that you've come up with the
-correct list of primes.
+correct list of primes. A good first test is to check that you do not use
+division or remainder operations (div, /, mod or % depending on the
+language).
 
 * * * *
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -32,7 +32,7 @@ language).
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -13,8 +13,8 @@ for A, and so with the others."
 
 Ciphers are very straight-forward algorithms that allow us to render
 text less readable while still allowing easy deciphering. They are
-vulnerable to many forms of cryptoanalysis, but we are lucky that
-generally our little sisters are not cryptoanalysts.
+vulnerable to many forms of cryptanalysis, but we are lucky that
+generally our little sisters are not cryptanalysts.
 
 The Caesar Cipher was used for some messages from Julius Caesar that
 were sent afield. Now Caesar knew that the cipher wasn't very good, but

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -84,7 +84,7 @@ on Wikipedia][dh] for one of the first implementations of this scheme.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -24,7 +24,7 @@ implement your own abstract data type.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -20,7 +20,7 @@ youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -36,7 +36,7 @@ basic tools instead.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -11,7 +11,7 @@ The sum of these multiples is 78.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -67,7 +67,7 @@ Means that the Devastating Donkeys and Courageous Californians tied.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -61,7 +61,7 @@ the corresponding output row should contain the spaces in its right-most column(
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -25,7 +25,7 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -24,7 +24,7 @@ conversion, pretend it doesn't exist and implement it yourself.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -31,7 +31,7 @@ On the twelfth day of Christmas my true love gave to me: twelve Drummers Drummin
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -27,7 +27,7 @@ To conclude, the only valid moves are:
 - emptying one bucket and doing nothing to the other
 - filling one bucket and doing nothing to the other
 
-Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by [Lindsay](http://lindsaylevine.com).
+Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.
 
 * * * *
 

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -32,7 +32,7 @@ Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lind
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -37,7 +37,7 @@ To include color from the command line:
 
 ## Source
 
-This is an exercise to introduce users to basic programming constructs, just after Hello World. [https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+[https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -15,7 +15,7 @@ If no name is given, the result should be "One for you, one for me."
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -14,7 +14,7 @@ free: 1
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -54,7 +54,7 @@ If you'd like, handle exponentials.
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -30,7 +30,7 @@ list of child nodes) a zipper might support these operations:
 * * * *
 
 For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ruby).
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
 
 For running the tests provided, you will need the Minitest gem. Open a
 terminal window and run the following command to install minitest:


### PR DESCRIPTION
Updated link to ruby resources in exercism v2 and regenerated documents.

Included hints into affine-cipher to attempt to match previous documentation.

Fixes #824 