### PR TITLE
wordy: Regenerate Tests

### DIFF
--- a/exercises/wordy/.meta/generator/wordy_case.rb
+++ b/exercises/wordy/.meta/generator/wordy_case.rb
@@ -8,10 +8,6 @@ class WordyCase < Generator::ExerciseCase
 
   private
 
-  def error_expected?
-    expected == false
-  end
-
   def assertion
     return error_assertion if error_expected?
     return message_assertion if message

--- a/exercises/wordy/wordy_test.rb
+++ b/exercises/wordy/wordy_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'wordy'
 
-# Common test data version: 1.1.0 df75482
+# Common test data version: 1.2.0 86d0069
 class WordyTest < Minitest::Test
   def test_addition
     # skip


### PR DESCRIPTION
Update `wordy` tests to: `1.2.0 86d0069`

Update generator to use the standard error indicator.