### PR TITLE
largest-series-product: Regenerate Tests

### DIFF
--- a/exercises/largest-series-product/.meta/generator/largest_series_product_case.rb
+++ b/exercises/largest-series-product/.meta/generator/largest_series_product_case.rb
@@ -11,10 +11,6 @@ class LargestSeriesProductCase < Generator::ExerciseCase
 
   private
 
-  def error_expected?
-    expected == -1
-  end
-
   def subject_of_test
     "Series.new('#{digits}').largest_product(#{span})"
   end

--- a/exercises/largest-series-product/largest_series_product_test.rb
+++ b/exercises/largest-series-product/largest_series_product_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'largest_series_product'
 
-# Common test data version: 1.1.0 92b86a8
+# Common test data version: 1.2.0 85da7a5
 class LargestSeriesProductTest < Minitest::Test
   def test_finds_the_largest_product_if_span_equals_length
     # skip


### PR DESCRIPTION
Update `largest-series-product` tests to: `1.2.0 85da7a5`

Update generator to use the standard error indicator.