### PR TITLE
ocr-numbers: Regenerate Tests

### DIFF
--- a/exercises/ocr-numbers/.meta/generator/ocr_numbers_case.rb
+++ b/exercises/ocr-numbers/.meta/generator/ocr_numbers_case.rb
@@ -4,7 +4,7 @@ class OcrNumbersCase < Generator::ExerciseCase
   def workload
     [
       formatted_rows,
-      if expected == -1
+      if error_expected?
         assert_raises(ArgumentError, subject_of_test)
       else
         assert_equal(expected, subject_of_test)

--- a/exercises/ocr-numbers/ocr_numbers_test.rb
+++ b/exercises/ocr-numbers/ocr_numbers_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'ocr_numbers'
 
-# Common test data version: 1.1.0 fd5431c
+# Common test data version: 1.2.0 965ecad
 class OcrNumbersTest < Minitest::Test
   def test_recognizes_0
     # skip


### PR DESCRIPTION
Update `ocr-numbers` tests to: `1.2.0 965ecad`

Update generator to use the standard error indicator.