### PR TITLE
queen-attack: Regenerate Tests

### DIFF
--- a/exercises/queen-attack/.meta/generator/queen_attack_case.rb
+++ b/exercises/queen-attack/.meta/generator/queen_attack_case.rb
@@ -30,8 +30,4 @@ class QueenAttackCase < Generator::ExerciseCase
   def new_queen
     "Queens.new(white: #{parse_position queen})"
   end
-
-  def error_expected?
-    expected == -1
-  end
 end

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'queen_attack'
 
-# Common test data version: 2.1.0 7a8bcba
+# Common test data version: 2.2.0 aaadbac
 class QueenAttackTest < Minitest::Test
   def test_queen_with_a_valid_position
     # skip


### PR DESCRIPTION
Update `queen-attack` tests to: `2.2.0 aaadbac`

Update generator to use the standard error indicator.