### PR TITLE
say: Regenerate Tests

### DIFF
--- a/exercises/say/.meta/generator/say_case.rb
+++ b/exercises/say/.meta/generator/say_case.rb
@@ -10,11 +10,6 @@ class SayCase < Generator::ExerciseCase
 
   private
 
-  # non-standard so override
-  def error_expected?
-    expected == -1
-  end
-
   def assertion
     if error_expected?
       assert_raises(ArgumentError, subject_of_test)

--- a/exercises/say/say_test.rb
+++ b/exercises/say/say_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'say'
 
-# Common test data version: 1.1.0 c1467a0
+# Common test data version: 1.2.0 a0cee46
 class SayTest < Minitest::Test
   def test_zero
     # skip


### PR DESCRIPTION
Update `say` tests to: `1.2.0 a0cee46`

Update generator to use the standard error indicator.