### PR TITLE
phone-number: Regenerate Tests

### DIFF
--- a/exercises/phone-number/.meta/generator/phone_number_case.rb
+++ b/exercises/phone-number/.meta/generator/phone_number_case.rb
@@ -2,6 +2,16 @@ require 'generator/exercise_case'
 
 class PhoneNumberCase < Generator::ExerciseCase
   def workload
-     assert_equal(expected, "PhoneNumber.clean(#{phrase.inspect})")
+    if error_expected?
+      assert_raises(ArgumentError, subject_of_test)
+    else
+      assert_equal(expected, subject_of_test)
+    end
+  end
+
+  private
+
+  def subject_of_test
+    "PhoneNumber.clean(#{phrase.inspect})"
   end
 end

--- a/exercises/phone-number/.meta/generator/phone_number_case.rb
+++ b/exercises/phone-number/.meta/generator/phone_number_case.rb
@@ -3,7 +3,7 @@ require 'generator/exercise_case'
 class PhoneNumberCase < Generator::ExerciseCase
   def workload
     if error_expected?
-      assert_raises(ArgumentError, subject_of_test)
+      assert_equal(nil, subject_of_test)
     else
       assert_equal(expected, subject_of_test)
     end

--- a/exercises/phone-number/.meta/solutions/phone_number.rb
+++ b/exercises/phone-number/.meta/solutions/phone_number.rb
@@ -11,7 +11,8 @@ module PhoneNumber
   def self.clean(number)
     sanitized = digits_only(number)
     sections = nanp_parse(sanitized)
-    format '%<area_code>s%<exchange_code>s%<subscriber>s', sections if sections
+    raise ArgumentError unless sections
+    format '%<area_code>s%<exchange_code>s%<subscriber>s', sections
   end
 
   def self.digits_only(number)

--- a/exercises/phone-number/.meta/solutions/phone_number.rb
+++ b/exercises/phone-number/.meta/solutions/phone_number.rb
@@ -11,8 +11,7 @@ module PhoneNumber
   def self.clean(number)
     sanitized = digits_only(number)
     sections = nanp_parse(sanitized)
-    raise ArgumentError unless sections
-    format '%<area_code>s%<exchange_code>s%<subscriber>s', sections
+    format '%<area_code>s%<exchange_code>s%<subscriber>s', sections if sections
   end
 
   def self.digits_only(number)

--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'phone_number'
 
-# Common test data version: 1.5.0 e8a5119
+# Common test data version: 1.6.0 a317aa4
 class PhoneNumberTest < Minitest::Test
   def test_cleans_the_number
     # skip
@@ -20,12 +20,16 @@ class PhoneNumberTest < Minitest::Test
 
   def test_invalid_when_9_digits
     skip
-    assert_nil PhoneNumber.clean("123456789")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("123456789")
+    end
   end
 
   def test_invalid_when_11_digits_does_not_start_with_a_1
     skip
-    assert_nil PhoneNumber.clean("22234567890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("22234567890")
+    end
   end
 
   def test_valid_when_11_digits_and_starting_with_1
@@ -40,56 +44,78 @@ class PhoneNumberTest < Minitest::Test
 
   def test_invalid_when_more_than_11_digits
     skip
-    assert_nil PhoneNumber.clean("321234567890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("321234567890")
+    end
   end
 
   def test_invalid_with_letters
     skip
-    assert_nil PhoneNumber.clean("123-abc-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("123-abc-7890")
+    end
   end
 
   def test_invalid_with_punctuations
     skip
-    assert_nil PhoneNumber.clean("123-@:!-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("123-@:!-7890")
+    end
   end
 
   def test_invalid_if_area_code_starts_with_0
     skip
-    assert_nil PhoneNumber.clean("(023) 456-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("(023) 456-7890")
+    end
   end
 
   def test_invalid_if_area_code_starts_with_1
     skip
-    assert_nil PhoneNumber.clean("(123) 456-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("(123) 456-7890")
+    end
   end
 
   def test_invalid_if_exchange_code_starts_with_0
     skip
-    assert_nil PhoneNumber.clean("(223) 056-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("(223) 056-7890")
+    end
   end
 
   def test_invalid_if_exchange_code_starts_with_1
     skip
-    assert_nil PhoneNumber.clean("(223) 156-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("(223) 156-7890")
+    end
   end
 
   def test_invalid_if_area_code_starts_with_0_on_valid_11_digit_number
     skip
-    assert_nil PhoneNumber.clean("1 (023) 456-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("1 (023) 456-7890")
+    end
   end
 
   def test_invalid_if_area_code_starts_with_1_on_valid_11_digit_number
     skip
-    assert_nil PhoneNumber.clean("1 (123) 456-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("1 (123) 456-7890")
+    end
   end
 
   def test_invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number
     skip
-    assert_nil PhoneNumber.clean("1 (223) 056-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("1 (223) 056-7890")
+    end
   end
 
   def test_invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number
     skip
-    assert_nil PhoneNumber.clean("1 (223) 156-7890")
+    assert_raises(ArgumentError) do
+      PhoneNumber.clean("1 (223) 156-7890")
+    end
   end
 end

--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -20,16 +20,12 @@ class PhoneNumberTest < Minitest::Test
 
   def test_invalid_when_9_digits
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("123456789")
-    end
+    assert_nil PhoneNumber.clean("123456789")
   end
 
   def test_invalid_when_11_digits_does_not_start_with_a_1
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("22234567890")
-    end
+    assert_nil PhoneNumber.clean("22234567890")
   end
 
   def test_valid_when_11_digits_and_starting_with_1
@@ -44,78 +40,56 @@ class PhoneNumberTest < Minitest::Test
 
   def test_invalid_when_more_than_11_digits
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("321234567890")
-    end
+    assert_nil PhoneNumber.clean("321234567890")
   end
 
   def test_invalid_with_letters
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("123-abc-7890")
-    end
+    assert_nil PhoneNumber.clean("123-abc-7890")
   end
 
   def test_invalid_with_punctuations
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("123-@:!-7890")
-    end
+    assert_nil PhoneNumber.clean("123-@:!-7890")
   end
 
   def test_invalid_if_area_code_starts_with_0
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("(023) 456-7890")
-    end
+    assert_nil PhoneNumber.clean("(023) 456-7890")
   end
 
   def test_invalid_if_area_code_starts_with_1
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("(123) 456-7890")
-    end
+    assert_nil PhoneNumber.clean("(123) 456-7890")
   end
 
   def test_invalid_if_exchange_code_starts_with_0
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("(223) 056-7890")
-    end
+    assert_nil PhoneNumber.clean("(223) 056-7890")
   end
 
   def test_invalid_if_exchange_code_starts_with_1
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("(223) 156-7890")
-    end
+    assert_nil PhoneNumber.clean("(223) 156-7890")
   end
 
   def test_invalid_if_area_code_starts_with_0_on_valid_11_digit_number
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("1 (023) 456-7890")
-    end
+    assert_nil PhoneNumber.clean("1 (023) 456-7890")
   end
 
   def test_invalid_if_area_code_starts_with_1_on_valid_11_digit_number
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("1 (123) 456-7890")
-    end
+    assert_nil PhoneNumber.clean("1 (123) 456-7890")
   end
 
   def test_invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("1 (223) 056-7890")
-    end
+    assert_nil PhoneNumber.clean("1 (223) 056-7890")
   end
 
   def test_invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number
     skip
-    assert_raises(ArgumentError) do
-      PhoneNumber.clean("1 (223) 156-7890")
-    end
+    assert_nil PhoneNumber.clean("1 (223) 156-7890")
   end
 end


### PR DESCRIPTION
Update `phone-number` tests to: `1.6.0 a317aa4`

Update generator to use the standard error indicator.
Update solution to pass updated tests.