### PR TITLE
change: Regenerate Tests

### DIFF
--- a/exercises/change/.meta/generator/change_case.rb
+++ b/exercises/change/.meta/generator/change_case.rb
@@ -3,13 +3,22 @@ require 'generator/exercise_case'
 class ChangeCase < Generator::ExerciseCase
   def workload
     if error_expected?
-      assert_raises(ArgumentError, subject_of_test)
+      handle_errors
     else
       assert_equal(expected, subject_of_test)
     end
   end
 
   private
+
+  def handle_errors
+    case test_name
+    when 'test_cannot_find_negative_change_values'
+      assert_raises('Change::NegativeTargetError', subject_of_test)
+    else
+      assert_raises('Change::ImpossibleCombinationError', subject_of_test)
+    end
+  end
 
   def subject_of_test
     "Change.generate(#{coins}, #{target})"

--- a/exercises/change/.meta/generator/change_case.rb
+++ b/exercises/change/.meta/generator/change_case.rb
@@ -2,6 +2,16 @@ require 'generator/exercise_case'
 
 class ChangeCase < Generator::ExerciseCase
   def workload
-    assert_equal(expected, "Change.generate(#{coins}, #{target})")
+    if error_expected?
+      assert_raises(ArgumentError, subject_of_test)
+    else
+      assert_equal(expected, subject_of_test)
+    end
+  end
+
+  private
+
+  def subject_of_test
+    "Change.generate(#{coins}, #{target})"
   end
 end

--- a/exercises/change/.meta/solutions/change.rb
+++ b/exercises/change/.meta/solutions/change.rb
@@ -1,6 +1,9 @@
 class Change
   attr_reader :coins, :target
 
+  class NegativeTargetError < ArgumentError; end
+  class ImpossibleCombinationError < StandardError; end
+
   def initialize(coins, target)
     @coins  = coins.sort.reverse
     @target = target
@@ -8,10 +11,11 @@ class Change
   end
 
   def generate
+    raise NegativeTargetError if target < 0
     return [] if target.zero?
 
     calculate_change(coins, [], target)
-    raise ArgumentError if total_change.none?
+    raise ImpossibleCombinationError if total_change.none?
 
     total_change.sort
   end

--- a/exercises/change/.meta/solutions/change.rb
+++ b/exercises/change/.meta/solutions/change.rb
@@ -11,8 +11,9 @@ class Change
     return [] if target.zero?
 
     calculate_change(coins, [], target)
+    raise ArgumentError if total_change.none?
 
-    total_change.any? ? total_change.sort : -1
+    total_change.sort
   end
 
   def self.generate(coins, target)

--- a/exercises/change/change_test.rb
+++ b/exercises/change/change_test.rb
@@ -45,21 +45,21 @@ class ChangeTest < Minitest::Test
 
   def test_error_testing_for_change_smaller_than_the_smallest_of_coins
     skip
-    assert_raises(ArgumentError) do
+    assert_raises(Change::ImpossibleCombinationError) do
       Change.generate([5, 10], 3)
     end
   end
 
   def test_error_if_no_combination_can_add_up_to_target
     skip
-    assert_raises(ArgumentError) do
+    assert_raises(Change::ImpossibleCombinationError) do
       Change.generate([5, 10], 94)
     end
   end
 
   def test_cannot_find_negative_change_values
     skip
-    assert_raises(ArgumentError) do
+    assert_raises(Change::NegativeTargetError) do
       Change.generate([1, 2, 5], -5)
     end
   end

--- a/exercises/change/change_test.rb
+++ b/exercises/change/change_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'change'
 
-# Common test data version: 1.2.0 044d09a
+# Common test data version: 1.3.0 258c807
 class ChangeTest < Minitest::Test
   def test_single_coin_change
     # skip
@@ -45,16 +45,22 @@ class ChangeTest < Minitest::Test
 
   def test_error_testing_for_change_smaller_than_the_smallest_of_coins
     skip
-    assert_equal -1, Change.generate([5, 10], 3)
+    assert_raises(ArgumentError) do
+      Change.generate([5, 10], 3)
+    end
   end
 
   def test_error_if_no_combination_can_add_up_to_target
     skip
-    assert_equal -1, Change.generate([5, 10], 94)
+    assert_raises(ArgumentError) do
+      Change.generate([5, 10], 94)
+    end
   end
 
   def test_cannot_find_negative_change_values
     skip
-    assert_equal -1, Change.generate([1, 2, 5], -5)
+    assert_raises(ArgumentError) do
+      Change.generate([1, 2, 5], -5)
+    end
   end
 end


### PR DESCRIPTION
Update `change` tests to: `1.3.0 258c807`

Update generator to use the standard error indicator.
Update solution to pass updated tests.