### PR TITLE
connect: Strip leading whitespaces in test data.

### DIFF
--- a/exercises/connect/.meta/generator/connect_case.rb
+++ b/exercises/connect/.meta/generator/connect_case.rb
@@ -6,7 +6,7 @@ class ConnectCase < Generator::ExerciseCase
     [
       'board = [',
       indent_by(2,board.map(&method(:single_quote)).join(",\n")),
-      ']',
+      "].map {|row| row.gsub(/^ */, '')}",
       'game = Board.new(board)',
       "assert_equal #{single_quote(expected)}, game.winner, #{single_quote(description)}"
     ].map {|line| line + "\n" }.join

--- a/exercises/connect/connect_test.rb
+++ b/exercises/connect/connect_test.rb
@@ -11,7 +11,7 @@ class ConnectTest < Minitest::Test
       '  . . . . .',
       '   . . . . .',
       '    . . . . .'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal '', game.winner, 'an empty board has no winner'
   end
@@ -20,7 +20,7 @@ class ConnectTest < Minitest::Test
     skip
     board = [
       'X'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal 'X', game.winner, 'X can win on a 1x1 board'
   end
@@ -29,7 +29,7 @@ class ConnectTest < Minitest::Test
     skip
     board = [
       'O'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal 'O', game.winner, 'O can win on a 1x1 board'
   end
@@ -41,7 +41,7 @@ class ConnectTest < Minitest::Test
       ' X . . X',
       '  X . . X',
       '   X O O O'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal '', game.winner, 'only edges does not make a winner'
   end
@@ -54,7 +54,7 @@ class ConnectTest < Minitest::Test
       '  O X O .',
       '   . O X .',
       '    X X O O'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal '', game.winner, 'illegal diagonal does not make a winner'
   end
@@ -67,7 +67,7 @@ class ConnectTest < Minitest::Test
       '  O . X O',
       '   . O . X',
       '    . . O .'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal '', game.winner, 'nobody wins crossing adjacent angles'
   end
@@ -80,7 +80,7 @@ class ConnectTest < Minitest::Test
       '  O X O .',
       '   X X O X',
       '    . O X .'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal 'X', game.winner, 'X wins crossing from left to right'
   end
@@ -93,7 +93,7 @@ class ConnectTest < Minitest::Test
       '  O O O .',
       '   X X O X',
       '    . O X .'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal 'O', game.winner, 'O wins crossing from top to bottom'
   end
@@ -106,7 +106,7 @@ class ConnectTest < Minitest::Test
       '  . X . X .',
       '   . X X . .',
       '    O O O O O'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal 'X', game.winner, 'X wins using a convoluted path'
   end
@@ -123,7 +123,7 @@ class ConnectTest < Minitest::Test
       '      O X X X X X O X O',
       '       O O O O O O O X O',
       '        X X X X X X X X O'
-    ]
+    ].map {|row| row.gsub(/^ */, '')}
     game = Board.new(board)
     assert_equal 'X', game.winner, 'X wins using a spiral path'
   end


### PR DESCRIPTION
README and test show test data as such for readability, test data should
should be passed in like the README indicates, without the spaces added
for readability.

Fixes #810 outstanding issue by striping out leading spaces in constructed board array.