### PR TITLE
Ruby/Acronym : promote to core exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -424,9 +424,9 @@
     {
       "slug": "acronym",
       "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
-      "core": false,
+      "core": true,
       "unlocked_by": "two-fer",
-      "difficulty": 2,
+      "difficulty": 1,
       "topics": [
         "regular_expressions",
         "strings",

--- a/config.json
+++ b/config.json
@@ -425,7 +425,7 @@
       "slug": "acronym",
       "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
       "core": true,
-      "unlocked_by": "two-fer",
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "regular_expressions",

--- a/config.json
+++ b/config.json
@@ -87,7 +87,7 @@
       "slug": "pangram",
       "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
       "core": false,
-      "unlocked_by": "isogram",
+      "unlocked_by": "acronym",
       "difficulty": 2,
       "topics": [
         "loops",
@@ -343,8 +343,8 @@
       "slug": "anagram",
       "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
       "core": false,
-      "unlocked_by": "isogram",
-      "difficulty": 3,
+      "unlocked_by": "acronym",
+      "difficulty": 5,
       "topics": [
         "filtering",
         "parsing",


### PR DESCRIPTION
This is one step in a process where I'm working on analyzing the exercises, in order to provide the best experience for both students and mentors. In the current order of the exercises, there's a gap between the very simple TwoFer exercise, and the next exercise Hamming, which is not so simple at all. So, I'm looking for exercises that bridge that gap, and also reordering the existing exercises. 

One question in the re-ordering is if adding extra core exercises would affect the queue and mentoring happiness. We're doing an experiment with another easy-to-mentor, early core exercise.

Acronym is our first choice, because:
- A _lot_ of the first submissions are very similar
- One snippet / precooked comment can cover 80% of new submissions, so it's supposed to be easy/fast to mentor
- It's a real step up from TwoFer, but not a huge jump in required Ruby skills.
- As a bonus: its Minimal Solution uses a method (`String#scan`) that's a real asset to be used in following exercises.

Updating Mentor Notes right now. 