### PR TITLE
Make Acronym unlock WordCount

### DIFF
--- a/config.json
+++ b/config.json
@@ -161,7 +161,7 @@
       "slug": "word-count",
       "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
       "core": false,
-      "unlocked_by": "two-fer",
+      "unlocked_by": "acronym",
       "difficulty": 3,
       "topics": [
         "sorting",


### PR DESCRIPTION
... to check if Acronym's introduction to String#scan will change how many students will use `scan` in their first iteration in Word Count, and if that makes mentoring Word Count more interesting. 
  
Side effect: we're short one exercise being unlocked by TwoFer now that we take Word Count out.