### PR TITLE
Accumulate: Fix additional enum test in readme

### DIFF
--- a/exercises/accumulate/.meta/hints.md
+++ b/exercises/accumulate/.meta/hints.md
@@ -8,7 +8,7 @@ Here is an additional test you could add:
 def test_accumulate_when_block_is_deferred
   skip
   accumulate_enumerator = [1, 2, 3].accumulate
-  accumulated_result = accumulate_enumerator.each do |number|
+  accumulated_result = accumulate_enumerator.map do |number|
     number * number
   end
   assert_equal [1, 4, 9], accumulated_result

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -35,7 +35,7 @@ Here is an additional test you could add:
 def test_accumulate_when_block_is_deferred
   skip
   accumulate_enumerator = [1, 2, 3].accumulate
-  accumulated_result = accumulate_enumerator.each do |number|
+  accumulated_result = accumulate_enumerator.map do |number|
     number * number
   end
   assert_equal [1, 4, 9], accumulated_result


### PR DESCRIPTION
The ["Advanced" section of the accumulate README](https://github.com/exercism/ruby/blob/5f9efd80026a70bb881657c3f1d8281a19158db4/exercises/accumulate/README.md#advanced) suggests to return enumerator if no block was given. It provides an optional test for that.

However the test seems broken, since it expects `number * number` calculation being returned by `each`.
It should rather use `map` to return the result:

Reference: #796 #395