### PR TITLE
rail-fence-cipher: Remove Rubocop references

### DIFF
--- a/exercises/rail-fence-cipher/.meta/solutions/rail_fence_cipher.rb
+++ b/exercises/rail-fence-cipher/.meta/solutions/rail_fence_cipher.rb
@@ -1,4 +1,3 @@
-# rubocop:enable all
 class RailFenceCipher
   def self.encode(message, rails)
     return message if message.empty? || rails == 1

--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'rail_fence_cipher'
 
-# rubocop:enable all
 class RailFenceCipherTest < Minitest::Test
   def test_encode_with_empty_string
     assert_equal '', RailFenceCipher.encode('', 4)


### PR DESCRIPTION
These Rubocop meta-comments are not required.