### PR TITLE
grains: Fix generator and regenerate tests

### DIFF
--- a/exercises/grains/.meta/generator/grains_case.rb
+++ b/exercises/grains/.meta/generator/grains_case.rb
@@ -7,11 +7,6 @@ class GrainsCase < Generator::ExerciseCase
 
   private
 
-  # non-standard so override
-  def error_expected?
-    expected == -1
-  end
-
   def square_workload
     subject_of_test = "Grains.square(#{square})"
     if error_expected?

--- a/exercises/grains/grains_test.rb
+++ b/exercises/grains/grains_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'grains'
 
-# Common test data version: 1.1.0 f079c2d
+# Common test data version: 1.2.0 2ec42ab
 class GrainsTest < Minitest::Test
   def test_1
     # skip


### PR DESCRIPTION
The grains canonical data changed, so update the generator to match.
There is no real change to the test file other than the version bump.