### PR TITLE
Replacing refuse to assert on Isogram exercise test

### DIFF
--- a/exercises/isogram/isogram_test.rb
+++ b/exercises/isogram/isogram_test.rb
@@ -18,13 +18,13 @@ class IsogramTest < Minitest::Test
   def test_word_with_one_duplicated_character
     skip
     input = "eleven"
-    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+    assert Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
 
   def test_word_with_one_duplicated_character_from_the_end_of_the_alphabet
     skip
     input = "zzyzx"
-    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+    assert Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
 
   def test_longest_reported_english_isogram
@@ -36,13 +36,13 @@ class IsogramTest < Minitest::Test
   def test_word_with_duplicated_character_in_mixed_case
     skip
     input = "Alphabet"
-    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+    assert Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
 
   def test_word_with_duplicated_character_in_mixed_case_lowercase_first
     skip
     input = "alphAbet"
-    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+    assert Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
 
   def test_hypothetical_isogrammic_word_with_hyphen
@@ -66,12 +66,12 @@ class IsogramTest < Minitest::Test
   def test_duplicated_character_in_the_middle
     skip
     input = "accentor"
-    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+    assert Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
 
   def test_same_first_and_last_characters
     skip
     input = "angola"
-    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+    assert Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
   end
 end


### PR DESCRIPTION
Hi all, this is my first PR here so... be patient

I started at exercism today and I'm trying to do all ruby exercises to after this try became a mentor and help.

## Overview

When I was at isogram exercise I got stuck because my tests didn't pass and I found this `refute` at the test, and my question is: should be `refute` there?

https://github.com/exercism/ruby/blob/4aab415d1f12a6b1ef23d75de14151e3a2a4ee9e/exercises/isogram/isogram_test.rb#L24-L28

 I think the correct is `assert`, for example, with the given example, `zzyzx` the correct output should be `"Expected false, 'zzyzx' is not an isogram"`, but with the current test, It will not pass... Am I wrong? 



