### PR TITLE
refactor: pull romans up into constant

### DIFF
--- a/exercises/roman-numerals/.meta/solutions/roman_numerals.rb
+++ b/exercises/roman-numerals/.meta/solutions/roman_numerals.rb
@@ -1,18 +1,6 @@
 class Integer
-  def to_roman
-    i = self
-    s = ''
-    roman_mappings.each do |arabic, roman|
-      while i >= arabic
-        s << roman
-        i -= arabic
-      end
-    end
-    s
-  end
-
-  def roman_mappings
-    {
+  ROMAN_MAPPINGS = 
+   {
       1000 => 'M',
       900 => 'CM',
       500 => 'D',
@@ -27,5 +15,16 @@ class Integer
       4 => 'IV',
       1 => 'I'
     }
+
+  def to_roman
+    i = self
+    s = ''
+    ROMAN_MAPPINGS.each do |arabic, roman|
+      while i >= arabic
+        s << roman
+        i -= arabic
+      end
+    end
+    s
   end
 end


### PR DESCRIPTION
Small refactor to pull the roman numerals into a constant since they will never change and don't need to live inside a method. If this were a running program it would also save a bit of memory since we wouldn't be instantiating a new hash every time the `ROMAN_MAPPINGS` are called