### PR TITLE
ocr-numbers: Regenerate README.md with new hints

### DIFF
--- a/exercises/ocr-numbers/.meta/hints.md
+++ b/exercises/ocr-numbers/.meta/hints.md
@@ -1,4 +1,4 @@
-Some editors trim whitespace. If you rely on trailing whitespace in a multiline string, 
-instead use a format that doesn't rely on trailing whitespace, or adjust the settings in your editor. 
+Some editors trim whitespace. If you rely on trailing whitespace in a multiline string,
+instead use a format that doesn't rely on trailing whitespace, or adjust the settings in your editor.
 
 [A multiline string cheatsheet for ruby](https://commandercoriander.net/blog/2014/11/09/a-multiline-string-cheatsheet-for-ruby/)

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -78,6 +78,12 @@ Update your program to handle multiple numbers, one per line. When converting se
 
 Is converted to "123,456,789"
 
+Some editors trim whitespace. If you rely on trailing whitespace in a multiline string,
+instead use a format that doesn't rely on trailing whitespace, or adjust the settings in your editor.
+
+[A multiline string cheatsheet for ruby](https://commandercoriander.net/blog/2014/11/09/a-multiline-string-cheatsheet-for-ruby/)
+
+
 * * * *
 
 For installation and learning resources, refer to the


### PR DESCRIPTION
Regenerates the Readme file to include the new hints introduced on #901. Cleaned up some whitespace and moved the file to the correct directory first.

Resolves #913.