### PR TITLE
series: Separate hints.md in two paragraphs

### DIFF
--- a/exercises/series/.meta/hints.md
+++ b/exercises/series/.meta/hints.md
@@ -1,2 +1,3 @@
 In this exercise you're practicing iterating over an array, meaning: executing an operation on each element of an array. Ruby has many useful built-in methods for iterations. Take a look at [this article](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/).
+
 Most of the methods listed in the article are not methods specifically for Array, but come from [Enumerable](https://ruby-doc.org/core/Enumerable.html). The article doesn't list iterating over _consecutive elements_. The first challenge is to find a method that does.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -21,6 +21,7 @@ Note that these series are only required to occupy *adjacent positions*
 in the input; the digits need not be *numerically consecutive*.
 
 In this exercise you're practicing iterating over an array, meaning: executing an operation on each element of an array. Ruby has many useful built-in methods for iterations. Take a look at [this article](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/).
+
 Most of the methods listed in the article are not methods specifically for Array, but come from [Enumerable](https://ruby-doc.org/core/Enumerable.html). The article doesn't list iterating over _consecutive elements_. The first challenge is to find a method that does.
 
 


### PR DESCRIPTION
This separates the paragraph in Series' hints.md in two. Please see https://github.com/exercism/ruby/pull/916#issuecomment-456002645 for context.