### PR TITLE
Use squiqqly heredoc in tests

### DIFF
--- a/exercises/beer-song/.meta/generator/beer_song_case.rb
+++ b/exercises/beer-song/.meta/generator/beer_song_case.rb
@@ -3,7 +3,7 @@ require 'generator/exercise_case'
 class BeerSongCase < Generator::ExerciseCase
   def workload
     [
-      "expected = #{indent_heredoc(expected, 'TEXT', 0, ".gsub(/^ */, '')" )}\n",
+      "expected = #{indent_heredoc(expected, 'TEXT' )}\n",
       "assert_equal expected, BeerSong.recite(#{start_bottles}, #{take_down})\n"
     ].join
   end

--- a/exercises/beer-song/beer_song_test.rb
+++ b/exercises/beer-song/beer_song_test.rb
@@ -5,7 +5,7 @@ require_relative 'beer_song'
 class BeerSongTest < Minitest::Test
   def test_first_generic_verse
     # skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     99 bottles of beer on the wall, 99 bottles of beer.
     Take one down and pass it around, 98 bottles of beer on the wall.
     TEXT
@@ -14,7 +14,7 @@ class BeerSongTest < Minitest::Test
 
   def test_last_generic_verse
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     3 bottles of beer on the wall, 3 bottles of beer.
     Take one down and pass it around, 2 bottles of beer on the wall.
     TEXT
@@ -23,7 +23,7 @@ class BeerSongTest < Minitest::Test
 
   def test_verse_with_2_bottles
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     2 bottles of beer on the wall, 2 bottles of beer.
     Take one down and pass it around, 1 bottle of beer on the wall.
     TEXT
@@ -32,7 +32,7 @@ class BeerSongTest < Minitest::Test
 
   def test_verse_with_1_bottle
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     1 bottle of beer on the wall, 1 bottle of beer.
     Take it down and pass it around, no more bottles of beer on the wall.
     TEXT
@@ -41,7 +41,7 @@ class BeerSongTest < Minitest::Test
 
   def test_verse_with_0_bottles
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     No more bottles of beer on the wall, no more bottles of beer.
     Go to the store and buy some more, 99 bottles of beer on the wall.
     TEXT
@@ -50,7 +50,7 @@ class BeerSongTest < Minitest::Test
 
   def test_first_two_verses
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     99 bottles of beer on the wall, 99 bottles of beer.
     Take one down and pass it around, 98 bottles of beer on the wall.
 
@@ -62,7 +62,7 @@ class BeerSongTest < Minitest::Test
 
   def test_last_three_verses
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     2 bottles of beer on the wall, 2 bottles of beer.
     Take one down and pass it around, 1 bottle of beer on the wall.
 
@@ -77,7 +77,7 @@ class BeerSongTest < Minitest::Test
 
   def test_all_verses
     skip
-    expected = <<-TEXT.gsub(/^ */, '')
+    expected = <<~TEXT
     99 bottles of beer on the wall, 99 bottles of beer.
     Take one down and pass it around, 98 bottles of beer on the wall.
 

--- a/exercises/tournament/.meta/generator/tournament_case.rb
+++ b/exercises/tournament/.meta/generator/tournament_case.rb
@@ -3,15 +3,9 @@ require 'generator/exercise_case'
 class TournamentCase < Generator::ExerciseCase
   def workload
     [
-      "input = #{indent_heredoc(rows, 'INPUT', 0, delimiter_mod)}\n\n",
-      "expected = #{indent_heredoc(expected, 'TALLY', 0, delimiter_mod)}\n\n",
+      "input = #{indent_heredoc(rows, 'INPUT')}\n\n",
+      "expected = #{indent_heredoc(expected, 'TALLY')}\n\n",
       "assert_equal expected, Tournament.tally(input)"
     ]
-  end
-
-  private
-
-  def delimiter_mod
-    ".gsub(/^ */, '')"
   end
 end

--- a/exercises/tournament/tournament_test.rb
+++ b/exercises/tournament/tournament_test.rb
@@ -5,11 +5,11 @@ require_relative 'tournament'
 class TournamentTest < Minitest::Test
   def test_just_the_header_if_no_input
     # skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
 
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     TALLY
 
@@ -18,11 +18,11 @@ class TournamentTest < Minitest::Test
 
   def test_a_win_is_three_points_a_loss_is_zero_points
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;win
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
     Blithering Badgers             |  1 |  0 |  0 |  1 |  0
@@ -33,11 +33,11 @@ class TournamentTest < Minitest::Test
 
   def test_a_win_can_also_be_expressed_as_a_loss
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Blithering Badgers;Allegoric Alaskans;loss
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
     Blithering Badgers             |  1 |  0 |  0 |  1 |  0
@@ -48,11 +48,11 @@ class TournamentTest < Minitest::Test
 
   def test_a_different_team_can_win
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Blithering Badgers;Allegoric Alaskans;win
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Blithering Badgers             |  1 |  1 |  0 |  0 |  3
     Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0
@@ -63,11 +63,11 @@ class TournamentTest < Minitest::Test
 
   def test_a_draw_is_one_point_each
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;draw
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
     Blithering Badgers             |  1 |  0 |  1 |  0 |  1
@@ -78,12 +78,12 @@ class TournamentTest < Minitest::Test
 
   def test_there_can_be_more_than_one_match
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;win
     Allegoric Alaskans;Blithering Badgers;win
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
     Blithering Badgers             |  2 |  0 |  0 |  2 |  0
@@ -94,12 +94,12 @@ class TournamentTest < Minitest::Test
 
   def test_there_can_be_more_than_one_winner
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;loss
     Allegoric Alaskans;Blithering Badgers;win
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
     Blithering Badgers             |  2 |  1 |  0 |  1 |  3
@@ -110,13 +110,13 @@ class TournamentTest < Minitest::Test
 
   def test_there_can_be_more_than_two_teams
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;win
     Blithering Badgers;Courageous Californians;win
     Courageous Californians;Allegoric Alaskans;loss
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
     Blithering Badgers             |  2 |  1 |  0 |  1 |  3
@@ -128,7 +128,7 @@ class TournamentTest < Minitest::Test
 
   def test_typical_input
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;win
     Devastating Donkeys;Courageous Californians;draw
     Devastating Donkeys;Allegoric Alaskans;win
@@ -137,7 +137,7 @@ class TournamentTest < Minitest::Test
     Allegoric Alaskans;Courageous Californians;win
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
     Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
@@ -150,14 +150,14 @@ class TournamentTest < Minitest::Test
 
   def test_incomplete_competition_not_all_pairs_have_played
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Allegoric Alaskans;Blithering Badgers;loss
     Devastating Donkeys;Allegoric Alaskans;loss
     Courageous Californians;Blithering Badgers;draw
     Allegoric Alaskans;Courageous Californians;win
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
     Blithering Badgers             |  2 |  1 |  1 |  0 |  4
@@ -170,7 +170,7 @@ class TournamentTest < Minitest::Test
 
   def test_ties_broken_alphabetically
     skip
-    input = <<-INPUT.gsub(/^ */, '')
+    input = <<~INPUT
     Courageous Californians;Devastating Donkeys;win
     Allegoric Alaskans;Blithering Badgers;win
     Devastating Donkeys;Allegoric Alaskans;loss
@@ -179,7 +179,7 @@ class TournamentTest < Minitest::Test
     Allegoric Alaskans;Courageous Californians;draw
     INPUT
 
-    expected = <<-TALLY.gsub(/^ */, '')
+    expected = <<~TALLY
     Team                           | MP |  W |  D |  L |  P
     Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
     Courageous Californians        |  3 |  2 |  1 |  0 |  7

--- a/exercises/transpose/.meta/generator/transpose_case.rb
+++ b/exercises/transpose/.meta/generator/transpose_case.rb
@@ -15,7 +15,7 @@ class TransposeCase < Generator::ExerciseCase
   private
 
   def delimiter_mod
-    ".gsub(/^ {6}/, '').strip"
+    ".strip"
   end
 
 end

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -5,11 +5,11 @@ require_relative 'transpose'
 class TransposeTest < Minitest::Test
   def test_empty_string
     # skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
 
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
 
     EXPECTED
 
@@ -18,11 +18,11 @@ class TransposeTest < Minitest::Test
 
   def test_two_characters_in_a_row
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       A1
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       A
       1
     EXPECTED
@@ -32,12 +32,12 @@ class TransposeTest < Minitest::Test
 
   def test_two_characters_in_a_column
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       A
       1
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       A1
     EXPECTED
 
@@ -46,12 +46,12 @@ class TransposeTest < Minitest::Test
 
   def test_simple
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       ABC
       123
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       A1
       B2
       C3
@@ -62,11 +62,11 @@ class TransposeTest < Minitest::Test
 
   def test_single_line
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       Single line.
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       S
       i
       n
@@ -86,12 +86,12 @@ class TransposeTest < Minitest::Test
 
   def test_first_line_longer_than_second_line
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       The fourth line.
       The fifth line.
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       TT
       hh
       ee
@@ -115,12 +115,12 @@ class TransposeTest < Minitest::Test
 
   def test_second_line_longer_than_first_line
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       The first line.
       The second line.
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       TT
       hh
       ee
@@ -144,14 +144,14 @@ class TransposeTest < Minitest::Test
 
   def test_mixed_line_length
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       The longest line.
       A long line.
       A longer line.
       A line.
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       TAAA
       h   
       elll
@@ -176,7 +176,7 @@ class TransposeTest < Minitest::Test
 
   def test_square
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       HEART
       EMBER
       ABUSE
@@ -184,7 +184,7 @@ class TransposeTest < Minitest::Test
       TREND
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       HEART
       EMBER
       ABUSE
@@ -197,14 +197,14 @@ class TransposeTest < Minitest::Test
 
   def test_rectangle
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       FRACTURE
       OUTLINED
       BLOOMING
       SEPTETTE
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       FOBS
       RULE
       ATOP
@@ -220,7 +220,7 @@ class TransposeTest < Minitest::Test
 
   def test_triangle
     skip
-    input = <<-INPUT.gsub(/^ {6}/, '').strip
+    input = <<~INPUT.strip
       T
       EE
       AAA
@@ -229,7 +229,7 @@ class TransposeTest < Minitest::Test
       RRRRRR
     INPUT
 
-    expected = <<-EXPECTED.gsub(/^ {6}/, '').strip
+    expected = <<~EXPECTED.strip
       TEASER
        EASER
         ASER

--- a/lib/generator/exercise_case/case_helpers.rb
+++ b/lib/generator/exercise_case/case_helpers.rb
@@ -20,7 +20,7 @@ module Generator
       #    indent_heredoc(["foo", "bar"], 'TEXT', 1)
       def indent_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
         [
-          "<<-#{delimiter}#{delimiter_method}",
+          "<<~#{delimiter}#{delimiter_method}",
           lines.map { |line| ' ' * depth + line }.join("\n"),
           delimiter
         ].join("\n")

--- a/test/generator/exercise_case/case_helpers_test.rb
+++ b/test/generator/exercise_case/case_helpers_test.rb
@@ -54,7 +54,7 @@ module Generator
         end
       end
       def test_heredoc
-        expected = "<<-TEXT\n foo\n bar\nTEXT"
+        expected = "<<~TEXT\n foo\n bar\nTEXT"
         assert_equal expected, HeredocCase.new.workload
       end
     end


### PR DESCRIPTION
Previously it used regular heredocs and removed the indentation using
regular expressions.
I think it is now easier to read and understand.

~A side-effect of this change is to upgrade the project to Ruby 2.3.
This is the version that introduced squiqqly heredocs.
I think it's reasonable to upgrade, as Ruby 2.3 first came out over 3
years ago (2015-12-25).~

Update: Ruby has been updated to 2.5 in #933 
