### PR TITLE
Upgrade to ruby 2.5 and rubocop 0.63

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,487 @@
 AllCops:
   TargetRubyVersion: 2.3
 
+# Supports --auto-correct
+Layout/AccessModifierIndentation:
+  Description: Check indentation of private/protected visibility modifiers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
+  Enabled: false
+  EnforcedStyle: indent
+  SupportedStyles:
+  - outdent
+  - indent
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/AlignArray:
+  Description: Align the elements of an array literal if they span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
+  Enabled: false
+
+# Supports --auto-correct
+Layout/AlignHash:
+  Description: Align the elements of a hash literal if they span more than one line.
+  Enabled: false
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
+
+# Supports --auto-correct
+Layout/AlignParameters:
+  Description: Align the parameters of a method call if they span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
+  Enabled: false
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+
+# Supports --auto-correct
+Layout/BlockAlignment:
+  Description: Align block ends correctly.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/BlockEndNewline:
+  Description: Put end statement of multiline block on its own line.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/CaseIndentation:
+  Description: Indentation of when in a case/when/[else/]end.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
+  Enabled: false
+  EnforcedStyle: case
+  SupportedStyles:
+  - case
+  - end
+  IndentOneStep: false
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/ClosingParenthesisIndentation:
+  Description: Checks the indentation of hanging closing parentheses.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/CommentIndentation:
+  Description: Indentation of comments.
+  Enabled: false
+
+Layout/ConditionPosition:
+  Description: Checks for condition placed in a confusing position relative to the keyword.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
+  Enabled: false
+
+# Supports --auto-correct
+Layout/DefEndAlignment:
+  Description: Align ends corresponding to defs correctly.
+  Enabled: false
+  EnforcedStyleAlignWith: start_of_line
+  AutoCorrect: false
+
+# Supports --auto-correct
+Layout/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: false
+  EnforcedStyle: leading
+  SupportedStyles:
+  - leading
+  - trailing
+
+# Supports --auto-correct
+Layout/ElseAlignment:
+  Description: Align elses and elsifs correctly.
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+# Supports --auto-correct
+Layout/EmptyLineBetweenDefs:
+  Description: Use empty lines between defs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
+  Enabled: false
+  AllowAdjacentOneLineDefs: false
+
+# Supports --auto-correct
+Layout/EmptyLines:
+  Description: Don't use several empty lines in a row.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundAccessModifier:
+  Description: Keep blank lines around access modifiers.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundBlockBody:
+  Description: Keeps track of empty lines around block bodies.
+  Enabled: false
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundClassBody:
+  Description: Keeps track of empty lines around class bodies.
+  Enabled: false
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundMethodBody:
+  Description: Keeps track of empty lines around method bodies.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundModuleBody:
+  Description: Keeps track of empty lines around module bodies.
+  Enabled: false
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+# Supports --auto-correct
+Layout/EndAlignment:
+  Description: Align ends correctly.
+  Enabled: false
+  EnforcedStyleAlignWith: keyword
+  AutoCorrect: false
+
+Layout/EndOfLine:
+  Description: Use Unix-style line endings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
+  Enabled: false
+
+# Supports --auto-correct
+Layout/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: false
+  AllowForAlignment: true
+  ForceEqualSignAlignment: false
+
+# Supports --auto-correct
+Layout/FirstArrayElementLineBreak:
+  Description: Checks for a line break before the first element in a multi-line array.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/FirstHashElementLineBreak:
+  Description: Checks for a line break before the first element in a multi-line hash.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/FirstMethodArgumentLineBreak:
+  Description: Checks for a line break before the first argument in a multi-line method
+    call.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/FirstMethodParameterLineBreak:
+  Description: Checks for a line break before the first parameter in a multi-line method
+    parameter definition.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/FirstParameterIndentation:
+  Description: Checks the indentation of the first parameter in a method call.
+  Enabled: false
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+  - consistent
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/IndentArray:
+  Description: Checks the indentation of the first element in an array literal.
+  Enabled: false
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_brackets
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/IndentAssignment:
+  Description: Checks the indentation of the first line of the right-hand-side of a
+    multi-line assignment.
+  Enabled: false
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/IndentHash:
+  Description: Checks the indentation of the first key in a hash literal.
+  Enabled: false
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_braces
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/IndentationConsistency:
+  Description: Keep indentation straight.
+  Enabled: false
+  EnforcedStyle: normal
+  SupportedStyles:
+  - normal
+  - rails
+
+# Supports --auto-correct
+Layout/IndentationWidth:
+  Description: Use 2 spaces for indentation.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
+  Enabled: false
+  Width: 2
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+# Supports --auto-correct
+Layout/InitialIndentation:
+  Description: Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/LeadingCommentSpace:
+  Description: Comments should start with a space.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
+  Enabled: false
+
+# Supports --auto-correct
+Layout/MultilineArrayBraceLayout:
+  Description: Checks that the closing brace in an array literal is symmetrical with
+    respect to the opening brace and the array elements.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/MultilineAssignmentLayout:
+  Description: Check for a newline after the assignment operator in multi-line assignments.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment
+  Enabled: false
+  SupportedTypes:
+  - block
+  - case
+  - class
+  - if
+  - kwbegin
+  - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+  - same_line
+  - new_line
+
+# Supports --auto-correct
+Layout/MultilineBlockLayout:
+  Description: Ensures newlines after multiline block do statements.
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+# Supports --auto-correct
+Layout/MultilineMethodCallIndentation:
+  Description: Checks indentation of method calls with the dot operator that span more
+    than one line.
+  Enabled: false
+  EnforcedStyle: aligned
+  SupportedStyles:
+  - aligned
+  - indented
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span more than one line.
+  Enabled: false
+  EnforcedStyle: aligned
+  SupportedStyles:
+  - aligned
+  - indented
+  IndentationWidth: 
+
+# Supports --auto-correct
+Layout/RescueEnsureAlignment:
+  Description: Align rescues and ensures correctly.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceAfterColon:
+  Description: Use spaces after colons.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceAfterComma:
+  Description: Use spaces after commas.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+
+# Supports --auto-correct
+Layout/SpaceAfterMethodName:
+  Description: Do not put a space between a method name and the opening parenthesis
+    in a method definition.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceAfterNot:
+  Description: Tracks redundant space after the ! operator.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceAfterSemicolon:
+  Description: Use spaces after semicolons.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceAroundBlockParameters:
+  Description: Checks the spacing inside and after block parameters pipes.
+  Enabled: false
+  EnforcedStyleInsidePipes: no_space
+
+# Supports --auto-correct
+Layout/SpaceAroundEqualsInParameterDefault:
+  Description: Checks that the equals signs in parameter default assignments have or
+    don't have surrounding space depending on configuration.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
+  Enabled: false
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceAroundKeyword:
+  Description: Use spaces after if/elsif/unless/while/until/case/when.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceAroundOperators:
+  Description: Use a single space around operators.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: false
+  AllowForAlignment: true
+
+# Supports --auto-correct
+Layout/SpaceBeforeBlockBraces:
+  Description: Checks that the left block brace has or doesn't have space before it.
+  Enabled: false
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceBeforeComma:
+  Description: No spaces before commas.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceBeforeComment:
+  Description: Checks for missing space between code and a comment on the same line.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceBeforeFirstArg:
+  Description: Checks that exactly one space is used between a method name and the first
+    argument for method calls without parentheses.
+  Enabled: false
+  AllowForAlignment: true
+
+# Supports --auto-correct
+Layout/SpaceBeforeSemicolon:
+  Description: No spaces before semicolons.
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceInsideBlockBraces:
+  Description: Checks that block braces have or don't have surrounding space. For blocks
+    taking parameters, checks that the left brace has or doesn't have trailing space.
+  Enabled: false
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SpaceBeforeBlockParameters: true
+
+# Supports --auto-correct
+Layout/SpaceInsideHashLiteralBraces:
+  Description: Use spaces inside hash literal braces - or don't.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: false
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceInsideParens:
+  Description: No spaces after ( or before ).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceInsideRangeLiteral:
+  Description: No spaces inside range literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
+  Enabled: false
+
+# Supports --auto-correct
+Layout/SpaceInsideStringInterpolation:
+  Description: Checks for padding/surrounding spaces inside string interpolation.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#string-interpolation
+  Enabled: false
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/Tab:
+  Description: No hard tabs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
+  Enabled: false
+
+# Supports --auto-correct
+Layout/TrailingBlankLines:
+  Description: Checks trailing blank lines and final newline.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
+  Enabled: false
+  EnforcedStyle: final_newline
+  SupportedStyles:
+  - final_newline
+  - final_blank_line
+
+# Supports --auto-correct
+Layout/TrailingWhitespace:
+  Description: Avoid trailing whitespace.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
+  Enabled: false
+
 # Type 'Lint' (48):
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 Lint/AmbiguousOperator:
   Description: Checks for ambiguous operators in the first argument of a method invocation
     without parentheses.
@@ -19,35 +499,15 @@ Lint/AssignmentInCondition:
   Enabled: false
   AllowSafeAssignment: true
 
-# Supports --auto-correct
-Lint/BlockAlignment:
-  Description: Align block ends correctly.
-  Enabled: false
-
 Lint/CircularArgumentReference:
   Description: Default values in optional keyword arguments and optional ordinal arguments
     should not refer back to the name of the argument.
-  Enabled: false
-
-Lint/ConditionPosition:
-  Description: Checks for condition placed in a confusing position relative to the keyword.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
   Enabled: false
 
 # Supports --auto-correct
 Lint/Debugger:
   Description: Check for debugger calls.
   Enabled: false
-
-# Supports --auto-correct
-Lint/DefEndAlignment:
-  Description: Align ends corresponding to defs correctly.
-  Enabled: false
-  AlignWith: start_of_line
-  SupportedStyles:
-  - start_of_line
-  - def
-  AutoCorrect: false
 
 # Supports --auto-correct
 Lint/DeprecatedClassMethods:
@@ -78,17 +538,6 @@ Lint/EmptyInterpolation:
   Description: Checks for empty string interpolation.
   Enabled: false
 
-# Supports --auto-correct
-Lint/EndAlignment:
-  Description: Align ends correctly.
-  Enabled: false
-  AlignWith: keyword
-  SupportedStyles:
-  - keyword
-  - variable
-  - start_of_line
-  AutoCorrect: false
-
 Lint/EndInMethod:
   Description: END blocks should not be placed inside method definitions.
   Enabled: false
@@ -98,8 +547,9 @@ Lint/EnsureReturn:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-return-ensure
   Enabled: false
 
-Lint/Eval:
-  Description: The use of eval represents a serious security risk.
+Lint/FlipFlop:
+  Description: Checks for flip flops
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
   Enabled: false
 
 Lint/FloatOutOfRange:
@@ -125,11 +575,7 @@ Lint/IneffectiveAccessModifier:
     of a class method, which does not work.
   Enabled: false
 
-Lint/InvalidCharacterLiteral:
-  Description: Checks for invalid character literals with a non-escaped whitespace character.
-  Enabled: false
-
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: Checks of literals used in conditions.
   Enabled: false
 
@@ -194,7 +640,7 @@ Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
 # Supports --auto-correct
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: 'Checks for rubocop:disable comments that can be removed. Note: this
     cop is not disabled when disabling all cops. It must be explicitly disabled.'
   Enabled: false
@@ -251,6 +697,10 @@ Metrics/AbcSize:
   Enabled: false
   Max: 15
 
+Metrics/BlockLength:
+  Enabled: false
+  Max: 27
+
 Metrics/BlockNesting:
   Description: Avoid excessive block nesting
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count
@@ -305,6 +755,78 @@ Metrics/PerceivedComplexity:
   Enabled: false
   Max: 7
 
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+
+Naming/AsciiIdentifiers:
+  Description: Use only ascii symbols in identifiers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-identifiers
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Description: When defining binary operators, name the argument other.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
+  Enabled: false
+
+Naming/ClassAndModuleCamelCase:
+  Description: Use CamelCase for classes and modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#camelcase-classes
+  Enabled: false
+
+Naming/ConstantName:
+  Description: Constants should use SCREAMING_SNAKE_CASE.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#screaming-snake-case
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Naming/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+  ExpectMatchingDefinition: false
+  Regex: 
+  IgnoreExecutableScripts: true
+
+Naming/MethodName:
+  Description: Use the configured style when naming methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
+  Enabled: false
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Naming/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: false
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  NamePrefixBlacklist:
+  - is_
+  - has_
+  - have_
+  NameWhitelist:
+  - is_a?
+
+Naming/VariableName:
+  Description: Use the configured style when naming variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
+  Enabled: false
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Naming/VariableNumber:
+  Enabled: false
+
 # Type 'Performance' (21):
 # Supports --auto-correct
 Performance/CaseWhenSplat:
@@ -353,14 +875,6 @@ Performance/FlatMap:
   Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code
   Enabled: false
   EnabledForFlattenWithoutParams: false
-
-# Supports --auto-correct
-Performance/HashEachMethods:
-  Description: Use `Hash#each_key` and `Hash#each_value` instead of `Hash#keys.each`
-    and `Hash#values.each`.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-each
-  Enabled: false
-  AutoCorrect: false
 
 # Supports --auto-correct
 Performance/LstripRstrip:
@@ -522,22 +1036,11 @@ Rails/Validation:
   Include:
   - app/models/**/*.rb
 
+Security/Eval:
+  Description: The use of eval represents a serious security risk.
+  Enabled: false
+
 # Type 'Style' (184):
-# Supports --auto-correct
-Style/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
-  Enabled: false
-  EnforcedStyle: indent
-  SupportedStyles:
-  - outdent
-  - indent
-  IndentationWidth: 
-
-Style/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
-  Enabled: false
-
 # Supports --auto-correct
 Style/Alias:
   Description: Use alias_method instead of alias.
@@ -547,35 +1050,6 @@ Style/Alias:
   SupportedStyles:
   - prefer_alias
   - prefer_alias_method
-
-# Supports --auto-correct
-Style/AlignArray:
-  Description: Align the elements of an array literal if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
-  Enabled: false
-
-# Supports --auto-correct
-Style/AlignHash:
-  Description: Align the elements of a hash literal if they span more than one line.
-  Enabled: false
-  EnforcedHashRocketStyle: key
-  EnforcedColonStyle: key
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
-
-# Supports --auto-correct
-Style/AlignParameters:
-  Description: Align the parameters of a method call if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
-  Enabled: false
-  EnforcedStyle: with_first_parameter
-  SupportedStyles:
-  - with_first_parameter
-  - with_fixed_indentation
 
 # Supports --auto-correct
 Style/AndOr:
@@ -596,11 +1070,6 @@ Style/ArrayJoin:
 Style/AsciiComments:
   Description: Use only ascii symbols in comments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-comments
-  Enabled: false
-
-Style/AsciiIdentifiers:
-  Description: Use only ascii symbols in identifiers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-identifiers
   Enabled: false
 
 # Supports --auto-correct
@@ -668,11 +1137,6 @@ Style/BlockDelimiters:
   - it
 
 # Supports --auto-correct
-Style/BlockEndNewline:
-  Description: Put end statement of multiline block on its own line.
-  Enabled: false
-
-# Supports --auto-correct
 Style/BracesAroundHashParameters:
   Description: Enforce braces style around hash parameters.
   Enabled: false
@@ -688,26 +1152,9 @@ Style/CaseEquality:
   Enabled: false
 
 # Supports --auto-correct
-Style/CaseIndentation:
-  Description: Indentation of when in a case/when/[else/]end.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
-  Enabled: false
-  IndentWhenRelativeTo: case
-  SupportedStyles:
-  - case
-  - end
-  IndentOneStep: false
-  IndentationWidth: 
-
-# Supports --auto-correct
 Style/CharacterLiteral:
   Description: Checks for uses of character literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
-  Enabled: false
-
-Style/ClassAndModuleCamelCase:
-  Description: Use CamelCase for classes and modules.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#camelcase-classes
   Enabled: false
 
 Style/ClassAndModuleChildren:
@@ -736,11 +1183,6 @@ Style/ClassMethods:
 Style/ClassVars:
   Description: Avoid the use of class variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-class-vars
-  Enabled: false
-
-# Supports --auto-correct
-Style/ClosingParenthesisIndentation:
-  Description: Checks the indentation of hanging closing parentheses.
   Enabled: false
 
 # Supports --auto-correct
@@ -786,22 +1228,12 @@ Style/CommentAnnotation:
   - REVIEW
 
 # Supports --auto-correct
-Style/CommentIndentation:
-  Description: Indentation of comments.
-  Enabled: false
-
-# Supports --auto-correct
 Style/ConditionalAssignment:
   Description: Use the return value of `if` and `case` statements for assignment to
     a variable and variable comparison instead of assigning that variable inside of
     each branch.
   Enabled: false
   SingleLineConditionsOnly: true
-
-Style/ConstantName:
-  Description: Constants should use SCREAMING_SNAKE_CASE.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#screaming-snake-case
-  Enabled: false
 
 # Supports --auto-correct
 Style/Copyright:
@@ -816,25 +1248,9 @@ Style/DefWithParentheses:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
   Enabled: false
 
-# Supports --auto-correct
-Style/DeprecatedHashMethods:
-  Description: Checks for use of deprecated Hash methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
-  Enabled: false
-
 Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
-
-# Supports --auto-correct
-Style/DotPosition:
-  Description: Checks the position of the dot in multi-line method calls.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
-  Enabled: false
-  EnforcedStyle: leading
-  SupportedStyles:
-  - leading
-  - trailing
 
 Style/DoubleNegation:
   Description: Checks for uses of double negation (!!).
@@ -843,11 +1259,6 @@ Style/DoubleNegation:
 
 Style/EachWithObject:
   Description: Prefer `each_with_object` over `inject` or `reduce`.
-  Enabled: false
-
-# Supports --auto-correct
-Style/ElseAlignment:
-  Description: Align elses and elsifs correctly.
   Enabled: false
 
 # Supports --auto-correct
@@ -861,79 +1272,17 @@ Style/EmptyElse:
   - both
 
 # Supports --auto-correct
-Style/EmptyLineBetweenDefs:
-  Description: Use empty lines between defs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
-  Enabled: false
-  AllowAdjacentOneLineDefs: false
-
-# Supports --auto-correct
-Style/EmptyLines:
-  Description: Don't use several empty lines in a row.
-  Enabled: false
-
-# Supports --auto-correct
-Style/EmptyLinesAroundAccessModifier:
-  Description: Keep blank lines around access modifiers.
-  Enabled: false
-
-# Supports --auto-correct
-Style/EmptyLinesAroundBlockBody:
-  Description: Keeps track of empty lines around block bodies.
-  Enabled: false
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-
-# Supports --auto-correct
-Style/EmptyLinesAroundClassBody:
-  Description: Keeps track of empty lines around class bodies.
-  Enabled: false
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-
-# Supports --auto-correct
-Style/EmptyLinesAroundMethodBody:
-  Description: Keeps track of empty lines around method bodies.
-  Enabled: false
-
-# Supports --auto-correct
-Style/EmptyLinesAroundModuleBody:
-  Description: Keeps track of empty lines around module bodies.
-  Enabled: false
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-
-# Supports --auto-correct
 Style/EmptyLiteral:
   Description: Prefer literals to Array.new/Hash.new/String.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
   Enabled: false
 
-# Supports --auto-correct
-Style/Encoding:
-  Description: Use UTF-8 as the source file encoding.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
+Style/EmptyMethod:
   Enabled: false
-  EnforcedStyle: always
-  SupportedStyles:
-  - when_needed
-  - always
-  AutoCorrectEncodingComment: "# encoding: utf-8"
 
 Style/EndBlock:
   Description: Avoid the use of END blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-END-blocks
-  Enabled: false
-
-Style/EndOfLine:
-  Description: Use Unix-style line endings.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
   Enabled: false
 
 # Supports --auto-correct
@@ -942,58 +1291,7 @@ Style/EvenOdd:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
   Enabled: false
 
-# Supports --auto-correct
-Style/ExtraSpacing:
-  Description: Do not use unnecessary spacing.
-  Enabled: false
-  AllowForAlignment: true
-  ForceEqualSignAlignment: false
-
-Style/FileName:
-  Description: Use snake_case for source file names.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
-  Enabled: false
-  Exclude: []
-  ExpectMatchingDefinition: false
-  Regex: 
-  IgnoreExecutableScripts: true
-
-# Supports --auto-correct
-Style/FirstArrayElementLineBreak:
-  Description: Checks for a line break before the first element in a multi-line array.
-  Enabled: false
-
-# Supports --auto-correct
-Style/FirstHashElementLineBreak:
-  Description: Checks for a line break before the first element in a multi-line hash.
-  Enabled: false
-
-# Supports --auto-correct
-Style/FirstMethodArgumentLineBreak:
-  Description: Checks for a line break before the first argument in a multi-line method
-    call.
-  Enabled: false
-
-# Supports --auto-correct
-Style/FirstMethodParameterLineBreak:
-  Description: Checks for a line break before the first parameter in a multi-line method
-    parameter definition.
-  Enabled: false
-
-# Supports --auto-correct
-Style/FirstParameterIndentation:
-  Description: Checks the indentation of the first parameter in a method call.
-  Enabled: false
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
-  SupportedStyles:
-  - consistent
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
-  IndentationWidth: 
-
-Style/FlipFlop:
-  Description: Checks for flip flops
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
+Style/ExpandPathArguments:
   Enabled: false
 
 Style/For:
@@ -1060,12 +1358,8 @@ Style/IfInsideElse:
   Description: Finds if nodes inside else, which can be converted to elsif.
   Enabled: false
 
-# Supports --auto-correct
 Style/IfUnlessModifier:
-  Description: Favor modifier if/unless usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
 
 Style/IfWithSemicolon:
   Description: Do not use if x; .... Use the ternary operator instead.
@@ -1073,59 +1367,9 @@ Style/IfWithSemicolon:
   Enabled: false
 
 # Supports --auto-correct
-Style/IndentArray:
-  Description: Checks the indentation of the first element in an array literal.
-  Enabled: false
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_brackets
-  IndentationWidth: 
-
-# Supports --auto-correct
-Style/IndentAssignment:
-  Description: Checks the indentation of the first line of the right-hand-side of a
-    multi-line assignment.
-  Enabled: false
-  IndentationWidth: 
-
-# Supports --auto-correct
-Style/IndentHash:
-  Description: Checks the indentation of the first key in a hash literal.
-  Enabled: false
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_braces
-  IndentationWidth: 
-
-# Supports --auto-correct
-Style/IndentationConsistency:
-  Description: Keep indentation straight.
-  Enabled: false
-  EnforcedStyle: normal
-  SupportedStyles:
-  - normal
-  - rails
-
-# Supports --auto-correct
-Style/IndentationWidth:
-  Description: Use 2 spaces for indentation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: false
-  Width: 2
-
-# Supports --auto-correct
 Style/InfiniteLoop:
   Description: Use Kernel#loop for infinite loops.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#infinite-loop
-  Enabled: false
-
-# Supports --auto-correct
-Style/InitialIndentation:
-  Description: Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: false
 
 Style/InlineComment:
@@ -1149,18 +1393,12 @@ Style/LambdaCall:
   - braces
 
 # Supports --auto-correct
-Style/LeadingCommentSpace:
-  Description: Comments should start with a space.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
-  Enabled: false
-
-# Supports --auto-correct
 Style/LineEndConcatenation:
   Description: Use \ instead of + or << to concatenate two string literals at line end.
   Enabled: false
 
 # Supports --auto-correct
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: Do not use parentheses for method calls with no arguments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-args-no-parens
   Enabled: false
@@ -1181,14 +1419,8 @@ Style/MethodDefParentheses:
   - require_no_parentheses
   - require_no_parentheses_except_multiline
 
-Style/MethodName:
-  Description: Use the configured style when naming methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
+Style/MethodMissingSuper:
   Enabled: false
-  EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 
 Style/MissingElse:
   Description: Require if/case expressions to have an else branches. If enabled, it
@@ -1201,33 +1433,13 @@ Style/MissingElse:
   - case
   - both
 
+Style/MissingRespondToMissing:
+  Enabled: false
+
 Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
   Enabled: false
-
-# Supports --auto-correct
-Style/MultilineArrayBraceLayout:
-  Description: Checks that the closing brace in an array literal is symmetrical with
-    respect to the opening brace and the array elements.
-  Enabled: false
-
-# Supports --auto-correct
-Style/MultilineAssignmentLayout:
-  Description: Check for a newline after the assignment operator in multi-line assignments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment
-  Enabled: false
-  SupportedTypes:
-  - block
-  - case
-  - class
-  - if
-  - kwbegin
-  - module
-  EnforcedStyle: new_line
-  SupportedStyles:
-  - same_line
-  - new_line
 
 Style/MultilineBlockChain:
   Description: Avoid multi-line chains of blocks.
@@ -1235,36 +1447,10 @@ Style/MultilineBlockChain:
   Enabled: false
 
 # Supports --auto-correct
-Style/MultilineBlockLayout:
-  Description: Ensures newlines after multiline block do statements.
-  Enabled: false
-
-# Supports --auto-correct
 Style/MultilineIfThen:
   Description: Do not use then for multi-line if/unless.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-then
   Enabled: false
-
-# Supports --auto-correct
-Style/MultilineMethodCallIndentation:
-  Description: Checks indentation of method calls with the dot operator that span more
-    than one line.
-  Enabled: false
-  EnforcedStyle: aligned
-  SupportedStyles:
-  - aligned
-  - indented
-  IndentationWidth: 
-
-# Supports --auto-correct
-Style/MultilineOperationIndentation:
-  Description: Checks indentation of binary operations that span more than one line.
-  Enabled: false
-  EnforcedStyle: aligned
-  SupportedStyles:
-  - aligned
-  - indented
-  IndentationWidth: 
 
 Style/MultilineTernaryOperator:
   Description: 'Avoid multi-line ?: (the ternary operator); use if/unless instead.'
@@ -1346,11 +1532,6 @@ Style/OneLineConditional:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
   Enabled: false
 
-Style/OpMethod:
-  Description: When defining binary operators, name the argument other.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
-  Enabled: false
-
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false
@@ -1412,20 +1593,11 @@ Style/PerlBackrefs:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
   Enabled: false
 
-Style/PredicateName:
-  Description: Check the names of predicate methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+# Supports --auto-correct
+Style/PreferredHashMethods:
+  Description: Checks for use of deprecated Hash methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
   Enabled: false
-  NamePrefix:
-  - is_
-  - has_
-  - have_
-  NamePrefixBlacklist:
-  - is_
-  - has_
-  - have_
-  NameWhitelist:
-  - is_a?
 
 # Supports --auto-correct
 Style/Proc:
@@ -1490,14 +1662,12 @@ Style/RegexpLiteral:
   AllowInnerSlashes: false
 
 # Supports --auto-correct
-Style/RescueEnsureAlignment:
-  Description: Align rescues and ensures correctly.
-  Enabled: false
-
-# Supports --auto-correct
 Style/RescueModifier:
   Description: Avoid using rescue in its modifier form.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers
+  Enabled: false
+
+Style/RescueStandardError:
   Enabled: false
 
 # Supports --auto-correct
@@ -1550,156 +1720,6 @@ Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
 
 # Supports --auto-correct
-Style/SpaceAfterColon:
-  Description: Use spaces after colons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceAfterComma:
-  Description: Use spaces after commas.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-
-# Supports --auto-correct
-Style/SpaceAfterControlKeyword:
-  Description: Use spaces after if/elsif/unless/while/until/case/when.
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceAfterMethodName:
-  Description: Do not put a space between a method name and the opening parenthesis
-    in a method definition.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceAfterSemicolon:
-  Description: Use spaces after semicolons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceAroundBlockParameters:
-  Description: Checks the spacing inside and after block parameters pipes.
-  Enabled: false
-  EnforcedStyleInsidePipes: no_space
-  SupportedStyles:
-  - space
-  - no_space
-
-# Supports --auto-correct
-Style/SpaceAroundEqualsInParameterDefault:
-  Description: Checks that the equals signs in parameter default assignments have or
-    don't have surrounding space depending on configuration.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
-  Enabled: false
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-
-# Supports --auto-correct
-Style/SpaceAroundOperators:
-  Description: Use a single space around operators.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: false
-  AllowForAlignment: true
-
-# Supports --auto-correct
-Style/SpaceBeforeBlockBraces:
-  Description: Checks that the left block brace has or doesn't have space before it.
-  Enabled: false
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-
-# Supports --auto-correct
-Style/SpaceBeforeComma:
-  Description: No spaces before commas.
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceBeforeComment:
-  Description: Checks for missing space between code and a comment on the same line.
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceBeforeFirstArg:
-  Description: Checks that exactly one space is used between a method name and the first
-    argument for method calls without parentheses.
-  Enabled: false
-  AllowForAlignment: true
-
-# Supports --auto-correct
-Style/SpaceBeforeModifierKeyword:
-  Description: Put a space before the modifier keyword.
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceBeforeSemicolon:
-  Description: No spaces before semicolons.
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceInsideBlockBraces:
-  Description: Checks that block braces have or don't have surrounding space. For blocks
-    taking parameters, checks that the left brace has or doesn't have trailing space.
-  Enabled: false
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: true
-
-# Supports --auto-correct
-Style/SpaceInsideBrackets:
-  Description: No spaces after [ or before ].
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceInsideHashLiteralBraces:
-  Description: Use spaces inside hash literal braces - or don't.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: false
-  EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
-  SupportedStyles:
-  - space
-  - no_space
-
-# Supports --auto-correct
-Style/SpaceInsideParens:
-  Description: No spaces after ( or before ).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceInsideRangeLiteral:
-  Description: No spaces inside range literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
-  Enabled: false
-
-# Supports --auto-correct
-Style/SpaceInsideStringInterpolation:
-  Description: Checks for padding/surrounding spaces inside string interpolation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#string-interpolation
-  Enabled: false
-  EnforcedStyle: no_space
-  SupportedStyles:
-  - space
-  - no_space
-
-# Supports --auto-correct
 Style/SpecialGlobalVars:
   Description: Avoid Perl-style global variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
@@ -1718,6 +1738,9 @@ Style/StabbyLambdaParentheses:
   SupportedStyles:
   - require_parentheses
   - require_no_parentheses
+
+Style/StderrPuts:
+  Enabled: false
 
 # Supports --auto-correct
 Style/StringLiterals:
@@ -1775,54 +1798,17 @@ Style/SymbolProc:
   - respond_to
 
 # Supports --auto-correct
-Style/Tab:
-  Description: No hard tabs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: false
-
-# Supports --auto-correct
-Style/TrailingBlankLines:
-  Description: Checks trailing blank lines and final newline.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
-  Enabled: false
-  EnforcedStyle: final_newline
-  SupportedStyles:
-  - final_newline
-  - final_blank_line
-
-# Supports --auto-correct
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
-  - comma
-  - consistent_comma
-  - no_comma
-
-# Supports --auto-correct
-Style/TrailingCommaInLiteral:
-  Description: Checks for trailing comma in array and hash literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
-  Enabled: false
-  EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
-  - comma
-  - consistent_comma
-  - no_comma
 
 # Supports --auto-correct
 Style/TrailingUnderscoreVariable:
   Description: Checks for the usage of unneeded trailing underscores at the end of parallel
     variable assignment.
   AllowNamedUnderscoreVariables: true
-  Enabled: false
-
-# Supports --auto-correct
-Style/TrailingWhitespace:
-  Description: Avoid trailing whitespace.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
   Enabled: false
 
 # Supports --auto-correct
@@ -1880,15 +1866,6 @@ Style/VariableInterpolation:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
   Enabled: false
 
-Style/VariableName:
-  Description: Use the configured style when naming variables.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
-  Enabled: false
-  EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
-
 # Supports --auto-correct
 Style/WhenThen:
   Description: Use when x then ... for one-line cases.
@@ -1900,13 +1877,6 @@ Style/WhileUntilDo:
   Description: Checks for redundant do after while or until.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do
   Enabled: false
-
-# Supports --auto-correct
-Style/WhileUntilModifier:
-  Description: Favor modifier while/until usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
-  Enabled: false
-  MaxLineLength: 80
 
 # Supports --auto-correct
 Style/WordArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 # Supports --auto-correct
 Layout/AccessModifierIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
 
 # Type 'Lint' (48):
 Lint/AmbiguousOperator:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.1.2
+  - 2.3
 install:
   - bundle install --quiet
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3
+  - 2.5
 install:
   - bundle install --quiet
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gem 'minitest'
 gem 'rake'
-gem 'rubocop', '0.36.0'
+gem 'rubocop', '0.63.1'
 gem 'simplecov'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Exercism Exercises in Ruby
 
 ## Setup
 
-You'll need a recent (2.1+) version of Ruby, but that's it. Minitest ships
+You'll need a recent (2.3+) version of Ruby, but that's it. Minitest ships
 with the language, so you're all set.
 
 ## Anatomy of an Exercise

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Exercism Exercises in Ruby
 
 ## Setup
 
-You'll need a recent (2.3+) version of Ruby, but that's it. Minitest ships
+You'll need a recent (2.5+) version of Ruby, but that's it. Minitest ships
 with the language, so you're all set.
 
 ## Anatomy of an Exercise


### PR DESCRIPTION
https://github.com/exercism/ruby/issues/930

I'd prefer to only upgrade ruby, but doing so breaks rubocop.
Upgrading rubocop on its own also isn't an option as it requires newer versions of ruby.

`./bin/compile --all`'s output doesn't change and the tests are passing.

Rubocop needed quite substantial changes. I'd be interested how the original .rubocop.yml was generated so that I can make my rubocop change less drastic.