### PR TITLE
high-scores: Regenerate tests

### DIFF
--- a/exercises/high-scores/.meta/solutions/high_scores.rb
+++ b/exercises/high-scores/.meta/solutions/high_scores.rb
@@ -15,8 +15,8 @@ class HighScores
     scores.last
   end
 
-  def personal_top
-    scores.sort.reverse.take(3)
+  def personal_top_three
+    scores.max(3)
   end
 
   def report

--- a/exercises/high-scores/.meta/solutions/high_scores.rb
+++ b/exercises/high-scores/.meta/solutions/high_scores.rb
@@ -18,10 +18,4 @@ class HighScores
   def personal_top_three
     scores.max(3)
   end
-
-  def report
-    difference = "#{personal_best - latest} short of" if personal_best != latest
-
-    "Your latest score was #{latest}. That's #{difference} your personal best!".squeeze
-  end
 end

--- a/exercises/high-scores/README.md
+++ b/exercises/high-scores/README.md
@@ -2,7 +2,7 @@
 
 Manage a game player's High Score list.
 
-Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score, the three highest scores, and a report on the difference between the last and the highest scores.
+Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.
 
 In this exercise you're going to instantiate a class and add some instance methods. http://ruby-for-beginners.rubymonstas.org/writing_classes/initializers.html
 

--- a/exercises/high-scores/high_scores_test.rb
+++ b/exercises/high-scores/high_scores_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'high_scores'
 
-# Common test data version: 2.0.0 7a386a2
+# Common test data version: 3.0.0 999ec47
 class HighScoresTest < Minitest::Test
   def test_list_of_scores
     # skip
@@ -24,46 +24,39 @@ class HighScoresTest < Minitest::Test
     assert_equal expected, HighScores.new(scores).personal_best
   end
 
-  def test_personal_top
+  def test_personal_top_three_from_a_list_of_scores
     skip
-    scores = [50, 30, 10]
-    expected = [50, 30, 10]
-    assert_equal expected, HighScores.new(scores).personal_top
+    scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
+    expected = [100, 90, 70]
+    assert_equal expected, HighScores.new(scores).personal_top_three
   end
 
   def test_personal_top_highest_to_lowest
     skip
     scores = [20, 10, 30]
     expected = [30, 20, 10]
-    assert_equal expected, HighScores.new(scores).personal_top
+    assert_equal expected, HighScores.new(scores).personal_top_three
   end
 
   def test_personal_top_when_there_is_a_tie
     skip
     scores = [40, 20, 40, 30]
     expected = [40, 40, 30]
-    assert_equal expected, HighScores.new(scores).personal_top
+    assert_equal expected, HighScores.new(scores).personal_top_three
   end
 
   def test_personal_top_when_there_are_less_than_3
     skip
     scores = [30, 70]
     expected = [70, 30]
-    assert_equal expected, HighScores.new(scores).personal_top
+    assert_equal expected, HighScores.new(scores).personal_top_three
   end
 
   def test_personal_top_when_there_is_only_one
     skip
     scores = [40]
     expected = [40]
-    assert_equal expected, HighScores.new(scores).personal_top
-  end
-
-  def test_personal_top_from_a_long_list
-    skip
-    scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
-    expected = [100, 90, 70]
-    assert_equal expected, HighScores.new(scores).personal_top
+    assert_equal expected, HighScores.new(scores).personal_top_three
   end
 
   def test_message_for_new_personal_best

--- a/exercises/high-scores/high_scores_test.rb
+++ b/exercises/high-scores/high_scores_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'high_scores'
 
-# Common test data version: 3.0.0 999ec47
+# Common test data version: 4.0.0 ad1f9c4
 class HighScoresTest < Minitest::Test
   def test_list_of_scores
     # skip
@@ -57,26 +57,5 @@ class HighScoresTest < Minitest::Test
     scores = [40]
     expected = [40]
     assert_equal expected, HighScores.new(scores).personal_top_three
-  end
-
-  def test_message_for_new_personal_best
-    skip
-    scores = [20, 40, 0, 30, 70]
-    expected = "Your latest score was 70. That's your personal best!"
-    assert_equal expected, HighScores.new(scores).report
-  end
-
-  def test_message_when_latest_score_is_not_the_highest_score
-    skip
-    scores = [20, 100, 0, 30, 70]
-    expected = "Your latest score was 70. That's 30 short of your personal best!"
-    assert_equal expected, HighScores.new(scores).report
-  end
-
-  def test_message_for_repeated_personal_best
-    skip
-    scores = [20, 70, 50, 70, 30]
-    expected = "Your latest score was 30. That's 40 short of your personal best!"
-    assert_equal expected, HighScores.new(scores).report
   end
 end


### PR DESCRIPTION
Update tests to: ~`3.0.0 999ec47`~ `4.0.0 ad1f9c4`

These are the changes introduced by:
* https://github.com/exercism/problem-specifications/pull/1447
* https://github.com/exercism/problem-specifications/pull/1459

### v3.0.0 notes

Right now I kept the new method name `personal_top_three`, but a case could be made for naming it `personal_top_3` or rather `personal_top3`, as the [rubocop styleguide suggests](https://github.com/rubocop-hq/ruby-style-guide#snake-case-symbols-methods-vars-with-numbers). Personally, I'm not a fan of `personal_top3` 🤔 Thoughts are welcome.

@F3PiX I believe we can make this change without affecting the overhauling efforts, but let me know if that's not the case.

### v4.0.0 notes

Also updated README.md :+1:

### TODO

- [x] Update changelog on the mentor notes as soon as this is merged (https://github.com/exercism/website-copy/pull/783)
- [x] Upload mentor notes to remove references to the `report` method.