### PR TITLE
Added note for hexadecimal exercise readme

### DIFF
--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -7,6 +7,11 @@ teal: 008080, navy: 000080).
 
 The program should handle invalid hexadecimal strings.
 
+## Note
+
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
 * * * *
 
 For installation and learning resources, refer to the


### PR DESCRIPTION
When I viewed Community Solutions for hexadecimal exercise, I detected that, according to Readme, one can simply using Ruby standard library method `to_i(16)`. I think we should to fix it