### PR TITLE
grep: New exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1172,6 +1172,21 @@
       "topics": [
         "data_structures"
       ]
+    },
+    {
+      "slug": "grep",
+      "uuid": "99485900-5d16-4848-af1c-2f1a62ad35ab",
+      "core": false,
+      "unlocked_by": "twelve-days",
+      "difficulty": 8,
+      "topics": [
+        "files",
+        "parsing",
+        "pattern_matching",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ]
     }
   ]
 }

--- a/exercises/grep/.meta/generator/grep_case.rb
+++ b/exercises/grep/.meta/generator/grep_case.rb
@@ -1,0 +1,14 @@
+require 'generator/exercise_case'
+
+class GrepCase < Generator::ExerciseCase
+  def workload
+    [
+      "pattern = #{pattern.inspect}",
+      "flags = #{flags}",
+      "files = #{files}",
+      "expected = #{indent_heredoc(expected, 'EXPECTED', 2, '.rstrip')}",
+      "",
+      "assert_equal expected, Grep.grep(pattern, flags, files)"
+    ]
+  end
+end

--- a/exercises/grep/.meta/generator/test_template.erb
+++ b/exercises/grep/.meta/generator/test_template.erb
@@ -1,0 +1,51 @@
+require 'minitest/autorun'
+require_relative '<%= exercise_name %>'
+
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
+class <%= exercise_test_classname %> < Minitest::Test
+  def setup
+    IO.write 'iliad.txt', <<~END
+      Achilles sing, O Goddess! Peleus' son;
+      His wrath pernicious, who ten thousand woes
+      Caused to Achaia's host, sent many a soul
+      Illustrious into Ades premature,
+      And Heroes gave (so stood the will of Jove)
+      To dogs and to all ravening fowls a prey,
+      When fierce dispute had separated once
+      The noble Chief Achilles from the son
+      Of Atreus, Agamemnon, King of men.
+    END
+
+    IO.write 'midsummer-night.txt', <<~END
+      I do entreat your grace to pardon me.
+      I know not by what power I am made bold,
+      Nor how it may concern my modesty,
+      In such a presence here to plead my thoughts;
+      But I beseech your grace that I may know
+      The worst that may befall me in this case,
+      If I refuse to wed Demetrius.
+    END
+
+    IO.write 'paradise-lost.txt', <<~END
+      Of Mans First Disobedience, and the Fruit
+      Of that Forbidden Tree, whose mortal tast
+      Brought Death into the World, and all our woe,
+      With loss of Eden, till one greater Man
+      Restore us, and regain the blissful Seat,
+      Sing Heav'nly Muse, that on the secret top
+      Of Oreb, or of Sinai, didst inspire
+      That Shepherd, who first taught the chosen Seed
+    END
+  end
+
+  def teardown
+    File.delete('iliad.txt')
+    File.delete('midsummer-night.txt')
+    File.delete('paradise-lost.txt')
+  end
+
+<%=
+  test_cases.map.with_index do |test_case, index|
+    test_case.to_s(index.zero?)
+  end.join("\n")
+%>end

--- a/exercises/grep/.meta/solutions/grep.rb
+++ b/exercises/grep/.meta/solutions/grep.rb
@@ -1,0 +1,51 @@
+class Grep
+  def self.grep(pattern, flags, files)
+    matched_lines = []
+
+    files.each do |file_name|
+      file = open(file_name)
+
+      file.each_line.map(&:chomp).each_with_index do |line, i|
+        if match?(line, pattern, flags)
+          matched_lines << [file_name, i + 1, line]
+        end
+      end
+    end
+
+    if flags.include?('-l')
+      format_files(matched_lines)
+    else
+      format_lines(matched_lines, files, flags)
+    end
+  end
+
+  def self.match?(line, pattern, flags)
+    modifiers = 'i' if flags.include?('-i') # case-insensitive
+    pattern = "^#{pattern}$" if flags.include?('-x') # match entire lines
+    regex = Regexp.new(pattern, modifiers)
+
+    return !regex.match?(line) if flags.include?('-v') # invert matching
+    regex.match?(line)
+  end
+
+  def self.format_files(matched_lines)
+    matched_lines.map do |file_name, _, _|
+      file_name
+    end.uniq.join("\n")
+  end
+
+  def self.format_lines(matched_lines, files, flags)
+    result = []
+
+    matched_lines.each do |file_name, line_number, line|
+      line_result = ''
+      line_result += file_name + ':' if files.size > 1
+      line_result += line_number.to_s + ':' if flags.include?('-n')
+      line_result += line
+
+      result << line_result
+    end
+
+    result.join("\n")
+  end
+end

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -1,0 +1,95 @@
+# Grep
+
+Search a file for lines matching a regular expression pattern. Return the line
+number and contents of each matching line.
+
+The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) command can be used to search for lines in one or more files
+that match a user-provided search query (known as the *pattern*).
+
+The `grep` command takes three arguments:
+
+1. The pattern used to match lines in a file.
+2. Zero or more flags to customize the matching behavior.
+3. One or more files in which to search for matching lines.
+
+Your task is to implement the `grep` function, which should read the contents
+of the specified files, find the lines that match the specified pattern
+and then output those lines as a single string. Note that the lines should
+be output in the order in which they were found, with the first matching line
+in the first file being output first.
+
+As an example, suppose there is a file named "input.txt" with the following contents:
+
+```text
+hello
+world
+hello again
+```
+
+If we were to call `grep "hello" input.txt`, the returned string should be:
+
+```text
+hello
+hello again
+```
+
+### Flags
+
+As said earlier, the `grep` command should also support the following flags:
+
+- `-n` Print the line numbers of each matching line.
+- `-l` Print only the names of files that contain at least one matching line.
+- `-i` Match line using a case-insensitive comparison.
+- `-v` Invert the program -- collect all lines that fail to match the pattern.
+- `-x` Only match entire lines, instead of lines that contain a match.
+
+If we run `grep -n "hello" input.txt`, the `-n` flag will require the matching
+lines to be prefixed with its line number:
+
+```text
+1:hello
+3:hello again
+```
+
+And if we run `grep -i "HELLO" input.txt`, we'll do a case-insensitive match,
+and the output will be:
+
+```text
+hello
+hello again
+```
+
+The `grep` command should support multiple flags at once.
+
+For example, running `grep -l -v "hello" file1.txt file2.txt` should
+print the names of files that do not contain the string "hello".
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby grep_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride grep_test.rb
+
+
+## Source
+
+Conversation with Nate Foster. [http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf](http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grep/grep_test.rb
+++ b/exercises/grep/grep_test.rb
@@ -1,0 +1,402 @@
+require 'minitest/autorun'
+require_relative 'grep'
+
+# Common test data version: 1.2.0 4f2efaa
+class GrepTest < Minitest::Test
+  def setup
+    IO.write 'iliad.txt', <<~END
+      Achilles sing, O Goddess! Peleus' son;
+      His wrath pernicious, who ten thousand woes
+      Caused to Achaia's host, sent many a soul
+      Illustrious into Ades premature,
+      And Heroes gave (so stood the will of Jove)
+      To dogs and to all ravening fowls a prey,
+      When fierce dispute had separated once
+      The noble Chief Achilles from the son
+      Of Atreus, Agamemnon, King of men.
+    END
+
+    IO.write 'midsummer-night.txt', <<~END
+      I do entreat your grace to pardon me.
+      I know not by what power I am made bold,
+      Nor how it may concern my modesty,
+      In such a presence here to plead my thoughts;
+      But I beseech your grace that I may know
+      The worst that may befall me in this case,
+      If I refuse to wed Demetrius.
+    END
+
+    IO.write 'paradise-lost.txt', <<~END
+      Of Mans First Disobedience, and the Fruit
+      Of that Forbidden Tree, whose mortal tast
+      Brought Death into the World, and all our woe,
+      With loss of Eden, till one greater Man
+      Restore us, and regain the blissful Seat,
+      Sing Heav'nly Muse, that on the secret top
+      Of Oreb, or of Sinai, didst inspire
+      That Shepherd, who first taught the chosen Seed
+    END
+  end
+
+  def teardown
+    File.delete('iliad.txt')
+    File.delete('midsummer-night.txt')
+    File.delete('paradise-lost.txt')
+  end
+
+  def test_one_file_one_match_no_flags
+    # skip
+    pattern = "Agamemnon"
+    flags = []
+    files = ["iliad.txt"]
+    expected = <<~EXPECTED.rstrip
+      Of Atreus, Agamemnon, King of men.
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_one_match_print_line_numbers_flag
+    skip
+    pattern = "Forbidden"
+    flags = ["-n"]
+    files = ["paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      2:Of that Forbidden Tree, whose mortal tast
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_one_match_case_insensitive_flag
+    skip
+    pattern = "FORBIDDEN"
+    flags = ["-i"]
+    files = ["paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      Of that Forbidden Tree, whose mortal tast
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_one_match_print_file_names_flag
+    skip
+    pattern = "Forbidden"
+    flags = ["-l"]
+    files = ["paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      paradise-lost.txt
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_one_match_match_entire_lines_flag
+    skip
+    pattern = "With loss of Eden, till one greater Man"
+    flags = ["-x"]
+    files = ["paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      With loss of Eden, till one greater Man
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_one_match_multiple_flags
+    skip
+    pattern = "OF ATREUS, Agamemnon, KIng of MEN."
+    flags = ["-n", "-i", "-x"]
+    files = ["iliad.txt"]
+    expected = <<~EXPECTED.rstrip
+      9:Of Atreus, Agamemnon, King of men.
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_several_matches_no_flags
+    skip
+    pattern = "may"
+    flags = []
+    files = ["midsummer-night.txt"]
+    expected = <<~EXPECTED.rstrip
+      Nor how it may concern my modesty,
+      But I beseech your grace that I may know
+      The worst that may befall me in this case,
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_several_matches_print_line_numbers_flag
+    skip
+    pattern = "may"
+    flags = ["-n"]
+    files = ["midsummer-night.txt"]
+    expected = <<~EXPECTED.rstrip
+      3:Nor how it may concern my modesty,
+      5:But I beseech your grace that I may know
+      6:The worst that may befall me in this case,
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_several_matches_match_entire_lines_flag
+    skip
+    pattern = "may"
+    flags = ["-x"]
+    files = ["midsummer-night.txt"]
+    expected = <<~EXPECTED.rstrip
+
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_several_matches_case_insensitive_flag
+    skip
+    pattern = "ACHILLES"
+    flags = ["-i"]
+    files = ["iliad.txt"]
+    expected = <<~EXPECTED.rstrip
+      Achilles sing, O Goddess! Peleus' son;
+      The noble Chief Achilles from the son
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_several_matches_inverted_flag
+    skip
+    pattern = "Of"
+    flags = ["-v"]
+    files = ["paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      Brought Death into the World, and all our woe,
+      With loss of Eden, till one greater Man
+      Restore us, and regain the blissful Seat,
+      Sing Heav'nly Muse, that on the secret top
+      That Shepherd, who first taught the chosen Seed
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_no_matches_various_flags
+    skip
+    pattern = "Gandalf"
+    flags = ["-n", "-l", "-x", "-i"]
+    files = ["iliad.txt"]
+    expected = <<~EXPECTED.rstrip
+
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_one_match_file_flag_takes_precedence_over_line_flag
+    skip
+    pattern = "ten"
+    flags = ["-n", "-l"]
+    files = ["iliad.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_one_file_several_matches_inverted_and_match_entire_lines_flags
+    skip
+    pattern = "Illustrious into Ades premature,"
+    flags = ["-x", "-v"]
+    files = ["iliad.txt"]
+    expected = <<~EXPECTED.rstrip
+      Achilles sing, O Goddess! Peleus' son;
+      His wrath pernicious, who ten thousand woes
+      Caused to Achaia's host, sent many a soul
+      And Heroes gave (so stood the will of Jove)
+      To dogs and to all ravening fowls a prey,
+      When fierce dispute had separated once
+      The noble Chief Achilles from the son
+      Of Atreus, Agamemnon, King of men.
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_one_match_no_flags
+    skip
+    pattern = "Agamemnon"
+    flags = []
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt:Of Atreus, Agamemnon, King of men.
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_several_matches_no_flags
+    skip
+    pattern = "may"
+    flags = []
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      midsummer-night.txt:Nor how it may concern my modesty,
+      midsummer-night.txt:But I beseech your grace that I may know
+      midsummer-night.txt:The worst that may befall me in this case,
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_several_matches_print_line_numbers_flag
+    skip
+    pattern = "that"
+    flags = ["-n"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      midsummer-night.txt:5:But I beseech your grace that I may know
+      midsummer-night.txt:6:The worst that may befall me in this case,
+      paradise-lost.txt:2:Of that Forbidden Tree, whose mortal tast
+      paradise-lost.txt:6:Sing Heav'nly Muse, that on the secret top
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_one_match_print_file_names_flag
+    skip
+    pattern = "who"
+    flags = ["-l"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt
+      paradise-lost.txt
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_several_matches_case_insensitive_flag
+    skip
+    pattern = "TO"
+    flags = ["-i"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt:Caused to Achaia's host, sent many a soul
+      iliad.txt:Illustrious into Ades premature,
+      iliad.txt:And Heroes gave (so stood the will of Jove)
+      iliad.txt:To dogs and to all ravening fowls a prey,
+      midsummer-night.txt:I do entreat your grace to pardon me.
+      midsummer-night.txt:In such a presence here to plead my thoughts;
+      midsummer-night.txt:If I refuse to wed Demetrius.
+      paradise-lost.txt:Brought Death into the World, and all our woe,
+      paradise-lost.txt:Restore us, and regain the blissful Seat,
+      paradise-lost.txt:Sing Heav'nly Muse, that on the secret top
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_several_matches_inverted_flag
+    skip
+    pattern = "a"
+    flags = ["-v"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt:Achilles sing, O Goddess! Peleus' son;
+      iliad.txt:The noble Chief Achilles from the son
+      midsummer-night.txt:If I refuse to wed Demetrius.
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_one_match_match_entire_lines_flag
+    skip
+    pattern = "But I beseech your grace that I may know"
+    flags = ["-x"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      midsummer-night.txt:But I beseech your grace that I may know
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_one_match_multiple_flags
+    skip
+    pattern = "WITH LOSS OF EDEN, TILL ONE GREATER MAN"
+    flags = ["-n", "-i", "-x"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      paradise-lost.txt:4:With loss of Eden, till one greater Man
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_no_matches_various_flags
+    skip
+    pattern = "Frodo"
+    flags = ["-n", "-l", "-x", "-i"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_several_matches_file_flag_takes_precedence_over_line_number_flag
+    skip
+    pattern = "who"
+    flags = ["-n", "-l"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt
+      paradise-lost.txt
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+
+  def test_multiple_files_several_matches_inverted_and_match_entire_lines_flags
+    skip
+    pattern = "Illustrious into Ades premature,"
+    flags = ["-x", "-v"]
+    files = ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+    expected = <<~EXPECTED.rstrip
+      iliad.txt:Achilles sing, O Goddess! Peleus' son;
+      iliad.txt:His wrath pernicious, who ten thousand woes
+      iliad.txt:Caused to Achaia's host, sent many a soul
+      iliad.txt:And Heroes gave (so stood the will of Jove)
+      iliad.txt:To dogs and to all ravening fowls a prey,
+      iliad.txt:When fierce dispute had separated once
+      iliad.txt:The noble Chief Achilles from the son
+      iliad.txt:Of Atreus, Agamemnon, King of men.
+      midsummer-night.txt:I do entreat your grace to pardon me.
+      midsummer-night.txt:I know not by what power I am made bold,
+      midsummer-night.txt:Nor how it may concern my modesty,
+      midsummer-night.txt:In such a presence here to plead my thoughts;
+      midsummer-night.txt:But I beseech your grace that I may know
+      midsummer-night.txt:The worst that may befall me in this case,
+      midsummer-night.txt:If I refuse to wed Demetrius.
+      paradise-lost.txt:Of Mans First Disobedience, and the Fruit
+      paradise-lost.txt:Of that Forbidden Tree, whose mortal tast
+      paradise-lost.txt:Brought Death into the World, and all our woe,
+      paradise-lost.txt:With loss of Eden, till one greater Man
+      paradise-lost.txt:Restore us, and regain the blissful Seat,
+      paradise-lost.txt:Sing Heav'nly Muse, that on the secret top
+      paradise-lost.txt:Of Oreb, or of Sinai, didst inspire
+      paradise-lost.txt:That Shepherd, who first taught the chosen Seed
+    EXPECTED
+
+    assert_equal expected, Grep.grep(pattern, flags, files)
+  end
+end


### PR DESCRIPTION
Closes #946.

### Implementation

The implementation was heavily influenced by [python's](https://github.com/exercism/python/blob/a83f53697a1a213967838a78b86f2b358727d76f/exercises/grep/example.py#L45). It can certainly be improved, but we may want to leave that for the mentor notes themselves, since the main goal here is to get CI to pass.

### Test Generation

The tests are generated using the [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/grep/canonical-data.json), but the file contents are hardcoded in a custom test template. I ended up doing this because I couldn't easily pass custom variables from the test case file to the ERB test template. Without that I can't parse the canonical data comments and make the file contents dynamic, like some tracks do.

I couldn't find other exercises that did anything close to this and looking at the generator code I didn't find a clear way to pass a `file_data` hash to the template file.

~Note: I really want to merge #929... Having the generator write `<<-EXPECTED.gsub(/^ */, '').strip` instead of `<<~EXPECTED` on the test file adds a layer of extra complexity we could easily avoid.~ We've merged this and I updated the code 👍.

@exercism/ruby 

**TODO**

- [x] Add to `config.json`
- [ ] Add issue to create mentor notes 