### PR TITLE
Revert "acronym: Update and exclude new tests"

### DIFF
--- a/exercises/acronym/.meta/generator/acronym_case.rb
+++ b/exercises/acronym/.meta/generator/acronym_case.rb
@@ -4,19 +4,4 @@ class AcronymCase < Generator::ExerciseCase
   def workload
     assert_equal(expected,  "Acronym.abbreviate('#{phrase}')")
   end
-
-  def to_s(*args)
-    super unless excluded_tests.include?(test_name)
-  end
-
-  private
-
-  # We exclude these tests because they currently don't fit the purpose
-  # we have for Acronym on the Ruby track.
-  def excluded_tests
-    %w(
-      test_apostrophes
-      test_underscore_emphasis
-    )
-  end
 end

--- a/exercises/acronym/acronym_test.rb
+++ b/exercises/acronym/acronym_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'acronym'
 
-# Common test data version: 1.7.0 cacf1f1
+# Common test data version: 1.5.0 787d24e
 class AcronymTest < Minitest::Test
   def test_basic
     # skip

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -6,5 +6,5 @@ class <%= exercise_test_classname %> < Minitest::Test
 <%=
   test_cases.map.with_index do |test_case, index|
     test_case.to_s(index.zero?)
-  end.compact.join("\n")
+  end.join("\n")
 %>end


### PR DESCRIPTION
Reverts exercism/ruby#950

Reverts so that template changes can be made on it's own merits.