### PR TITLE
[WIP] Handle test cases with to_s evaluating to nil

### DIFF
--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -6,5 +6,5 @@ class <%= exercise_test_classname %> < Minitest::Test
 <%=
   test_cases.map.with_index do |test_case, index|
     test_case.to_s(index.zero?)
-  end.join("\n")
+  end.compact.join("\n")
 %>end


### PR DESCRIPTION
This change makes it possible for `ExerciseCase`s to override the `to_s` method, returning `nil` for tests we don't want for the Ruby track. You can see an example of this on #953.

Without this change these excluded tests would still not appear on the generated test file, but an extra new-line would be present where they would be, given how:

```ruby
# Without the change:
[1, 2, nil, 4].join("\n")
# => "1\n2\n\n4"

# With the change:
[1, 2, nil, 4].compact.join("\n")
# => "1\n2\n4"
```

In practice, what this means is that, for example, on the Acronym update from #953 the generated test file `acronym_test.rb` will end with:

```ruby
  end
end
```

Instead of:

```ruby
  end


end
```

Note: #953 relies on this change.