### PR TITLE
[WIP] acronym: Update and exclude new tests

### DIFF
--- a/exercises/acronym/.meta/generator/acronym_case.rb
+++ b/exercises/acronym/.meta/generator/acronym_case.rb
@@ -4,4 +4,19 @@ class AcronymCase < Generator::ExerciseCase
   def workload
     assert_equal(expected,  "Acronym.abbreviate('#{phrase}')")
   end
+
+  def to_s(*args)
+    super unless excluded_tests.include?(test_name)
+  end
+
+  private
+
+  # We exclude these tests because they currently don't fit the purpose
+  # we have for Acronym on the Ruby track.
+  def excluded_tests
+    %w(
+      test_apostrophes
+      test_underscore_emphasis
+    )
+  end
 end

--- a/exercises/acronym/acronym_test.rb
+++ b/exercises/acronym/acronym_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'acronym'
 
-# Common test data version: 1.5.0 787d24e
+# Common test data version: 1.7.0 cacf1f1
 class AcronymTest < Minitest::Test
   def test_basic
     # skip


### PR DESCRIPTION
Note: this PR was initially merged and reverted (#950). This new version separates the changes to the test template into its own PR (#952). This PR thus depends on PR #952.

We've [recently](https://github.com/exercism/ruby/pull/931#discussion_r251869850) stopped updating the Acronym exercise because of two new test cases:

* `test_apostrophes` (introduced by https://github.com/exercism/problem-specifications/pull/1377)
* `test_underscore_emphasis` (introduced by https://github.com/exercism/problem-specifications/pull/1436)

This PR changes the generator to automatically exclude these two test cases. With this change we can still get updates from the canonical version without adding the tests we don't want at the same time.

If the idea of excluding certain tests proves useful we may want to consider supporting it in the base `ExerciseCase` so it can be easily be used by other generators.