### PR TITLE
Move ETL close to WordCount

### DIFF
--- a/config.json
+++ b/config.json
@@ -420,8 +420,8 @@
       "slug": "etl",
       "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
       "core": false,
-      "unlocked_by": "scrabble-score",
-      "difficulty": 1,
+      "unlocked_by": "word-count",
+      "difficulty": 4,
       "topics": [
         "loops",
         "maps",


### PR DESCRIPTION
- This is preparing for promoting ETL to a core exercise. As a core, ETL should go just after Word Count. Let's first check if, as a side,  it isn't too hard on this point in the track by making it unlocked by WordCount.   
- The difficulty score is arbitrary; the Track Anatomy Project didn't touch those yet. I just made it one step more difficult than WordCount.

@exercism/ruby 