### PR TITLE
PrimeFactors: Replace `for` with `of` (for is a Ruby keyword)

### DIFF
--- a/exercises/prime-factors/.meta/solutions/prime_factors.rb
+++ b/exercises/prime-factors/.meta/solutions/prime_factors.rb
@@ -1,5 +1,5 @@
 class PrimeFactors
-  def self.for(number)
+  def self.of(number)
     factors = []
     divisor = 2
     while number > 1

--- a/exercises/prime-factors/prime_factors_test.rb
+++ b/exercises/prime-factors/prime_factors_test.rb
@@ -3,56 +3,56 @@ require_relative 'prime_factors'
 
 class PrimeFactorsTest < Minitest::Test
   def test_1
-    assert_equal [], PrimeFactors.for(1)
+    assert_equal [], PrimeFactors.of(1)
   end
 
   def test_2
     skip
-    assert_equal [2], PrimeFactors.for(2)
+    assert_equal [2], PrimeFactors.of(2)
   end
 
   def test_3
     skip
-    assert_equal [3], PrimeFactors.for(3)
+    assert_equal [3], PrimeFactors.of(3)
   end
 
   def test_4
     skip
-    assert_equal [2, 2], PrimeFactors.for(4)
+    assert_equal [2, 2], PrimeFactors.of(4)
   end
 
   def test_6
     skip
-    assert_equal [2, 3], PrimeFactors.for(6)
+    assert_equal [2, 3], PrimeFactors.of(6)
   end
 
   def test_8
     skip
-    assert_equal [2, 2, 2], PrimeFactors.for(8)
+    assert_equal [2, 2, 2], PrimeFactors.of(8)
   end
 
   def test_9
     skip
-    assert_equal [3, 3], PrimeFactors.for(9)
+    assert_equal [3, 3], PrimeFactors.of(9)
   end
 
   def test_27
     skip
-    assert_equal [3, 3, 3], PrimeFactors.for(27)
+    assert_equal [3, 3, 3], PrimeFactors.of(27)
   end
 
   def test_625
     skip
-    assert_equal [5, 5, 5, 5], PrimeFactors.for(625)
+    assert_equal [5, 5, 5, 5], PrimeFactors.of(625)
   end
 
   def test_901255
     skip
-    assert_equal [5, 17, 23, 461], PrimeFactors.for(901_255)
+    assert_equal [5, 17, 23, 461], PrimeFactors.of(901_255)
   end
 
   def test_93819012551
     skip
-    assert_equal [11, 9539, 894_119], PrimeFactors.for(93_819_012_551)
+    assert_equal [11, 9539, 894_119], PrimeFactors.of(93_819_012_551)
   end
 end


### PR DESCRIPTION
`for` is a Ruby keyword, so this is just bad naming if you ask me.