### PR TITLE
Promote Resistor Color Duo to core

### DIFF
--- a/config.json
+++ b/config.json
@@ -304,7 +304,7 @@
       "slug": "leap",
       "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
       "core": false,
-      "unlocked_by": "two-fer",
+      "unlocked_by": "resistor-color-duo",
       "difficulty": 1,
       "topics": [
         "booleans",

--- a/config.json
+++ b/config.json
@@ -27,6 +27,16 @@
         "strings"
       ]
     },
+    { "slug": "resistor-color-duo",
+      "uuid": "57b0c57e-26a5-4ccf-aaf2-2fefddd918c1",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "array",
+        "loops"
+      ]
+    },
     {
       "slug": "acronym",
       "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
@@ -219,16 +229,6 @@
       "topics": [
         "bitwise_operations",
         "math"
-      ]
-    },
-    { "slug": "resistor-color-duo",
-      "uuid": "57b0c57e-26a5-4ccf-aaf2-2fefddd918c1",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "array",
-        "loops"
       ]
     },
     {


### PR DESCRIPTION
Resistor Color Duo was introduced in March, and added as a side exercise on [Level 1](https://github.com/exercism/ruby/issues/969) first.
As a core exercise, it brings in the `integer` datatype to level 1, and a simple array iterator (for beginners) or reading values from a hash. 
Looking at the [community solutions](https://exercism.io/tracks/ruby/exercises/resistor-color-duo/solutions), there's lots of opportunities to guide to more idiomatic Ruby.

(cc ~@exercism/track-maintainers~ Ruby maintainers)