### PR TITLE
ResistorColorDuo: Remove unclear mention of "encoding"

### DIFF
--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -6,9 +6,9 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
-In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
+In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the resistance value.
 
-The band colors are encoded as follows:
+The band colors and associated values are as follows:
 
 - Black: 0
 - Brown: 1


### PR DESCRIPTION
Encoding has a very specific meaning and using that word in the instructions was confusing and contradicts the test cases.

The test cases actually don't specify how "Brown" should be decoded at all.