### PR TITLE
Move flatten array up in the track

### DIFF
--- a/config.json
+++ b/config.json
@@ -559,8 +559,8 @@
       "slug": "flatten-array",
       "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
       "core": false,
-      "unlocked_by": "hello-world",
-      "difficulty": 1,
+      "unlocked_by": "series",
+      "difficulty": 3,
       "topics": [
         "arrays",
         "recursion"


### PR DESCRIPTION
See #970
Resistor Color (#1 in the series) is added to the track as a side exercise, unlocked by Hello World.
The main reason to add the exercise was to have a replacement for Flatten Array. 
Flatten Array is not a nice exercise as an introduction to the track, because it's either just using the `Array#flatten` or reimplementing this built in method. 
Let's see if people have fun with if we move it to a later position, and if not, we can remove it from the track alltogether.

PS I changed the difficulty to 3, as a non-official way to reference the [level](#969). In the UI, it's still marked 'easy', AFAIK.  