### PR TITLE
Update transpose test case with new case_helper method.

### DIFF
--- a/config.json
+++ b/config.json
@@ -559,8 +559,8 @@
       "slug": "flatten-array",
       "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
       "core": false,
-      "unlocked_by": "hello-world",
-      "difficulty": 1,
+      "unlocked_by": "series",
+      "difficulty": 3,
       "topics": [
         "arrays",
         "recursion"

--- a/exercises/transpose/.meta/generator/transpose_case.rb
+++ b/exercises/transpose/.meta/generator/transpose_case.rb
@@ -4,18 +4,12 @@ class TransposeCase < Generator::ExerciseCase
 
   def workload
     [
-      "input = #{indent_heredoc(input_lines, 'INPUT', 2, delimiter_mod)}",
+      "input = #{to_string(lines)}",
       "",
-      "expected = #{indent_heredoc(expected, 'EXPECTED', 2, delimiter_mod)}",
+      "expected = #{to_string(expected)}",
       "",
-      "assert_equal expected, Transpose.transpose(input)",
+      "assert_equal expected, Transpose.transpose(input)"
     ]
-  end
-
-  private
-
-  def delimiter_mod
-    ".strip"
   end
 
 end

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -5,238 +5,99 @@ require_relative 'transpose'
 class TransposeTest < Minitest::Test
   def test_empty_string
     # skip
-    input = <<~INPUT.strip
+    input = ""
 
-    INPUT
-
-    expected = <<~EXPECTED.strip
-
-    EXPECTED
+    expected = ""
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_two_characters_in_a_row
     skip
-    input = <<~INPUT.strip
-      A1
-    INPUT
+    input = "A1"
 
-    expected = <<~EXPECTED.strip
-      A
-      1
-    EXPECTED
+    expected = "A\n1"
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_two_characters_in_a_column
     skip
-    input = <<~INPUT.strip
-      A
-      1
-    INPUT
+    input = "A\n1"
 
-    expected = <<~EXPECTED.strip
-      A1
-    EXPECTED
+    expected = "A1"
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_simple
     skip
-    input = <<~INPUT.strip
-      ABC
-      123
-    INPUT
+    input = "ABC\n123"
 
-    expected = <<~EXPECTED.strip
-      A1
-      B2
-      C3
-    EXPECTED
+    expected = "A1\nB2\nC3"
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_single_line
     skip
-    input = <<~INPUT.strip
-      Single line.
-    INPUT
+    input = "Single line."
 
-    expected = <<~EXPECTED.strip
-      S
-      i
-      n
-      g
-      l
-      e
-       
-      l
-      i
-      n
-      e
-      .
-    EXPECTED
+    expected = "S\ni\nn\ng\nl\ne\n \nl\ni\nn\ne\n."
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_first_line_longer_than_second_line
     skip
-    input = <<~INPUT.strip
-      The fourth line.
-      The fifth line.
-    INPUT
+    input = "The fourth line.\nThe fifth line."
 
-    expected = <<~EXPECTED.strip
-      TT
-      hh
-      ee
-        
-      ff
-      oi
-      uf
-      rt
-      th
-      h 
-       l
-      li
-      in
-      ne
-      e.
-      .
-    EXPECTED
+    expected = "TT\nhh\nee\n  \nff\noi\nuf\nrt\nth\nh \n l\nli\nin\nne\ne.\n."
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_second_line_longer_than_first_line
     skip
-    input = <<~INPUT.strip
-      The first line.
-      The second line.
-    INPUT
+    input = "The first line.\nThe second line."
 
-    expected = <<~EXPECTED.strip
-      TT
-      hh
-      ee
-        
-      fs
-      ie
-      rc
-      so
-      tn
-       d
-      l 
-      il
-      ni
-      en
-      .e
-       .
-    EXPECTED
+    expected = "TT\nhh\nee\n  \nfs\nie\nrc\nso\ntn\n d\nl \nil\nni\nen\n.e\n ."
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_mixed_line_length
     skip
-    input = <<~INPUT.strip
-      The longest line.
-      A long line.
-      A longer line.
-      A line.
-    INPUT
+    input = "The longest line.\nA long line.\nA longer line.\nA line."
 
-    expected = <<~EXPECTED.strip
-      TAAA
-      h   
-      elll
-       ooi
-      lnnn
-      ogge
-      n e.
-      glr
-      ei 
-      snl
-      tei
-       .n
-      l e
-      i .
-      n
-      e
-      .
-    EXPECTED
+    expected = "TAAA\nh   \nelll\n ooi\nlnnn\nogge\nn e.\nglr\nei \nsnl\ntei\n .n\nl e\ni .\nn\ne\n."
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_square
     skip
-    input = <<~INPUT.strip
-      HEART
-      EMBER
-      ABUSE
-      RESIN
-      TREND
-    INPUT
+    input = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
 
-    expected = <<~EXPECTED.strip
-      HEART
-      EMBER
-      ABUSE
-      RESIN
-      TREND
-    EXPECTED
+    expected = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_rectangle
     skip
-    input = <<~INPUT.strip
-      FRACTURE
-      OUTLINED
-      BLOOMING
-      SEPTETTE
-    INPUT
+    input = "FRACTURE\nOUTLINED\nBLOOMING\nSEPTETTE"
 
-    expected = <<~EXPECTED.strip
-      FOBS
-      RULE
-      ATOP
-      CLOT
-      TIME
-      UNIT
-      RENT
-      EDGE
-    EXPECTED
+    expected = "FOBS\nRULE\nATOP\nCLOT\nTIME\nUNIT\nRENT\nEDGE"
 
     assert_equal expected, Transpose.transpose(input)
   end
 
   def test_triangle
     skip
-    input = <<~INPUT.strip
-      T
-      EE
-      AAA
-      SSSS
-      EEEEE
-      RRRRRR
-    INPUT
+    input = "T\nEE\nAAA\nSSSS\nEEEEE\nRRRRRR"
 
-    expected = <<~EXPECTED.strip
-      TEASER
-       EASER
-        ASER
-         SER
-          ER
-           R
-    EXPECTED
+    expected = "TEASER\n EASER\n  ASER\n   SER\n    ER\n     R"
 
     assert_equal expected, Transpose.transpose(input)
   end

--- a/lib/generator/exercise_case/case_helpers.rb
+++ b/lib/generator/exercise_case/case_helpers.rb
@@ -26,6 +26,15 @@ module Generator
         ].join("\n")
       end
 
+      # combine array of string elements into a single string
+      # as part of workload with optional separator
+      #
+      #  example usage:  to_string(["foo", "bar"])
+      #  example output: "foo\nbar"
+      def to_string(phrases, separator="\n")
+        phrases.join(separator).inspect
+      end
+
       def underscore(number)
         fail ArgumentError, "#{number.inspect} is not an Integer" unless number.is_a? Integer
         number.to_s.reverse.gsub(/...(?=.)/, '\&_').reverse

--- a/test/generator/exercise_case/case_helpers_test.rb
+++ b/test/generator/exercise_case/case_helpers_test.rb
@@ -53,9 +53,36 @@ module Generator
           indent_heredoc(["foo", "bar"], 'TEXT', 1)
         end
       end
+
       def test_heredoc
         expected = "<<~TEXT\n foo\n bar\nTEXT"
         assert_equal expected, HeredocCase.new.workload
+      end
+
+      class ToStringCase
+        include CaseHelpers
+
+        def workload(phrases)
+          to_string(phrases)
+        end
+      end
+
+      def test_to_string_with_two_strings
+        phrases = ["foo", "bar"]
+        expected = "foo\nbar".inspect
+        assert_equal expected, ToStringCase.new.workload(phrases)
+      end
+
+      def test_to_string_with_string_and_integer
+        phrases = ["foo", 123]
+        expected = "foo\n123".inspect
+        assert_equal expected, ToStringCase.new.workload(phrases)
+      end
+
+      def test_to_string_with_string_and_nil
+        phrases = ["foo", nil]
+        expected = "foo\n".inspect
+        assert_equal expected, ToStringCase.new.workload(phrases)
       end
     end
   end


### PR DESCRIPTION
Issue #949 indicates that it would be preferable to display the `input` and `expected` values as a single-line string rather than as a heredoc. 

From the issue:

    input = "ABC\n123"
    
    # instead of the current
    
    input = <<~INPUT.strip
        ABC
        123
    INPUT


In this pull request, I have made the following changes:

- Create a new case_helper method that can take an array of strings and display with a separator defaulting to `"\n"`.
- Update `transpose_case.rb` so that it uses this `on_single_line` case helper where it previously used `indent_heredoc`.
- Generate updated test cases for `transpose_test.rb`.

All test cases still complete successfully after changes.

Please let me know if I can make any additional changes. Thanks!