### PR TITLE
atbash-cipher: implemented generator

### DIFF
--- a/exercises/atbash-cipher/.meta/generator/atbash_cipher_case.rb
+++ b/exercises/atbash-cipher/.meta/generator/atbash_cipher_case.rb
@@ -1,0 +1,27 @@
+require 'generator/exercise_case'
+
+class AtbashCipherCase < Generator::ExerciseCase
+  def workload
+    case property
+    when 'encode' then encode_workload
+    when 'decode' then decode_workload
+    else raise 'unexpected property encountered'
+    end
+  end
+
+  def encode_workload
+    [
+      "plaintext = '#{phrase}'",
+      "ciphertext = '#{expected}'",
+      "assert_equal ciphertext, AtbashCipher.encode(plaintext)"
+    ].join("\n")
+  end
+
+  def decode_workload
+    [
+      "ciphertext = '#{phrase}'",
+      "plaintext = '#{expected}'",
+      "assert_equal plaintext, AtbashCipher.decode(ciphertext)"
+    ].join("\n")
+  end
+end

--- a/exercises/atbash-cipher/.meta/generator/atbash_cipher_case.rb
+++ b/exercises/atbash-cipher/.meta/generator/atbash_cipher_case.rb
@@ -14,7 +14,7 @@ class AtbashCipherCase < Generator::ExerciseCase
       "plaintext = '#{phrase}'",
       "ciphertext = '#{expected}'",
       "assert_equal ciphertext, Atbash.encode(plaintext)"
-    ].join("\n")
+    ]
   end
 
   def decode_workload
@@ -22,6 +22,6 @@ class AtbashCipherCase < Generator::ExerciseCase
       "ciphertext = '#{phrase}'",
       "plaintext = '#{expected}'",
       "assert_equal plaintext, Atbash.decode(ciphertext)"
-    ].join("\n")
+    ]
   end
 end

--- a/exercises/atbash-cipher/.meta/generator/atbash_cipher_case.rb
+++ b/exercises/atbash-cipher/.meta/generator/atbash_cipher_case.rb
@@ -13,7 +13,7 @@ class AtbashCipherCase < Generator::ExerciseCase
     [
       "plaintext = '#{phrase}'",
       "ciphertext = '#{expected}'",
-      "assert_equal ciphertext, AtbashCipher.encode(plaintext)"
+      "assert_equal ciphertext, Atbash.encode(plaintext)"
     ].join("\n")
   end
 
@@ -21,7 +21,7 @@ class AtbashCipherCase < Generator::ExerciseCase
     [
       "ciphertext = '#{phrase}'",
       "plaintext = '#{expected}'",
-      "assert_equal plaintext, AtbashCipher.decode(ciphertext)"
+      "assert_equal plaintext, Atbash.decode(ciphertext)"
     ].join("\n")
   end
 end

--- a/exercises/atbash-cipher/.meta/solutions/atbash_cipher.rb
+++ b/exercises/atbash-cipher/.meta/solutions/atbash_cipher.rb
@@ -1,4 +1,4 @@
-class AtbashCipher
+class Atbash
   def self.encode(plaintext)
     new(plaintext).encode
   end
@@ -14,25 +14,25 @@ class AtbashCipher
   end
 
   def encode
-    chunk convert(normalize(text))
+    chunk(convert)
   end
 
   def decode
-    convert(normalize(text))
+    convert
   end
 
   private
 
-  def convert(s)
-    s.tr(alphabet, key)
+  def convert
+    normalize.tr(alphabet, key)
   end
 
   def chunk(s)
     s.scan(/.{1,5}/).join(' ')
   end
 
-  def normalize(s)
-    s.downcase.gsub(/[^a-z0-9]/, '')
+  def normalize
+    text.downcase.gsub(/[^a-z0-9]/, '')
   end
 
   def alphabet

--- a/exercises/atbash-cipher/.meta/solutions/atbash_cipher.rb
+++ b/exercises/atbash-cipher/.meta/solutions/atbash_cipher.rb
@@ -1,16 +1,24 @@
-class Atbash
+class AtbashCipher
   def self.encode(plaintext)
     new(plaintext).encode
   end
 
-  attr_reader :plaintext
+  def self.decode(ciphertext)
+    new(ciphertext).decode
+  end
 
-  def initialize(plaintext)
-    @plaintext = plaintext
+  attr_reader :text
+
+  def initialize(text)
+    @text = text
   end
 
   def encode
-    chunk convert(normalize(plaintext))
+    chunk convert(normalize(text))
+  end
+
+  def decode
+    convert(normalize(text))
   end
 
   private

--- a/exercises/atbash-cipher/atbash_cipher_test.rb
+++ b/exercises/atbash-cipher/atbash_cipher_test.rb
@@ -7,97 +7,97 @@ class AtbashCipherTest < Minitest::Test
     # skip
     plaintext = 'yes'
     ciphertext = 'bvh'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_no
     skip
     plaintext = 'no'
     ciphertext = 'ml'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_omg
     skip
     plaintext = 'OMG'
     ciphertext = 'lnt'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_spaces
     skip
     plaintext = 'O M G'
     ciphertext = 'lnt'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_mindblowingly
     skip
     plaintext = 'mindblowingly'
     ciphertext = 'nrmwy oldrm tob'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_numbers
     skip
     plaintext = 'Testing,1 2 3, testing.'
     ciphertext = 'gvhgr mt123 gvhgr mt'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_deep_thought
     skip
     plaintext = 'Truth is fiction.'
     ciphertext = 'gifgs rhurx grlm'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_encode_all_the_letters
     skip
     plaintext = 'The quick brown fox jumps over the lazy dog.'
     ciphertext = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
-    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+    assert_equal ciphertext, Atbash.encode(plaintext)
   end
 
   def test_decode_exercism
     skip
     ciphertext = 'vcvix rhn'
     plaintext = 'exercism'
-    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+    assert_equal plaintext, Atbash.decode(ciphertext)
   end
 
   def test_decode_a_sentence
     skip
     ciphertext = 'zmlyh gzxov rhlug vmzhg vkkrm thglm v'
     plaintext = 'anobstacleisoftenasteppingstone'
-    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+    assert_equal plaintext, Atbash.decode(ciphertext)
   end
 
   def test_decode_numbers
     skip
     ciphertext = 'gvhgr mt123 gvhgr mt'
     plaintext = 'testing123testing'
-    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+    assert_equal plaintext, Atbash.decode(ciphertext)
   end
 
   def test_decode_all_the_letters
     skip
     ciphertext = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
     plaintext = 'thequickbrownfoxjumpsoverthelazydog'
-    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+    assert_equal plaintext, Atbash.decode(ciphertext)
   end
 
   def test_decode_with_too_many_spaces
     skip
     ciphertext = 'vc vix    r hn'
     plaintext = 'exercism'
-    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+    assert_equal plaintext, Atbash.decode(ciphertext)
   end
 
   def test_decode_with_no_spaces
     skip
     ciphertext = 'zmlyhgzxovrhlugvmzhgvkkrmthglmv'
     plaintext = 'anobstacleisoftenasteppingstone'
-    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+    assert_equal plaintext, Atbash.decode(ciphertext)
   end
 end

--- a/exercises/atbash-cipher/atbash_cipher_test.rb
+++ b/exercises/atbash-cipher/atbash_cipher_test.rb
@@ -1,46 +1,103 @@
 require 'minitest/autorun'
 require_relative 'atbash_cipher'
 
-class AtbashTest < Minitest::Test
-  def test_encode_no
-    assert_equal 'ml', Atbash.encode('no')
-  end
-
+# Common test data version: 1.2.0 d5238bd
+class AtbashCipherTest < Minitest::Test
   def test_encode_yes
-    skip
-    assert_equal 'bvh', Atbash.encode('yes')
+    # skip
+    plaintext = 'yes'
+    ciphertext = 'bvh'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
   end
 
-  def test_encode_OMG
+  def test_encode_no
     skip
-    assert_equal 'lnt', Atbash.encode('OMG')
+    plaintext = 'no'
+    ciphertext = 'ml'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
   end
 
-  def test_encode_O_M_G
+  def test_encode_omg
     skip
-    assert_equal 'lnt', Atbash.encode('O M G')
+    plaintext = 'OMG'
+    ciphertext = 'lnt'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
   end
 
-  def test_encode_long_word
+  def test_encode_spaces
     skip
-    assert_equal 'nrmwy oldrm tob', Atbash.encode('mindblowingly')
+    plaintext = 'O M G'
+    ciphertext = 'lnt'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+  end
+
+  def test_encode_mindblowingly
+    skip
+    plaintext = 'mindblowingly'
+    ciphertext = 'nrmwy oldrm tob'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
   end
 
   def test_encode_numbers
     skip
-    assert_equal('gvhgr mt123 gvhgr mt',
-                 Atbash.encode('Testing, 1 2 3, testing.'))
+    plaintext = 'Testing,1 2 3, testing.'
+    ciphertext = 'gvhgr mt123 gvhgr mt'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
   end
 
-  def test_encode_sentence
+  def test_encode_deep_thought
     skip
-    assert_equal 'gifgs rhurx grlm', Atbash.encode('Truth is fiction.')
+    plaintext = 'Truth is fiction.'
+    ciphertext = 'gifgs rhurx grlm'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
   end
 
-  def test_encode_all_the_things
+  def test_encode_all_the_letters
     skip
     plaintext = 'The quick brown fox jumps over the lazy dog.'
-    cipher = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
-    assert_equal cipher, Atbash.encode(plaintext)
+    ciphertext = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+    assert_equal ciphertext, AtbashCipher.encode(plaintext)
+  end
+
+  def test_decode_exercism
+    skip
+    ciphertext = 'vcvix rhn'
+    plaintext = 'exercism'
+    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+  end
+
+  def test_decode_a_sentence
+    skip
+    ciphertext = 'zmlyh gzxov rhlug vmzhg vkkrm thglm v'
+    plaintext = 'anobstacleisoftenasteppingstone'
+    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+  end
+
+  def test_decode_numbers
+    skip
+    ciphertext = 'gvhgr mt123 gvhgr mt'
+    plaintext = 'testing123testing'
+    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+  end
+
+  def test_decode_all_the_letters
+    skip
+    ciphertext = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+    plaintext = 'thequickbrownfoxjumpsoverthelazydog'
+    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+  end
+
+  def test_decode_with_too_many_spaces
+    skip
+    ciphertext = 'vc vix    r hn'
+    plaintext = 'exercism'
+    assert_equal plaintext, AtbashCipher.decode(ciphertext)
+  end
+
+  def test_decode_with_no_spaces
+    skip
+    ciphertext = 'zmlyhgzxovrhlugvmzhgvkkrmthglmv'
+    plaintext = 'anobstacleisoftenasteppingstone'
+    assert_equal plaintext, AtbashCipher.decode(ciphertext)
   end
 end


### PR DESCRIPTION
[canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/atbash-cipher/canonical-data.json)

This exercise was only half implemented before, so I had to change the solution.

I regenerated the `README.md`, but there was no change.
