### PR TITLE
high-scores: Add latest_is_personal_best?

### DIFF
--- a/exercises/high-scores/.meta/generator/high_scores_case.rb
+++ b/exercises/high-scores/.meta/generator/high_scores_case.rb
@@ -4,8 +4,27 @@ class HighScoresCase < Generator::ExerciseCase
   def workload
     [
       "scores = #{scores}",
+      assertions
+    ].flatten
+  end
+
+  private
+
+  def assertions
+    case property
+    when 'latestIsPersonalBest' then boolean_assertion
+    else regular_assertion
+    end
+  end
+
+  def regular_assertion
+    [
       "expected = #{expected.inspect}",
       "assert_equal expected, HighScores.new(scores).#{snake_case(property)}"
     ]
+  end
+
+  def boolean_assertion
+    assert_or_refute(expected, "HighScores.new(scores).#{snake_case(property)}?")
   end
 end

--- a/exercises/high-scores/.meta/solutions/high_scores.rb
+++ b/exercises/high-scores/.meta/solutions/high_scores.rb
@@ -18,4 +18,8 @@ class HighScores
   def personal_top_three
     scores.max(3)
   end
+
+  def latest_is_personal_best?
+    latest == personal_best
+  end
 end

--- a/exercises/high-scores/high_scores_test.rb
+++ b/exercises/high-scores/high_scores_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'high_scores'
 
-# Common test data version: 4.0.0 ad1f9c4
+# Common test data version: 5.0.0 7dfb96c
 class HighScoresTest < Minitest::Test
   def test_list_of_scores
     # skip
@@ -57,5 +57,17 @@ class HighScoresTest < Minitest::Test
     scores = [40]
     expected = [40]
     assert_equal expected, HighScores.new(scores).personal_top_three
+  end
+
+  def test_latest_score_is_not_the_personal_best
+    skip
+    scores = [100, 40, 10, 70]
+    refute HighScores.new(scores).latest_is_personal_best?
+  end
+
+  def test_latest_score_is_the_personal_best
+    skip
+    scores = [70, 40, 10, 100]
+    assert HighScores.new(scores).latest_is_personal_best?
   end
 end


### PR DESCRIPTION
https://github.com/exercism/problem-specifications/pull/1564 added a new method to high-scores: `latestIsPersonalBest`. This PR adds that method to our implementation and tests.