### PR TITLE
resistor-color-trio: New exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1208,6 +1208,16 @@
       "topics": [
         "arrays"
       ]
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "2df14b68-75c8-4984-8ae2-ecd2cb7ed1d4",
+      "core": false,
+      "unlocked_by": "high-scores",
+      "difficulty": 4,
+      "topics": [
+        "loops"
+      ]
     }
   ]
 }

--- a/exercises/resistor-color-trio/.meta/generator/resistor_color_trio_case.rb
+++ b/exercises/resistor-color-trio/.meta/generator/resistor_color_trio_case.rb
@@ -1,0 +1,21 @@
+require 'generator/exercise_case'
+
+class ResistorColorTrioCase < Generator::ExerciseCase
+  def workload
+    if error_expected?
+      assert_raises(ArgumentError, subject_of_test)
+    else
+      assert_equal(expected, subject_of_test)
+    end
+  end
+
+  private
+
+  def subject_of_test
+    "ResistorColorTrio.new(#{colors}).label"
+  end
+
+  def expected
+    "Resistor value: #{super['value']} #{super['unit']}"
+  end
+end

--- a/exercises/resistor-color-trio/.meta/solutions/resistor_color_trio.rb
+++ b/exercises/resistor-color-trio/.meta/solutions/resistor_color_trio.rb
@@ -1,0 +1,40 @@
+class ResistorColorTrio
+  COLOR_CODES = %i[black brown red orange yellow green blue violet grey white].freeze
+
+  def initialize(colors)
+    @colors = colors.map(&:to_sym)
+    @tens, @ones, @zeros = @colors
+  end
+
+  def label
+    "Resistor value: #{to_s}"
+  end
+
+  private
+
+  attr_reader :tens, :ones, :zeros
+
+  def significants
+    COLOR_CODES.index(tens) * 10 + COLOR_CODES.index(ones)
+  end
+
+  def multiplier
+    @multiplier ||= 10.pow(COLOR_CODES.index(zeros))
+  end
+
+  def value
+    raise ArgumentError.new('Invalid color') unless valid_colors?
+
+    significants * multiplier
+  end
+
+  def to_s
+    value < 1000 ? "#{value} ohms" : "#{(value.to_f/1000).to_i} kiloohms"
+  end
+
+  def valid_colors?
+    COLOR_CODES.include?(tens) && \
+      COLOR_CODES.include?(ones) && \
+      COLOR_CODES.include?(zeros)
+  end
+end

--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -4,21 +4,12 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 
 - Each resistor has a resistance value.
 - Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
-  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 - Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
   In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
-  The color bands are encoded as follows:
+  The colors are mapped to the numbers from 0 to 9 in the sequence:
 
-* Black: 0
-* Brown: 1
-* Red: 2
-* Orange: 3
-* Yellow: 4
-* Green: 5
-* Blue: 6
-* Violet: 7
-* Grey: 8
-* White: 9
+Black - Brown - Red - Orange - Yellow - Green - Blue - Violet - Grey - White
 
 In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
 The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.

--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -1,0 +1,75 @@
+# Resistor Color Trio
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know only three things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+  The color bands are encoded as follows:
+
+* Black: 0
+* Brown: 1
+* Red: 2
+* Orange: 3
+* Yellow: 4
+* Green: 5
+* Blue: 6
+* Violet: 7
+* Grey: 8
+* White: 9
+
+In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.
+For the exercise it doesn't matter what ohms really are.
+For example:
+
+- orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
+- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
+
+(If Math is your thing, you may want to think of the zeros as exponents of 10. If Math is not your thing, go with the zeros. It really is the same thing, just in plain English instead of Math lingo.)
+
+This exercise is about translating the colors into a label:
+
+> "... ohms"
+
+So an input of `"orange", "orange", "black"` should return:
+
+> "33 ohms"
+
+When we get more than a thousand ohms, we say "kiloohms". That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+So an input of `"orange", "orange", "orange"` should return:
+
+> "33 kiloohms"
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby resistor_color_trio_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride resistor_color_trio_test.rb
+
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1549](https://github.com/exercism/problem-specifications/issues/1549)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-trio/resistor_color_trio_test.rb
+++ b/exercises/resistor-color-trio/resistor_color_trio_test.rb
@@ -1,0 +1,37 @@
+require 'minitest/autorun'
+require_relative 'resistor_color_trio'
+
+# Common test data version: 1.1.0 2c41a51
+class ResistorColorTrioTest < Minitest::Test
+  def test_orange_and_orange_and_black
+    # skip
+    assert_equal "Resistor value: 33 ohms", ResistorColorTrio.new(["orange", "orange", "black"]).label
+  end
+
+  def test_blue_and_grey_and_brown
+    skip
+    assert_equal "Resistor value: 680 ohms", ResistorColorTrio.new(["blue", "grey", "brown"]).label
+  end
+
+  def test_red_and_black_and_red
+    skip
+    assert_equal "Resistor value: 2 kiloohms", ResistorColorTrio.new(["red", "black", "red"]).label
+  end
+
+  def test_green_and_brown_and_orange
+    skip
+    assert_equal "Resistor value: 51 kiloohms", ResistorColorTrio.new(["green", "brown", "orange"]).label
+  end
+
+  def test_yellow_and_violet_and_yellow
+    skip
+    assert_equal "Resistor value: 470 kiloohms", ResistorColorTrio.new(["yellow", "violet", "yellow"]).label
+  end
+
+  def test_invalid_color
+    skip
+    assert_raises(ArgumentError) do
+      ResistorColorTrio.new(["yellow", "purple", "black"]).label
+    end
+  end
+end


### PR DESCRIPTION
Closes #979. I was waiting for https://github.com/exercism/problem-specifications/pull/1568 to be merged and didn't see the notification when it got merged a week ago. See the canonical data [here](https://github.com/exercism/problem-specifications/blob/master/exercises/resistor-color-trio/canonical-data.json).

The solution is based on code @F3PiX kindly gave me.

**TODO:**

- [x] Add to config.json