### PR TITLE
Move Resistor Trio up in the track

### DIFF
--- a/config.json
+++ b/config.json
@@ -1213,8 +1213,8 @@
       "slug": "resistor-color-trio",
       "uuid": "2df14b68-75c8-4984-8ae2-ecd2cb7ed1d4",
       "core": false,
-      "unlocked_by": "high-scores",
-      "difficulty": 4,
+      "unlocked_by": "series",
+      "difficulty": 5,
       "topics": [
         "loops"
       ]


### PR DESCRIPTION
Trio seems to be too hard on its current position (start Level 2). So, not much fun to mentor, and struggling students.

As a side after HighScores, the gap is too big. In HighScores, the design of the class is forced by the tests. In Trio, a lots of decisions to make at once.