### PR TITLE
Scrabble-score: Testing for nil is bad design

### DIFF
--- a/exercises/scrabble-score/.meta/solutions/scrabble_score.rb
+++ b/exercises/scrabble-score/.meta/solutions/scrabble_score.rb
@@ -4,7 +4,7 @@ class Scrabble
   end
 
   attr_reader :term
-  def initialize(term)
+  def initialize(term = '')
     @term = term.to_s.downcase
   end
 

--- a/exercises/scrabble-score/scrabble_score_test.rb
+++ b/exercises/scrabble-score/scrabble_score_test.rb
@@ -11,10 +11,9 @@ class ScrabbleTest < Minitest::Test
     assert_equal 0, Scrabble.new(" \t\n").score
   end
 
-  def test_nil_scores_zero
-    skip
-    assert_equal 0, Scrabble.new(nil).score
-  end
+   def test_nothing_given_scores_zero
+     assert_equal 0, Scrabble.new.score
+   end
 
   def test_scores_very_short_word
     skip


### PR DESCRIPTION
The user of the ScrabbleScore library should be responsible and
responding if they hand bad data to the library.  We want to give a
reasonable "nothing given" response in the library, which intuitively
seems to be a score of 0.

closes: #1001