### PR TITLE
resistor-color-trio: Remove duplicate Readme sentence

### DIFF
--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -5,8 +5,7 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 - Each resistor has a resistance value.
 - Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
   To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
-- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
-  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+- In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
   The colors are mapped to the numbers from 0 to 9 in the sequence:
 
 Black - Brown - Red - Orange - Yellow - Green - Blue - Violet - Grey - White


### PR DESCRIPTION
As pointed out in https://github.com/exercism/ruby/pull/995#commitcomment-35058392 by @brunohq, #995 introduced a duplicate sentence in Resistor Color Trio's readme. Please refer to that PR for more context.