### PR TITLE
Add tests for non-square matrix

### DIFF
--- a/exercises/matrix/matrix_test.rb
+++ b/exercises/matrix/matrix_test.rb
@@ -36,4 +36,16 @@ class MatrixTest < Minitest::Test
     matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
     assert_equal [1903, 3, 4], matrix.columns[1]
   end
+  
+  def test_asymmetric_matrix_rows
+    skip
+    matrix = Matrix.new("1 2\n3 4\n5 6")
+    assert_equal [1, 2], matrix.rows[0]
+  end
+  
+  def test_asymmetric_matrix_columns
+    skip
+    matrix = Matrix.new("1 2\n3 4\n5 6")
+    assert_equal [1, 3, 5], matrix.columns[0]
+  end
 end


### PR DESCRIPTION
I mentored a solution which relied on the matrixes to be size 3x3 or 2x2. While this doesn't test matrixes of all sizes, it adds tests for a non-square matrix of size 2x3

Related solution:
https://exercism.io/mentor/solutions/c06d5e96459b407495564e6de2fbf6ec