### PR TITLE
Binary search generator

### DIFF
--- a/exercises/binary-search/.meta/generator/binary_search_case.rb
+++ b/exercises/binary-search/.meta/generator/binary_search_case.rb
@@ -1,0 +1,25 @@
+require 'generator/exercise_case'
+
+class BinarySearchCase < Generator::ExerciseCase
+  def workload
+    [binary_search, assertion].join
+  end
+
+  private
+
+  def binary_search
+    "binary = BinarySearch.new(#{array})\n"
+  end
+
+  def assertion
+    expected.is_a?(Numeric) ? standard_assertion : error_assertion
+  end
+
+  def standard_assertion
+    "assert_equal #{expected}, binary.search_for(#{value})"
+  end
+
+  def error_assertion
+    assert_equal(nil, "binary.search_for(#{value})")
+  end
+end

--- a/exercises/binary-search/.meta/solutions/binary_search.rb
+++ b/exercises/binary-search/.meta/solutions/binary_search.rb
@@ -2,21 +2,22 @@ class BinarySearch
   attr_reader :list
 
   def initialize(data)
-    fail ArgumentError unless data.sort == data
     @list = data
   end
 
   def search_for(datum)
+    return nil if list.empty?
     return middle if list[middle] == datum
 
     if list[middle] > datum
-      sublist = list[0..middle]
-      fail 'Not Found' if sublist == list
+      sublist = list[0...middle]
+      return nil if sublist == list
       return BinarySearch.new(sublist).search_for(datum)
     else
       sublist = list[middle..-1]
-      fail 'Not Found' if sublist == list
-      return BinarySearch.new(sublist).search_for(datum) + middle
+      return nil if sublist == list
+      result = BinarySearch.new(sublist).search_for(datum)
+      return result.nil? ? nil : result + middle
     end
   end
 

--- a/exercises/binary-search/binary_search_test.rb
+++ b/exercises/binary-search/binary_search_test.rb
@@ -1,49 +1,71 @@
 require 'minitest/autorun'
 require_relative 'binary_search'
 
+# Common test data version: 1.3.0 bfb218f
 class BinarySearchTest < Minitest::Test
-  def test_it_has_list_data
-    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
-    assert_equal [1, 3, 4, 6, 8, 9, 11], binary.list
+  def test_finds_a_value_in_an_array_with_one_element
+    # skip
+    binary = BinarySearch.new([6])
+    assert_equal 0, binary.search_for(6)
   end
 
-  def test_it_raises_error_for_unsorted_list
-    skip
-    assert_raises ArgumentError do
-      BinarySearch.new([2, 1, 4, 3, 6])
-    end
-  end
-
-  def test_it_raises_error_for_data_not_in_list
-    skip
-    assert_raises RuntimeError do
-      BinarySearch.new([1, 3, 6]).search_for(2)
-    end
-  end
-
-  def test_it_finds_position_of_middle_item
+  def test_finds_a_value_in_the_middle_of_an_array
     skip
     binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
-    assert_equal 3, binary.middle
+    assert_equal 3, binary.search_for(6)
   end
 
-  def test_it_finds_position_of_search_data
+  def test_finds_a_value_at_the_beginning_of_an_array
     skip
     binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
-    assert_equal 5, binary.search_for(9)
+    assert_equal 0, binary.search_for(1)
   end
 
-  def test_it_finds_position_in_a_larger_list
+  def test_finds_a_value_at_the_end_of_an_array
     skip
-    binary = BinarySearch.new([1, 3, 5, 8, 13, 21, 34, 55, 89, 144])
-    assert_equal 1, binary.search_for(3)
-    assert_equal 7, binary.search_for(55)
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_equal 6, binary.search_for(11)
   end
 
-  def test_it_finds_correct_position_in_a_list_with_an_even_number_of_elements
+  def test_finds_a_value_in_an_array_of_odd_length
+    skip
+    binary = BinarySearch.new([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634])
+    assert_equal 9, binary.search_for(144)
+  end
+
+  def test_finds_a_value_in_an_array_of_even_length
     skip
     binary = BinarySearch.new([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377])
     assert_equal 5, binary.search_for(21)
-    assert_equal 6, binary.search_for(34)
+  end
+
+  def test_identifies_that_a_value_is_not_included_in_the_array
+    skip
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_nil binary.search_for(7)
+  end
+
+  def test_a_value_smaller_than_the_array_s_smallest_value_is_not_found
+    skip
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_nil binary.search_for(0)
+  end
+
+  def test_a_value_larger_than_the_array_s_largest_value_is_not_found
+    skip
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_nil binary.search_for(13)
+  end
+
+  def test_nothing_is_found_in_an_empty_array
+    skip
+    binary = BinarySearch.new([])
+    assert_nil binary.search_for(1)
+  end
+
+  def test_nothing_is_found_when_the_left_and_right_bounds_cross
+    skip
+    binary = BinarySearch.new([1, 2])
+    assert_nil binary.search_for(0)
   end
 end


### PR DESCRIPTION
- Add missing generator to `binary-search` as per #396.
- Fixes `binary_search.rb` according to canonical tests.
