### PR TITLE
Delete unnecessary instructions in Twelve Days test

### DIFF
--- a/exercises/twelve-days/twelve_days_test.rb
+++ b/exercises/twelve-days/twelve_days_test.rb
@@ -2,14 +2,6 @@ require 'minitest/autorun'
 require_relative 'twelve_days'
 
 class TwelveDaysTest < Minitest::Test
-  # This test is an acceptance test.
-  #
-  # If you find it difficult to work the problem with so much
-  # output, go ahead and add a `skip`, and write whatever
-  # unit tests will help you. Then unskip it again
-  # to make sure you got it right.
-  # There's no need to submit the tests you write, unless you
-  # specifically want feedback on them.
   def test_the_whole_song
     song_file = File.expand_path('../song.txt', __FILE__)
     expected = IO.read(song_file)


### PR DESCRIPTION
Closes #1005. I figured this wording is better, and it should make the button to update the exercise visible.