### PR TITLE
microwave: Test that minute overflow adds to input minutes

### DIFF
--- a/exercises/microwave/.meta/solutions/microwave.rb
+++ b/exercises/microwave/.meta/solutions/microwave.rb
@@ -2,10 +2,11 @@ class Microwave
   attr_reader :minutes, :seconds
 
   def initialize(digits)
-    base = digits > 99 ? 100 : 60
-
-    @minutes = digits / base
-    @seconds = (digits - minutes * base) % base
+    @minutes, @seconds = digits.divmod(100)
+    if @seconds >= 60
+      @seconds -= 60
+      @minutes += 1
+    end
   end
 
   def timer

--- a/exercises/microwave/microwave_test.rb
+++ b/exercises/microwave/microwave_test.rb
@@ -52,4 +52,9 @@ class MicrowaveTest < Minitest::Test
     # skip
     assert_equal '10:01', Microwave.new(1001).timer
   end
+
+  def test_minute_overflow_adds_to_input_minutes
+    skip
+    assert_equal '03:12', Microwave.new(272).timer
+  end
 end


### PR DESCRIPTION
If I enter a nonzero number of minutes into my microwave and add a
number of seconds that exceeds 1 minute, the correct behaviour would be
to add the additional minute to the existing minutes already input.

To test this, add the input `272`, which first is understood as 2
minutes 72 seconds, and then the 72 seconds is understood as 1 minute 12
seconds. The result is 3 minutes 12 seconds.

As noted in the README, this microwave *does* convert the input to
canonical format before display, so the output we would want here is
03:12.

The repo's solution was required to be changed to pass this new test.
Before its change, it had the result of "02:72" which violates the
README's stipulation that the microwave converts to canonical.