### PR TITLE
matrix: add testcase for last column

### DIFF
--- a/exercises/matrix/matrix_test.rb
+++ b/exercises/matrix/matrix_test.rb
@@ -36,4 +36,10 @@ class MatrixTest < Minitest::Test
     matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
     assert_equal [1903, 3, 4], matrix.columns[1]
   end
+
+  def test_extract_last_column
+    skip
+    matrix = Matrix.new("1 2 3\n10 20 30\n100 200 300")
+    assert_equal [3, 30, 300], matrix.columns[2]
+  end
 end

--- a/exercises/matrix/matrix_test.rb
+++ b/exercises/matrix/matrix_test.rb
@@ -40,6 +40,6 @@ class MatrixTest < Minitest::Test
   def test_extract_last_column
     skip
     matrix = Matrix.new("1 2 3\n10 20 30\n100 200 300")
-    assert_equal [3, 30, 300], matrix.columns[2]
+    assert_equal [3, 30, 300], matrix.columns.last
   end
 end


### PR DESCRIPTION
While mentoring the exercise of one of the mentee https://exercism.io/mentor/solutions/8f836f0ff9264cea98b3d2c45d010a8a I found the mentee has implemented `columns` and tried to make the test pass as:

```ruby
 def columns
    return_array = []
    (rows.length - 1).times do |num|
      return_array << rows.map { |row| row[num] }
    end
    return_array
 end
```

And, now since we had only a test case to extract the 2nd column, the above implementation seems to be passing.

Adding the test case to check the last column as well.