### PR TITLE
RubyLearning .org domain not set up for classes

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -5,7 +5,6 @@ Exercism provides exercises and feedback but can be difficult to jump into for t
 * [Ruby in Twenty Minutes](https://www.ruby-lang.org/en/documentation/quickstart/)
 * [Ruby Documentation](http://ruby-doc.org/)
 * [RubyLearning.com](http://rubylearning.com/) - Ruby Tutorial and Study Notes
-* [RubyLearning.org](http://rubylearning.org/classes/) - Professionally Taught and Moderated Classes
 * [Learn to Program](http://pine.fm/LearnToProgram/) - A book (available online) written by Chris Pine
 * [StackOverflow](http://stackoverflow.com/questions/tagged/ruby)
 * [RubyMonk](https://rubymonk.com/)


### PR DESCRIPTION
The course material is no longer available on our former platform, classes link has been (temporarily) suspended for RubyLearning.  Regular content is available, and of course, I am still available for answers in regard to the RubyLearning.com site.