### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,88 +16,143 @@
     "indent_style": "space",
     "indent_size": 2
   },
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [
       {
         "slug": "bird-count",
         "uuid": "4d271980-ab4b-11ea-bb37-0242ac130002",
-        "concepts": ["strings"],
-        "prerequisites": ["classes", "booleans", "conditionals", "blocks"],
+        "concepts": [
+          "strings"
+        ],
+        "prerequisites": [
+          "classes",
+          "booleans",
+          "conditionals",
+          "blocks"
+        ],
         "status": "wip"
       },
       {
         "slug": "log-line-parser",
         "uuid": "e5476046-5289-11ea-8d77-2e728ce88125",
-
-        "concepts": ["strings"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "strings"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "wip"
       },
-
       {
         "slug": "boutique-inventory",
         "uuid": "9f3a89f2-196b-4d53-8481-1360b565c797",
-        "concepts": ["blocks", "enumeration"],
-        "prerequisites": ["hash"],
+        "concepts": [
+          "blocks",
+          "enumeration"
+        ],
+        "prerequisites": [
+          "hash"
+        ],
         "status": "wip"
       },
       {
         "slug": "boutique-inventory-improvements",
         "uuid": "cf415960-ceff-4a1c-b65a-c4b5b1a80155",
-        "concepts": ["ostruct"],
-        "prerequisites": ["enumeration"],
+        "concepts": [
+          "ostruct"
+        ],
+        "prerequisites": [
+          "enumeration"
+        ],
         "status": "wip"
       },
-
       {
         "slug": "moviegoer",
         "uuid": "2aa6c375-8a73-4f5f-ac8f-9db22a86e1f6",
-        "concepts": ["basics"],
+        "concepts": [
+          "basics"
+        ],
         "prerequisites": [],
         "status": "wip"
       },
-
       {
         "slug": "simple-calculator",
         "uuid": "ef6dca29-a990-4a6e-8b2c-4703fd0f751a",
-        "concepts": ["basics"],
+        "concepts": [
+          "basics"
+        ],
         "prerequisites": [],
         "status": "wip"
       },
-
       {
         "slug": "lasagna",
         "uuid": "71ae39c4-7364-11ea-bc55-0242ac130003",
-        "concepts": ["basics"],
+        "concepts": [
+          "basics"
+        ],
         "prerequisites": [],
         "status": "wip"
       },
       {
         "slug": "assembly-line",
         "uuid": "d7108eb2-326c-446d-9140-228e0f220975",
-        "concepts": ["numbers", "conditionals"],
-        "prerequisites": ["booleans"],
+        "concepts": [
+          "numbers",
+          "conditionals"
+        ],
+        "prerequisites": [
+          "booleans"
+        ],
         "status": "wip"
       },
       {
         "slug": "savings-account",
         "uuid": "970d3f26-1891-40c7-9550-42d529f5780f",
-        "concepts": ["floating-point-numbers", "loops"],
-        "prerequisites": ["numbers", "conditionals"],
+        "concepts": [
+          "floating-point-numbers",
+          "loops"
+        ],
+        "prerequisites": [
+          "numbers",
+          "conditionals"
+        ],
         "status": "wip"
       },
       {
         "slug": "amusement-park-improvements",
         "uuid": "06ea7869-4907-454d-a5e5-9d5b71098b17",
-        "concepts": ["booleans"],
-        "prerequisites": ["instance-variables"],
+        "concepts": [
+          "booleans"
+        ],
+        "prerequisites": [
+          "instance-variables"
+        ],
         "status": "wip"
       },
       {
         "slug": "amusement-park",
         "uuid": "6905e411-ae01-46b6-a31c-8867b768856e",
-        "concepts": ["instance-variables", "nil"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "instance-variables",
+          "nil"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "wip"
       }
     ],
@@ -109,7 +164,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["strings"]
+        "topics": [
+          "strings"
+        ]
       },
       {
         "slug": "two-fer",
@@ -118,7 +175,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["conditionals", "strings"]
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-duo",
@@ -127,7 +187,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["array", "loops"]
+        "topics": [
+          "array",
+          "loops"
+        ]
       },
       {
         "slug": "acronym",
@@ -136,7 +199,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["regular_expressions", "strings", "transforming"]
+        "topics": [
+          "regular_expressions",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "high-scores",
@@ -145,7 +212,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "matrix",
@@ -169,7 +238,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["arrays", "enumerable", "loops"]
+        "topics": [
+          "arrays",
+          "enumerable",
+          "loops"
+        ]
       },
       {
         "slug": "word-count",
@@ -178,7 +251,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["enumerable", "hash", "loops"]
+        "topics": [
+          "enumerable",
+          "hash",
+          "loops"
+        ]
       },
       {
         "slug": "hamming",
@@ -187,7 +264,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["equality", "loops", "strings"]
+        "topics": [
+          "equality",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "raindrops",
@@ -196,7 +277,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["conditionals", "filtering", "strings"]
+        "topics": [
+          "conditionals",
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "isogram",
@@ -205,7 +290,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["regular_expressions", "sequences", "strings"]
+        "topics": [
+          "regular_expressions",
+          "sequences",
+          "strings"
+        ]
       },
       {
         "slug": "scrabble-score",
@@ -214,7 +303,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "maps", "strings"]
+        "topics": [
+          "loops",
+          "maps",
+          "strings"
+        ]
       },
       {
         "slug": "luhn",
@@ -223,7 +316,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "integers", "strings"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "clock",
@@ -232,7 +329,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["equality", "text_formatting", "time"]
+        "topics": [
+          "equality",
+          "text_formatting",
+          "time"
+        ]
       },
       {
         "slug": "twelve-days",
@@ -273,7 +374,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["time"]
+        "topics": [
+          "time"
+        ]
       },
       {
         "slug": "resistor-color",
@@ -282,7 +385,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "rna-transcription",
@@ -291,7 +396,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["maps", "transforming"]
+        "topics": [
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "leap",
@@ -300,7 +408,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["booleans", "conditionals", "integers", "logic"]
+        "topics": [
+          "booleans",
+          "conditionals",
+          "integers",
+          "logic"
+        ]
       },
       {
         "slug": "pangram",
@@ -309,7 +422,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "strings"]
+        "topics": [
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "space-age",
@@ -318,7 +434,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["floating_point_numbers", "if_else_statements"]
+        "topics": [
+          "floating_point_numbers",
+          "if_else_statements"
+        ]
       },
       {
         "slug": "triangle",
@@ -327,7 +446,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["booleans", "conditionals", "logic"]
+        "topics": [
+          "booleans",
+          "conditionals",
+          "logic"
+        ]
       },
       {
         "slug": "difference-of-squares",
@@ -336,7 +459,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "anagram",
@@ -345,7 +471,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["filtering", "parsing", "sorting", "strings"]
+        "topics": [
+          "filtering",
+          "parsing",
+          "sorting",
+          "strings"
+        ]
       },
       {
         "slug": "sum-of-multiples",
@@ -354,7 +485,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["loops", "math"]
+        "topics": [
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "transpose",
@@ -363,7 +497,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["loops", "strings", "transforming"]
+        "topics": [
+          "loops",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "armstrong-numbers",
@@ -372,7 +510,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "flatten-array",
@@ -381,7 +521,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["arrays", "recursion"]
+        "topics": [
+          "arrays",
+          "recursion"
+        ]
       },
       {
         "slug": "phone-number",
@@ -405,7 +548,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["bitwise_operations", "math"]
+        "topics": [
+          "bitwise_operations",
+          "math"
+        ]
       },
       {
         "slug": "resistor-color-trio",
@@ -414,7 +560,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["loops"]
+        "topics": [
+          "loops"
+        ]
       },
       {
         "slug": "saddle-points",
@@ -423,7 +571,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "integers", "matrices", "searching"]
+        "topics": [
+          "arrays",
+          "integers",
+          "matrices",
+          "searching"
+        ]
       },
       {
         "slug": "etl",
@@ -432,7 +585,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["loops", "maps", "transforming"]
+        "topics": [
+          "loops",
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -441,7 +598,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["maps", "parsing", "strings"]
+        "topics": [
+          "maps",
+          "parsing",
+          "strings"
+        ]
       },
       {
         "slug": "pythagorean-triplet",
@@ -450,7 +611,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "collatz-conjecture",
@@ -459,7 +623,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["conditionals", "control_flow_loops", "integers", "math"]
+        "topics": [
+          "conditionals",
+          "control_flow_loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "sieve",
@@ -468,7 +637,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "loops", "math", "sorting"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "loops",
+          "math",
+          "sorting"
+        ]
       },
       {
         "slug": "proverb",
@@ -477,7 +652,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "loops", "strings"]
+        "topics": [
+          "arrays",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "palindrome-products",
@@ -486,7 +665,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "accumulate",
@@ -495,7 +677,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["lists"]
+        "topics": [
+          "lists"
+        ]
       },
       {
         "slug": "bob",
@@ -504,7 +688,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "strings"]
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
       },
       {
         "slug": "strain",
@@ -513,7 +700,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays", "filtering", "loops"]
+        "topics": [
+          "arrays",
+          "filtering",
+          "loops"
+        ]
       },
       {
         "slug": "nth-prime",
@@ -522,7 +713,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "perfect-numbers",
@@ -531,7 +726,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "filtering", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "filtering",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "alphametics",
@@ -540,7 +740,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "searching"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "searching"
+        ]
       },
       {
         "slug": "binary-search",
@@ -549,7 +753,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "searching", "sorting"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "searching",
+          "sorting"
+        ]
       },
       {
         "slug": "two-bucket",
@@ -558,7 +767,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "conditionals", "searching"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "searching"
+        ]
       },
       {
         "slug": "matching-brackets",
@@ -567,7 +780,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["parsing", "strings"]
+        "topics": [
+          "parsing",
+          "strings"
+        ]
       },
       {
         "slug": "all-your-base",
@@ -576,7 +792,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["integers", "math", "transforming"]
+        "topics": [
+          "integers",
+          "math",
+          "transforming"
+        ]
       },
       {
         "slug": "scale-generator",
@@ -585,7 +805,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["pattern_matching", "strings"]
+        "topics": [
+          "pattern_matching",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
@@ -594,7 +817,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["bitwise_operations", "enumeration"]
+        "topics": [
+          "bitwise_operations",
+          "enumeration"
+        ]
       },
       {
         "slug": "rail-fence-cipher",
@@ -620,7 +846,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["parsing", "strings", "transforming"]
+        "topics": [
+          "parsing",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "minesweeper",
@@ -629,7 +859,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "games", "loops", "matrices", "transforming"]
+        "topics": [
+          "arrays",
+          "games",
+          "loops",
+          "matrices",
+          "transforming"
+        ]
       },
       {
         "slug": "robot-simulator",
@@ -638,7 +874,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["concurrency", "loops", "sequences", "strings", "structs"]
+        "topics": [
+          "concurrency",
+          "loops",
+          "sequences",
+          "strings",
+          "structs"
+        ]
       },
       {
         "slug": "beer-song",
@@ -647,7 +889,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "strings", "text_formatting"]
+        "topics": [
+          "loops",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "protein-translation",
@@ -656,7 +902,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["filtering", "maps", "sequences"]
+        "topics": [
+          "filtering",
+          "maps",
+          "sequences"
+        ]
       },
       {
         "slug": "wordy",
@@ -680,7 +930,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "bitwise_operations", "integers"]
+        "topics": [
+          "arrays",
+          "bitwise_operations",
+          "integers"
+        ]
       },
       {
         "slug": "atbash-cipher",
@@ -689,7 +943,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "cryptography", "strings", "transforming"]
+        "topics": [
+          "algorithms",
+          "cryptography",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "crypto-square",
@@ -727,7 +986,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["randomness"]
+        "topics": [
+          "randomness"
+        ]
       },
       {
         "slug": "simple-cipher",
@@ -751,7 +1012,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "arrays", "searching"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "searching"
+        ]
       },
       {
         "slug": "pig-latin",
@@ -760,7 +1025,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["conditionals", "strings", "transforming"]
+        "topics": [
+          "conditionals",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "simple-linked-list",
@@ -769,7 +1038,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "loops"]
+        "topics": [
+          "arrays",
+          "loops"
+        ]
       },
       {
         "slug": "binary-search-tree",
@@ -794,7 +1066,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "loops", "searching"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "loops",
+          "searching"
+        ]
       },
       {
         "slug": "circular-buffer",
@@ -803,7 +1080,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["queues", "structs"]
+        "topics": [
+          "queues",
+          "structs"
+        ]
       },
       {
         "slug": "grade-school",
@@ -812,7 +1092,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["lists", "sorting", "structs"]
+        "topics": [
+          "lists",
+          "sorting",
+          "structs"
+        ]
       },
       {
         "slug": "roman-numerals",
@@ -821,7 +1105,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["numbers", "transforming"]
+        "topics": [
+          "numbers",
+          "transforming"
+        ]
       },
       {
         "slug": "rotational-cipher",
@@ -830,7 +1117,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["cryptography", "integers", "strings"]
+        "topics": [
+          "cryptography",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "affine-cipher",
@@ -839,7 +1130,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["cryptography", "math", "strings"]
+        "topics": [
+          "cryptography",
+          "math",
+          "strings"
+        ]
       },
       {
         "slug": "kindergarten-garden",
@@ -848,7 +1143,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["parsing", "records", "searching", "strings", "structs"]
+        "topics": [
+          "parsing",
+          "records",
+          "searching",
+          "strings",
+          "structs"
+        ]
       },
       {
         "slug": "largest-series-product",
@@ -857,7 +1158,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "math", "sequences"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math",
+          "sequences"
+        ]
       },
       {
         "slug": "prime-factors",
@@ -866,7 +1172,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "custom-set",
@@ -875,7 +1185,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["filtering", "loops", "sets"]
+        "topics": [
+          "filtering",
+          "loops",
+          "sets"
+        ]
       },
       {
         "slug": "house",
@@ -884,7 +1198,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["recursion", "strings", "text_formatting"]
+        "topics": [
+          "recursion",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "linked-list",
@@ -893,7 +1211,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["data_structure", "pointer"]
+        "topics": [
+          "data_structure",
+          "pointer"
+        ]
       },
       {
         "slug": "poker",
@@ -918,7 +1239,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "complex-numbers",
@@ -927,7 +1250,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "meetup",
@@ -936,7 +1261,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["dates", "time", "transforming", "type_conversion"]
+        "topics": [
+          "dates",
+          "time",
+          "transforming",
+          "type_conversion"
+        ]
       },
       {
         "slug": "diamond",
@@ -960,7 +1290,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "conditionals"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "conditionals"
+        ]
       },
       {
         "slug": "ocr-numbers",
@@ -969,7 +1303,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["parsing", "pattern_recognition"]
+        "topics": [
+          "parsing",
+          "pattern_recognition"
+        ]
       },
       {
         "slug": "say",
@@ -978,7 +1315,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["numbers", "strings", "text_formatting", "transforming"]
+        "topics": [
+          "numbers",
+          "strings",
+          "text_formatting",
+          "transforming"
+        ]
       },
       {
         "slug": "zipper",
@@ -987,7 +1329,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["data_structures"]
+        "topics": [
+          "data_structures"
+        ]
       },
       {
         "slug": "grep",
@@ -1027,7 +1371,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "arrays", "math", "recursion"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "math",
+          "recursion"
+        ]
       },
       {
         "slug": "queen-attack",
@@ -1036,7 +1385,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["booleans", "errors", "games", "logic"]
+        "topics": [
+          "booleans",
+          "errors",
+          "games",
+          "logic"
+        ]
       },
       {
         "slug": "book-store",
@@ -1045,7 +1399,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "floating_point_numbers", "integers", "lists"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers",
+          "integers",
+          "lists"
+        ]
       },
       {
         "slug": "connect",
@@ -1054,7 +1413,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 9,
-        "topics": ["arrays", "games", "graphs", "loops", "searching"]
+        "topics": [
+          "arrays",
+          "games",
+          "graphs",
+          "loops",
+          "searching"
+        ]
       },
       {
         "slug": "binary",
@@ -1113,7 +1478,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["math", "strings", "interpolation"]
+        "topics": [
+          "math",
+          "strings",
+          "interpolation"
+        ]
       },
       {
         "slug": "darts",
@@ -1122,7 +1491,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["math", "geometry"]
+        "topics": [
+          "math",
+          "geometry"
+        ]
       }
     ]
   },


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
