### PR TITLE
Fix example filepath in track's config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
       "%{snake_slug}_test.rb"
     ],
     "example": [
-      ".meta/example.rb"
+      ".meta/solutions/%{snake_slug}.rb"
     ],
     "exemplar": [
       ".meta/exemplar.rb"


### PR DESCRIPTION
Ruby's examples live inside a solutions subdir, not at the apex of .meta.