### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "b4d359f8-ae84-46f0-8bcb-34ab74ac7f10",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Ruby locally",
+      "blurb": "Learn how to install Ruby locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "81b32160-46d8-4095-9af0-3eb2dfc8fed8",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Ruby",
+      "blurb": "An overview of how to get started from scratch with Ruby"
+    },
+    {
+      "uuid": "3c0bc3e0-7703-4fdc-8700-2ee2dbb0185c",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Ruby track",
+      "blurb": "Learn how to test your Ruby exercises on Exercism"
+    },
+    {
+      "uuid": "67ed777f-eea7-4bff-9ba8-3199da520d7c",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Ruby resources",
+      "blurb": "A collection of useful resources to help you master Ruby"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
