### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/amusement-park-improvements/.meta/config.json
+++ b/exercises/concept/amusement-park-improvements/.meta/config.json
@@ -1,24 +1,12 @@
 {
   "blurb": "TODO: add blurb for amusement-park-improvements exercise",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "kotp",
-      "exercism_username": "kotp"
-    },
-    {
-      "github_username": "iHiD",
-      "exercism_username": "iHiD"
-    },
-    {
-      "github_username": "kayn1",
-      "exercism_username": "kayn1"
-    }
+    "kotp",
+    "iHiD",
+    "kayn1"
   ],
   "language_versions": ">=2.6.6",
   "files": {

--- a/exercises/concept/amusement-park/.meta/config.json
+++ b/exercises/concept/amusement-park/.meta/config.json
@@ -1,20 +1,11 @@
 {
   "blurb": "TODO: add blurb for amusement-park exercise",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    },
-    {
-      "github_username": "iHiD",
-      "exercism_username": "iHiD"
-    }
+    "neenjaw",
+    "iHiD"
   ],
   "contributors": [
-    {
-      "github_username": "kotp",
-      "exercism_username": "kotp"
-    }
+    "kotp"
   ],
   "language_versions": ">=2.6.6",
   "files": {

--- a/exercises/concept/assembly-line/.meta/config.json
+++ b/exercises/concept/assembly-line/.meta/config.json
@@ -1,20 +1,11 @@
 {
   "blurb": "TODO: add blurb for assembly-line exercise",
   "authors": [
-    {
-      "github_username": "dvik1950",
-      "exercism_username": "dvik1950"
-    }
+    "dvik1950"
   ],
   "contributors": [
-    {
-      "github_username": "kotp",
-      "exercism_username": "kotp"
-    },
-    {
-      "github_username": "iHiD",
-      "exercism_username": "iHiD"
-    }
+    "kotp",
+    "iHiD"
   ],
   "forked_from": [
     "csharp/numbers"

--- a/exercises/concept/bird-count/.meta/config.json
+++ b/exercises/concept/bird-count/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for bird-count exercise",
   "authors": [
-    {
-      "github_username": "pvcarrera",
-      "exercism_username": "pvcarrera"
-    }
+    "pvcarrera"
   ],
   "forked_from": [
     "csharp/arrays"

--- a/exercises/concept/boutique-inventory-improvements/.meta/config.json
+++ b/exercises/concept/boutique-inventory-improvements/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for boutique-inventory-improvements exercise",
   "authors": [
-    {
-      "github_username": "iHiD",
-      "exercism_username": "iHiD"
-    }
+    "iHiD"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/boutique-inventory/.meta/config.json
+++ b/exercises/concept/boutique-inventory/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for boutique-inventory exercise",
   "authors": [
-    {
-      "github_username": "iHiD",
-      "exercism_username": "iHiD"
-    }
+    "iHiD"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for lasagna exercise",
   "authors": [
-    {
-      "github_username": "iHiD",
-      "exercism_username": "iHiD"
-    },
-    {
-      "github_username": "pvcarrera",
-      "exercism_username": "pvcarrera"
-    }
+    "iHiD",
+    "pvcarrera"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/log-line-parser/.meta/config.json
+++ b/exercises/concept/log-line-parser/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for log-line-parser exercise",
   "authors": [
-    {
-      "github_username": "pvcarrera",
-      "exercism_username": "pvcarrera"
-    }
+    "pvcarrera"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/moviegoer/.meta/config.json
+++ b/exercises/concept/moviegoer/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for moviegoer exercise",
   "authors": [
-    {
-      "github_username": "TBD",
-      "exercism_username": "TBD"
-    }
+    "TBD"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/savings-account/.meta/config.json
+++ b/exercises/concept/savings-account/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for savings-account exercise",
   "authors": [
-    {
-      "github_username": "TBD",
-      "exercism_username": "TBD"
-    }
+    "TBD"
   ],
   "contributors": [
-    {
-      "github_username": "dvik1950",
-      "exercism_username": "dvik1950"
-    }
+    "dvik1950"
   ],
   "forked_from": [
     "csharp/floating-point-numbers"

--- a/exercises/concept/simple-calculator/.meta/config.json
+++ b/exercises/concept/simple-calculator/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for simple-calculator exercise",
   "authors": [
-    {
-      "github_username": "pvcarrera",
-      "exercism_username": "pvcarrera"
-    }
+    "pvcarrera"
   ],
   "forked_from": [
     "csharp/exceptions"


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
