### PR TITLE
🤖 Add labels append file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,88 @@
+- name: "Epic"
+  description: ""
+  color: "3E4B9E"
+
+- name: "Hacktoberfest"
+  description: ""
+  color: "b0581d"
+
+- name: "Project Track Anatomy"
+  description: "Changes related to the Ruby Track Anatomy."
+  color: "009cab"
+
+- name: "abandoned?"
+  description: ""
+  color: "cc8eac"
+
+- name: "bug"
+  description: ""
+  color: "fc2929"
+
+- name: "duplicate"
+  description: ""
+  color: "cccccc"
+
+- name: "enhancement"
+  description: ""
+  color: "84b6eb"
+
+- name: "first-timers only"
+  description: ""
+  color: "159818"
+
+- name: "github_actions"
+  description: "Pull requests that update Github_actions code"
+  color: "000000"
+
+- name: "good first patch"
+  description: ""
+  color: "159818"
+
+- name: "in progress"
+  description: ""
+  color: "ededed"
+
+- name: "invalid"
+  description: ""
+  color: "e6e6e6"
+
+- name: "new concept exercise :tulip:"
+  description: ""
+  color: "AD595A"
+
+- name: "pinned"
+  description: ""
+  color: "006b75"
+
+- name: "question"
+  description: ""
+  color: "cc317c"
+
+- name: "ready"
+  description: ""
+  color: "5319e7"
+
+- name: "ruby"
+  description: "Pull requests that update Ruby code"
+  color: "ce2d2d"
+
+- name: "security"
+  description: ""
+  color: "fbca04"
+
+- name: "stale"
+  description: ""
+  color: "ffffff"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"
+
+- name: "waiting on dependency"
+  description: ""
+  color: "ededed"
+
+- name: "wontfix"
+  description: ""
+  color: "ffffff"
+


### PR DESCRIPTION
This PR adds a `.appends/.github/labels.yml` file, which contains all the labels that are currently used in this repo. The `.github/labels.yml` file will contain the full list of labels that this repo can use, which will be a combination of the `.appends/.github/labels.yml` file and a centrally-managed `labels.yml` file.

We'll automatically sync any changes, which allows us to guarantee that all the track repositories will have a pre-determined set of labels, augmented with any custom labels defined in the `.appends/.github/labels.yml` file. This syncing will be done by another (automatically-synced) workflow, which we will add in a later PR.

## Tracking

https://github.com/exercism/v3-launch/issues/41