### PR TITLE
Savings Account: Correct average_negative_start_balance test

### DIFF
--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -79,7 +79,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_avarage_negative_start_balance
-    assert_equal 1_016.21, SavingsAccount.annual_balance_update(1_000.0)
+    assert_equal 1_016.21, SavingsAccount.annual_balance_update(-1_000.0)
   end
 
   def test_annual_balance_update_for_large_negative_start_balance

--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -62,7 +62,7 @@ class SavingsAccountTest < Minitest::Test
     assert_equal 0.000_001_005, SavingsAccount.annual_balance_update(0.000_001)
   end
 
-  def test_annual_balance_update_for_avarage_positive_start_balance
+  def test_annual_balance_update_for_average_positive_start_balance
     assert_equal 1_016.21, SavingsAccount.annual_balance_update(1_000.0)
   end
 
@@ -78,7 +78,7 @@ class SavingsAccountTest < Minitest::Test
     assert_equal(-0.12_695_199, SavingsAccount.annual_balance_update(-0.123))
   end
 
-  def test_annual_balance_update_for_avarage_negative_start_balance
+  def test_annual_balance_update_for_average_negative_start_balance
     assert_equal(-1_032.13, SavingsAccount.annual_balance_update(-1_000.0))
   end
 

--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -79,7 +79,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_avarage_negative_start_balance
-    assert_equal 1_016.21, SavingsAccount.annual_balance_update(-1_000.0)
+    assert_equal(-1_032.13, SavingsAccount.annual_balance_update(-1_000.0))
   end
 
   def test_annual_balance_update_for_large_negative_start_balance


### PR DESCRIPTION
There is an error in the Savings Account exercise, in the `test_annual_balance_update_for_avarage_negative_start_balance` test. This PR:
- makes the starting balance negative
- updates the associated expected result, since negative starting balances should be subject to the negative interest rate of 3.213%.
- corrects the misspellings of 'average' in the test method names