### PR TITLE
Bird Count: Force predicate methods to return boolean

### DIFF
--- a/exercises/concept/bird-count/bird_count_test.rb
+++ b/exercises/concept/bird-count/bird_count_test.rb
@@ -33,10 +33,10 @@ class BirdCountTest < Minitest::Test
   end
 
   def test_has_day_without_birds
-    assert BirdCount.new([5, 5, 4, 0, 7, 6]).day_without_birds?
+    assert BirdCount.new([5, 5, 4, 0, 7, 6]).day_without_birds?.equal?(true)
   end
 
   def test_has_day_without_birds_whith_no_day_without_birds
-    refute BirdCount.new([4, 5, 9, 10, 9, 4, 3]).day_without_birds?
+    assert BirdCount.new([4, 5, 9, 10, 9, 4, 3]).day_without_birds?.equal?(false)
   end
 end


### PR DESCRIPTION
Hi!
First of all, thank you very much for such an amazing platform, I like it very much!

I'm going through all the exercises and solving [the task](https://exercism.org/tracks/ruby/exercises/bird-count) I noticed that
tests are passed when the method `day_without_birds?` returns `truthy` or `falsey` values.

It would be nice to anticipate boolean values because of the following reasons:
1. It's mentioned in the description that the method should return either `true` or `false`
2. It's a good practice to return exactly boolean values if a method ends with `?` cause it's semantically better. Yes, it works in Ruby `ifs` but I think it's not a good idea to use approaches cause they actually can work

**NOTE FOR REVIEWERS**
I'm not sure how it's better to check if a method returns exactly a boolean value.
These
```ruby
assert false, method?
assert true, method?
```
haven't been passed by Rubocop.