### PR TITLE
Minor correction in introduction.md

### DIFF
--- a/concepts/advanced-enumeration/introduction.md
+++ b/concepts/advanced-enumeration/introduction.md
@@ -15,7 +15,7 @@ fibonacci.select { |number| number.odd? }   #=> [1, 1, 3, 5, 13]
 fibonacci.all?   { |number| number < 20 }   #=> true
 fibonacci.map    { |number| number * 2  }   #=> [0, 2, 2, 4, 6, 10, 16, 26]
 fibonacci.select { |number| number >= 5}    #=> [5, 8, 13]
-fibonacci.find   { |number| number >= 5}    #=> [5]
+fibonacci.find   { |number| number >= 5}    #=> 5
 
 # Some methods work with our without a block
 fibonacci.sum  #=> 33


### PR DESCRIPTION
Enumerable#find returns the first matching element, not an array containing the first matching element.

Source: https://apidock.com/ruby/Enumerable/find