### PR TITLE
Update references of "master" in README to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ $ git clone https://github.com/YOUR-USERNAME/YOUR-PROBLEM-S-REPOSITORY
 ```
 Next, you need to [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [synchronize](https://help.github.com/articles/syncing-a-fork/) it.
 
-Make sure you have synced up local master branch and upstream master branch.
-Since this will keep local master branch up-to-date with the upstream repository.
+Make sure you have synced up local main branch and upstream main branch.
+Since this will keep local main branch up-to-date with the upstream repository.
 Thereby, you will able to get the latest commits.
 
 
@@ -164,9 +164,9 @@ git remote add upstream https://github.com/exercism/ruby.git
 # Pull down any changes
 git fetch upstream
 
-# Merge any upstream changes with your master branch
-git checkout master
-git merge upstream/master
+# Merge any upstream changes with your main branch
+git checkout main
+git merge upstream/main
 ```
 
 Depending on your git workflow preferences and the state of your local repo,

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ $ git clone https://github.com/YOUR-USERNAME/YOUR-PROBLEM-S-REPOSITORY
 ```
 Next, you need to [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [synchronize](https://help.github.com/articles/syncing-a-fork/) it.
 
-Make sure you have synced up local main branch and upstream main branch.
-Since this will keep local main branch up-to-date with the upstream repository.
+Make sure you have synced up local `main` branch and upstream `main` branch.
+Since this will keep local `main` branch up-to-date with the upstream repository.
 Thereby, you will able to get the latest commits.
 
 
@@ -164,7 +164,7 @@ git remote add upstream https://github.com/exercism/ruby.git
 # Pull down any changes
 git fetch upstream
 
-# Merge any upstream changes with your main branch
+# Merge any upstream changes with your `main` branch
 git checkout main
 git merge upstream/main
 ```


### PR DESCRIPTION
Update reference of "Master in README to "main".

Details regarding this rename can be found here:
https://github.com/github/renaming