### PR TITLE
Savings-Account: Fix copy/paste error from positive to negative test.

### DIFF
--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -81,7 +81,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_average_negative_start_balance
-    assert_in_delta 1_016.21, SavingsAccount.annual_balance_update(1_000.0), 0.01
+    assert_in_delta -1_032.13, SavingsAccount.annual_balance_update(-1_000.0), 0.01
   end
 
   def test_annual_balance_update_for_large_negative_start_balance

--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -81,7 +81,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_average_negative_start_balance
-    assert_in_delta -1_032.13, SavingsAccount.annual_balance_update(-1_000.0), 0.01
+    assert_in_delta(-1_032.13, SavingsAccount.annual_balance_update(-1_000.0), 0.01)
   end
 
   def test_annual_balance_update_for_large_negative_start_balance


### PR DESCRIPTION
This is a duplication of #1190.  It has been a few weeks since the original post, and over a week since the last comment was posted.  I ran across this same issue today while working on this exercise.  It appears that the typos have been fixed on the main branch already, so I just included the number fixes (i.e. making the test honest about testing a negative balance).