### PR TITLE
Uses underscore consistently for fractional part of floats

### DIFF
--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -59,7 +59,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_small_positive_start_balance
-    assert_in_delta 0.000_001_005, SavingsAccount.annual_balance_update(0.000_001), 0.000_000_0001
+    assert_in_delta 0.000_001_005, SavingsAccount.annual_balance_update(0.000_001), 0.000_000_000_1
   end
 
   def test_annual_balance_update_for_average_positive_start_balance
@@ -67,17 +67,17 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_large_positive_start_balance
-    assert_in_delta 1_016.2_101_016_209_999, SavingsAccount.annual_balance_update(1_000.0001), 0.0_000_000_000_01
+    assert_in_delta 1_016.2_101_016_209_999, SavingsAccount.annual_balance_update(1_000.000_1), 0.000_000_000_001
   end
 
   def test_annual_balance_update_for_huge_positive_start_balance
     assert_in_delta 920_352_587.26_744_292_868_451_875,
       SavingsAccount.annual_balance_update(898_124_017.826_243_404_425),
-      0.00_000_000_000_000_001
+      0.000_000_000_000_000_01
   end
 
   def test_annual_balance_update_for_small_negative_start_balance
-    assert_in_delta(-0.12_695_199, SavingsAccount.annual_balance_update(-0.123), 0.00_000_01)
+    assert_in_delta(-0.12_695_199, SavingsAccount.annual_balance_update(-0.123), 0.000_000_1)
   end
 
   def test_annual_balance_update_for_average_negative_start_balance
@@ -85,7 +85,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_annual_balance_update_for_large_negative_start_balance
-    assert_in_delta(-157_878.97_174_203, SavingsAccount.annual_balance_update(-152_964.231), 0.00_000_001)
+    assert_in_delta(-157_878.97_174_203, SavingsAccount.annual_balance_update(-152_964.231), 0.000_000_01)
   end
 
   def test_years_before_desired_balance_for_small_start_balance
@@ -101,6 +101,6 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_years_before_desired_balance_for_large_difference_between_start_and_desired_balance
-    assert_equal 85, SavingsAccount.years_before_desired_balance(2_345.67, 12_345.6_789)
+    assert_equal 85, SavingsAccount.years_before_desired_balance(2_345.67, 12_345.678_9)
   end
 end

--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -39,7 +39,7 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_minimal_negative_interest_rate
-    assert_equal(-3.213, SavingsAccount.interest_rate(-0.0001))
+    assert_equal(-3.213, SavingsAccount.interest_rate(-0.000_1))
   end
 
   def test_small_negative_interest_rate
@@ -72,8 +72,7 @@ class SavingsAccountTest < Minitest::Test
 
   def test_annual_balance_update_for_huge_positive_start_balance
     assert_in_delta 920_352_587.26_744_292_868_451_875,
-      SavingsAccount.annual_balance_update(898_124_017.826_243_404_425),
-      0.000_000_000_000_000_01
+      SavingsAccount.annual_balance_update(898_124_017.826_243_404_425), 0.000_000_000_000_000_01
   end
 
   def test_annual_balance_update_for_small_negative_start_balance


### PR DESCRIPTION
Use the underscore consistently to separate groups of 3 digits in the rational part of numbers, starting at the decimal point and moving right.

This way the decimal places are separated into groups that would be prefixed with 'milli', 'micro', 'nano' etc, as often ist used in (physical) units (µ gram, milli second, nano meter…).