### PR TITLE
Bowling: A spare followed by strike

### DIFF
--- a/exercises/practice/bowling/bowling_test.rb
+++ b/exercises/practice/bowling/bowling_test.rb
@@ -99,6 +99,13 @@ class BowlingTest < Minitest::Test
     assert_equal 30, game.score
   end
 
+  def test_a_spare_followed_by_a_strike_should_not_get_bonus_from_next_frame
+    game = Game.new
+    rolls = [5, 5, 10, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    rolls.each { |pins| game.roll(pins) }
+    assert_equal 42, game.score
+  end
+
   def test_a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get_a_bonus
     skip
     game = Game.new


### PR DESCRIPTION
A spare followed by a strike should not get bonus from the following
frame.

closes: #1227

Co-authored-by: @gemp