### PR TITLE
Fix interest rate

### DIFF
--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -3,7 +3,7 @@ require_relative 'savings_account'
 
 class SavingsAccountTest < Minitest::Test
   def test_minimal_first_interest_rate
-    assert_in_delta 0.5, SavingsAccount.interest_rate(0), 0.000_1
+    assert_in_delta 0, SavingsAccount.interest_rate(0), 0.000_1
   end
 
   def test_tiny_first_interest_rate


### PR DESCRIPTION
According to new description:
```
0% for a balance of 0 dollars (it neither earns interest, nor is penalised).
```
expected value should be 0 instead of 0.5