### PR TITLE
Proposed new example for Palindrome Products

### DIFF
--- a/exercises/practice/palindrome-products/.meta/example_2.rb
+++ b/exercises/practice/palindrome-products/.meta/example_2.rb
@@ -1,8 +1,4 @@
-class Palindrome
-  attr_reader :value, :factors
-  private
-  def initialize(palindrome) @value, @factors = palindrome end
-end
+Palindrome = Struct.new(:value, :factors)
 
 class Palindromes
 
@@ -24,7 +20,7 @@ class Palindromes
   end
 
   def palindrome_and_factors(palindrome)
-    [palindrome, factors(palindrome)]
+    Palindrome.new palindrome, factors(palindrome)
   end
 
   public
@@ -41,11 +37,11 @@ class Palindromes
   end
 
   def largest
-    @largest ||= Palindrome.new palindrome_and_factors(candidates.max)
+    @largest ||= palindrome_and_factors(candidates.max)
   end
 
   def smallest
-    @smallest ||= Palindrome.new palindrome_and_factors(candidates.min)
+    @smallest ||= palindrome_and_factors(candidates.min)
   end
 
 end

--- a/exercises/practice/palindrome-products/.meta/example_2.rb
+++ b/exercises/practice/palindrome-products/.meta/example_2.rb
@@ -1,9 +1,7 @@
 class Palindrome
   attr_reader :value, :factors
   private
-  def initialize(palindrome)
-    @value, @factors = palindrome
-  end
+  def initialize(palindrome) @value, @factors = palindrome end
 end
 
 class Palindromes
@@ -26,19 +24,20 @@ class Palindromes
   end
 
   def palindrome_and_factors(palindrome)
-    [palindrome] << factors(palindrome)
+    [palindrome, factors(palindrome)]
   end
 
   public
 
   def generate
-    @candidates = range.map do |r1|
-      range.each_with_object([]) do |r2, candidates|
-        candidates << r1 * r2 if r2 >= r1
-      end.select do |candidate|
-        candidate == candidate.to_s.reverse.to_i
+    @candidates ||= range.each_with_object([]) do |r1, candidates|
+      (r1..range.last).each do |r2|
+        candidate = r1 * r2
+        if candidate == candidate.to_s.reverse.to_i
+          candidates << candidate
+        end
       end
-    end.flatten
+    end
   end
 
   def largest

--- a/exercises/practice/palindrome-products/.meta/example_2.rb
+++ b/exercises/practice/palindrome-products/.meta/example_2.rb
@@ -1,0 +1,52 @@
+class Palindrome
+  attr_reader :value, :factors
+  private
+  def initialize(palindrome)
+    @value, @factors = palindrome
+  end
+end
+
+class Palindromes
+
+  private
+
+  attr_reader :range, :candidates
+
+  def initialize(min_factor: 1, max_factor: 9)
+    @range = (min_factor..max_factor)
+  end
+
+  def factors(palindrome)
+    range.each_with_object([]) do |number, factors|
+      div, mod = palindrome.divmod(number)
+      if div <= number && range.include?(div) && mod.zero?
+        factors << [div, number]
+      end
+    end
+  end
+
+  def palindrome_and_factors(palindrome)
+    [palindrome] << factors(palindrome)
+  end
+
+  public
+
+  def generate
+    @candidates = range.map do |r1|
+      range.each_with_object([]) do |r2, candidates|
+        candidates << r1 * r2 if r2 >= r1
+      end.select do |candidate|
+        candidate == candidate.to_s.reverse.to_i
+      end
+    end.flatten
+  end
+
+  def largest
+    @largest ||= Palindrome.new palindrome_and_factors(candidates.max)
+  end
+
+  def smallest
+    @smallest ||= Palindrome.new palindrome_and_factors(candidates.min)
+  end
+
+end


### PR DESCRIPTION
This example_2 is ~~about 60%~~ more than two times faster than the present one.

* It still uses a double loop on `@range` because `repeated_combination(2)` is waaay slower.
* ~~`r1 * r2 if r2 >= r1` prevents to calculate `2*1` when we already have `1*2` mimicking `repeated_combination`~~ Redefined the range instead.
* It is much more efficient to recalculate the factors afterwards than to store them during the loops where it creates a lot of unnecessary `Palindrome` objects (or even only arrays of `[product, [i, j].sort]`).
* And the way they are calculated prevents `palindrome.factors << [i, j].sort; palindrome.factors.uniq!` just with `div <= number`.
* `n == n.to_s.reverse.to_i` is ~15% faster than `n.to_s == n.to_s.reverse`.
* Finally I found that adding a method `palindrome?` or monkey patching `Integer` slows down stuff as well as being overkill as it's used only once; it makes things clearer but it has a cost.

Mentored by @kotp ❤️