### PR TITLE
Fix typo in Bird Count instructions

### DIFF
--- a/exercises/concept/bird-count/.docs/instructions.md
+++ b/exercises/concept/bird-count/.docs/instructions.md
@@ -37,7 +37,7 @@ bird_count.total
 
 ## 4. Calculate the number of busy days
 
-Some days are busier that others. A busy day is one where five or more birds have visited your garden.
+Some days are busier than others. A busy day is one where five or more birds have visited your garden.
 Implement the `BirdCount#busy_days` method to return the number of busy days:
 
 ```ruby


### PR DESCRIPTION
This **Bird Count** exercise has a small typo in its instructions number 4.

```diff
- Some days are busier that others.
+ Some days are busier than others.
```