### PR TITLE
Zipper test to check go deep and return

### DIFF
--- a/exercises/practice/zipper/zipper_test.rb
+++ b/exercises/practice/zipper/zipper_test.rb
@@ -127,6 +127,24 @@ class ZipperTest < Minitest::Test
     assert_equal expected, value
   end
 
+  def test_left_right_up_and_up
+    skip
+    tree =
+      Node.new(1,
+        Node.new(2,
+          nil,
+          Node.new(3,
+            nil,
+            nil)),
+        Node.new(4,
+          nil,
+          nil))
+    zipper = Zipper.from_tree(tree)
+    value = zipper.left.right.up.up.value
+    expected = 1
+    assert_equal expected, value
+  end
+
   def test_set_value
     skip
     tree =


### PR DESCRIPTION
Adds a test to the Zipper exercise to check that the zipper can go deep in the structure and return to the top.

The issue within problem-specifications is here: https://github.com/exercism/problem-specifications/issues/1872

Addresses https://github.com/exercism/ruby/issues/1260