### PR TITLE
simple-calculator: fix instructions typo in part 2

### DIFF
--- a/exercises/concept/simple-calculator/.docs/instructions.md
+++ b/exercises/concept/simple-calculator/.docs/instructions.md
@@ -26,7 +26,7 @@ The main method for implementation in this task will be the class method `Simple
 Update the `SimpleCalculator.calculate()` method to raise an `UnsupportedOperation` exception for unknown operation symbols.
 
 ```ruby
-SimpleCalculator.calculate(1, '2', '-')
+SimpleCalculator.calculate(1, 2, '-')
 # => Raises an UnsupportedOperation
 ```
 


### PR DESCRIPTION
Update instructions typo, part 2 is meant to test unsupported operation vs invalid string argument.

Might cause confusion with beginners who have the sequencing of their error handling around the wrong way to start.