### PR TITLE
Practice exercises should emulate TDD with skips

### DIFF
--- a/exercises/practice/two-fer/two_fer_test.rb
+++ b/exercises/practice/two-fer/two_fer_test.rb
@@ -4,14 +4,17 @@ require_relative 'two_fer'
 # Common test data version: 1.2.0 4fc1acb
 class TwoFerTest < Minitest::Test
   def test_no_name_given
+    # skip
     assert_equal "One for you, one for me.", TwoFer.two_fer
   end
 
   def test_a_name_given
+    skip
     assert_equal "One for Alice, one for me.", TwoFer.two_fer("Alice")
   end
 
   def test_another_name_given
+    skip
     assert_equal "One for Bob, one for me.", TwoFer.two_fer("Bob")
   end
 end


### PR DESCRIPTION
The first skip should be commented (unskipped) while the remainders are
active.

Ref: #1189
