### PR TITLE
Moviegoer: remove unnecessary "attr_reader"

### DIFF
--- a/exercises/concept/moviegoer/moviegoer.rb
+++ b/exercises/concept/moviegoer/moviegoer.rb
@@ -3,8 +3,6 @@ class NotMovieClubMemberError < RuntimeError
 end
 
 class Moviegoer
-  attr_reader :age, :member
-
   def initialize(age, member: false)
     @age = age
     @member = member


### PR DESCRIPTION
The `attr_reader :age, :member` line is not necessary since we don't need to expose the attributes.

