### PR TITLE
Savings Account: Adds test for negative current balance edge case

### DIFF
--- a/exercises/concept/savings-account/.meta/exemplar.rb
+++ b/exercises/concept/savings-account/.meta/exemplar.rb
@@ -22,6 +22,7 @@ module SavingsAccount
   end
 
   def self.years_before_desired_balance(current_balance, desired_balance)
+    raise ArgumentError, 'Current balance cannot be negative' if current_balance.negative?
     years = 0
     while current_balance < desired_balance
       current_balance = annual_balance_update(current_balance)

--- a/exercises/concept/savings-account/.meta/exemplar.rb
+++ b/exercises/concept/savings-account/.meta/exemplar.rb
@@ -22,7 +22,7 @@ module SavingsAccount
   end
 
   def self.years_before_desired_balance(current_balance, desired_balance)
-    raise ArgumentError, 'Current balance cannot be negative' if current_balance.negative?
+    raise ArgumentError, 'Current balance must be positive' unless current_balance.positive?
     years = 0
     while current_balance < desired_balance
       current_balance = annual_balance_update(current_balance)

--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -105,10 +105,13 @@ class SavingsAccountTest < Minitest::Test
   end
 
   def test_years_before_desired_balance_for_negative_current_balance
-    assert_raises(ArgumentError, 'Current balance cannot be negative') do
+    assert_raises(ArgumentError, 'Current balance must be positive') do
       Timeout.timeout(0.1) do
         SavingsAccount.years_before_desired_balance(-1.0, 1.0)
       end
+    rescue Timeout::Error
+      raise RuntimeError, 'Impossible Solution, raise an ArugmentError if current '\
+                          'balance is not positive.'
     end
   end
 end

--- a/exercises/concept/savings-account/savings_account_test.rb
+++ b/exercises/concept/savings-account/savings_account_test.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'timeout'
 require_relative 'savings_account'
 
 class SavingsAccountTest < Minitest::Test
@@ -101,5 +102,13 @@ class SavingsAccountTest < Minitest::Test
 
   def test_years_before_desired_balance_for_large_difference_between_start_and_desired_balance
     assert_equal 85, SavingsAccount.years_before_desired_balance(2_345.67, 12_345.678_9)
+  end
+
+  def test_years_before_desired_balance_for_negative_current_balance
+    assert_raises(ArgumentError, 'Current balance cannot be negative') do
+      Timeout.timeout(0.1) do
+        SavingsAccount.years_before_desired_balance(-1.0, 1.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
A negative `current_balance` argument for `years_before_desired_balance` will result in an endless loop for the current example. This adds a test for the edge case. We get an endless loop since a negative balance will accrue negative interest, and will therefore get further from the `desired_balance` each year (assuming the `desired_balance` is greater than the `current_balance`).

Admittedly, raising an error may not be the desired approach for this exercise depending on where on the "Learning Exercise" track this exercise falls. It seems however, that the simple calculator exercise should have already introduced the "Raising Exceptions" concept. Anyway, I'm open a different approach like just returning `Float::INFINITY` as we done in [this solution](https://exercism.org/tracks/ruby/exercises/savings-account/solutions/clairedeshayes).

I wasn't sure about what value to pass to `timeout`, but `0.1` seconds seemed like ample time :shrug: 
