### PR TITLE
Fix wrong classname in "Word Count" exercise

### DIFF
--- a/exercises/practice/word-count/.meta/example.rb
+++ b/exercises/practice/word-count/.meta/example.rb
@@ -1,4 +1,4 @@
-class Phrase
+class WordCount
   def initialize(source)
     @source = source
   end

--- a/exercises/practice/word-count/.meta/generator/word_count_case.rb
+++ b/exercises/practice/word-count/.meta/generator/word_count_case.rb
@@ -3,7 +3,7 @@ require 'generator/exercise_case'
 class WordCountCase < Generator::ExerciseCase
   def workload
     [
-      "phrase = Phrase.new(#{sentence.inspect})",
+      "phrase = WordCount.new(#{sentence.inspect})",
       "counts = #{expected}",
       "assert_equal counts, phrase.word_count"
     ]

--- a/exercises/practice/word-count/word_count_test.rb
+++ b/exercises/practice/word-count/word_count_test.rb
@@ -5,77 +5,77 @@ require_relative 'word_count'
 class WordCountTest < Minitest::Test
   def test_count_one_word
     # skip
-    phrase = Phrase.new("word")
+    phrase = WordCount.new("word")
     counts = { "word" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_count_one_of_each_word
     skip
-    phrase = Phrase.new("one of each")
+    phrase = WordCount.new("one of each")
     counts = { "one" => 1, "of" => 1, "each" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_multiple_occurrences_of_a_word
     skip
-    phrase = Phrase.new("one fish two fish red fish blue fish")
+    phrase = WordCount.new("one fish two fish red fish blue fish")
     counts = { "one" => 1, "fish" => 4, "two" => 1, "red" => 1, "blue" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_handles_cramped_lists
     skip
-    phrase = Phrase.new("one,two,three")
+    phrase = WordCount.new("one,two,three")
     counts = { "one" => 1, "two" => 1, "three" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_handles_expanded_lists
     skip
-    phrase = Phrase.new("one,\ntwo,\nthree")
+    phrase = WordCount.new("one,\ntwo,\nthree")
     counts = { "one" => 1, "two" => 1, "three" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_ignore_punctuation
     skip
-    phrase = Phrase.new("car: carpet as java: javascript!!&@$%^&")
+    phrase = WordCount.new("car: carpet as java: javascript!!&@$%^&")
     counts = { "car" => 1, "carpet" => 1, "as" => 1, "java" => 1, "javascript" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_include_numbers
     skip
-    phrase = Phrase.new("testing, 1, 2 testing")
+    phrase = WordCount.new("testing, 1, 2 testing")
     counts = { "testing" => 2, "1" => 1, "2" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_normalize_case
     skip
-    phrase = Phrase.new("go Go GO Stop stop")
+    phrase = WordCount.new("go Go GO Stop stop")
     counts = { "go" => 3, "stop" => 2 }
     assert_equal counts, phrase.word_count
   end
 
   def test_with_apostrophes
     skip
-    phrase = Phrase.new("First: don't laugh. Then: don't cry.")
+    phrase = WordCount.new("First: don't laugh. Then: don't cry.")
     counts = { "first" => 1, "don't" => 2, "laugh" => 1, "then" => 1, "cry" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_with_quotations
     skip
-    phrase = Phrase.new("Joe can't tell between 'large' and large.")
+    phrase = WordCount.new("Joe can't tell between 'large' and large.")
     counts = { "joe" => 1, "can't" => 1, "tell" => 1, "between" => 1, "large" => 2, "and" => 1 }
     assert_equal counts, phrase.word_count
   end
 
   def test_multiple_spaces_not_detected_as_a_word
     skip
-    phrase = Phrase.new(" multiple   whitespaces")
+    phrase = WordCount.new(" multiple   whitespaces")
     counts = { "multiple" => 1, "whitespaces" => 1 }
     assert_equal counts, phrase.word_count
   end


### PR DESCRIPTION
I think we are using the wrong class name in the unit tests. it should be `WordCount`, not `Phrase`.

- In the test file, there is `require_relative 'word_count'` line
- The name of the class in the test is: `WordCountTest`

So there is no reference to `Phrase` in any place