### PR TITLE
log-line-parser: Fix readme for `capitalize!` method

### DIFF
--- a/exercises/concept/log-line-parser/.docs/introduction.md
+++ b/exercises/concept/log-line-parser/.docs/introduction.md
@@ -85,8 +85,8 @@ puts my_string         #=> "hello"
 
 # And bang-methods (...!) to modify the object
 my_string = "hello"
-my_string.capitalize!  #=> nil
-puts my_string         #=> "HELLO"
+my_string.capitalize!  #=> "Hello"
+puts my_string         #=> "Hello"
 ```
 
 [docs-string]: https://ruby-doc.org/core-2.7.0/String.html


### PR DESCRIPTION
https://ruby-doc.org/core-2.7.0/String.html#method-i-capitalize-21
Based on the ruby docs, the `capitalize!` method should result in this: 
```
my_string.capitalize!  #=> "Hello"
puts my_string         #=> "Hello"
```

`nil` happens if the string is already capitalized. The full capitalization of the entire string is the `upcase` method. 