### PR TITLE
Link to wayback machine for rubylearning.com

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -4,7 +4,7 @@ Exercism provides exercises and feedback but can be difficult to jump into for t
 
 * [Ruby in Twenty Minutes](https://www.ruby-lang.org/en/documentation/quickstart/)
 * [Ruby Documentation](http://ruby-doc.org/)
-* [RubyLearning.com](http://rubylearning.com/) - Ruby Tutorial and Study Notes
+* [RubyLearning.com (on wayback machine)](http://web.archive.org/web/20210813230808/https://rubylearning.com/) - Ruby Tutorial and Study Notes
 * [Learn to Program](http://pine.fm/LearnToProgram/) - A book (available online) written by Chris Pine
 * [StackOverflow](http://stackoverflow.com/questions/tagged/ruby)
 * [RubyMonk](https://rubymonk.com/)


### PR DESCRIPTION
The link goes to the wayback machine, for now.

Hopefully I can recover the domain record.  But if not, then the changes
will need to be made permanent, perhaps the resource moved to another
domain.

I am trying to communicate with the new registered entity to resolve
this.
