### PR TITLE
fixed a missing word "by"

### DIFF
--- a/exercises/concept/bird-count/.docs/introduction.md
+++ b/exercises/concept/bird-count/.docs/introduction.md
@@ -17,7 +17,7 @@ array = [1, "two", 3.0]
 
 ### Element Reference
 
-Elements in an array can be retrieved their indexes using the `#[]` method.
+Elements in an array can be retrieved by their indexes using the `#[]` method.
 This returns the element at index, or returns a subarray starting at the start index and continuing for a specified length.
 Negative indices count backward from the end of the array.
 


### PR DESCRIPTION
it should be "Elements in an array can be retrieved by their indexes using the `#[]` method." NOT "Elements in an array can be retrieved their indexes using the `#[]` method."