### PR TITLE
Use HereDoc for NoCheating exception message

### DIFF
--- a/exercises/practice/food-chain/food_chain_test.rb
+++ b/exercises/practice/food-chain/food_chain_test.rb
@@ -4,10 +4,13 @@ require_relative 'food_chain'
 
 class NoCheating < IOError
   def message
-    "The use of File.open and IO.read is restricted.\n"                \
-    'This exercise intends to help you improve your ability to work ' \
-    'with data generated from your code. Your program must not read ' \
-    'the song.txt file.'
+    <<~END_OF_MESSAGE
+      The use of File.open and IO.read is restricted.
+
+      This exercise intends to help you improve your ability to work
+      with data generated from your code. Your program must not read
+      the song.txt file.
+    END_OF_MESSAGE
   end
 end
 


### PR DESCRIPTION
Using HereDoc removes the artificial block and line continuation, and
gives a nicer terminal view of the message, rather than breaking words
at arbitrary places in a terminal that is fairly standard width.

