### PR TITLE
fix: `BoutiqueInventory#item_name` assertions

### DIFF
--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -15,7 +15,7 @@ A single item in the inventory is represented by a hash, and the whole inventory
 ]
 ```
 
-## 1. Return a list of the names of the items.
+## 1. Return a list of the names of the items
 
 Implement `BoutiqueInventory.item_names`, which should return a list of the item names ordered alphabetically.
 

--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -15,7 +15,7 @@ A single item in the inventory is represented by a hash, and the whole inventory
 ]
 ```
 
-## 1. Return a list of the names of the items in the inventory
+## 1. Return a list of the names of the items.
 
 Implement `BoutiqueInventory.item_names`, which should return a list of the item names, ordered alphabetically.
 

--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -15,9 +15,9 @@ A single item in the inventory is represented by a hash, and the whole inventory
 ]
 ```
 
-## 1. Return a list of the names of the items in stock
+## 1. Return a list of the names of the items in the inventory
 
-Implement `BoutiqueInventory.item_names` which should return a list of the item names, ordered alphabetically.
+Implement `BoutiqueInventory.item_names`, which should return a list of the item names, ordered alphabetically.
 
 ```ruby
 BoutiqueInventory.new([

--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -17,7 +17,7 @@ A single item in the inventory is represented by a hash, and the whole inventory
 
 ## 1. Return a list of the names of the items.
 
-Implement `BoutiqueInventory.item_names`, which should return a list of the item names, ordered alphabetically.
+Implement `BoutiqueInventory.item_names`, which should return a list of the item names ordered alphabetically.
 
 ```ruby
 BoutiqueInventory.new([

--- a/exercises/concept/boutique-inventory/.meta/exemplar.rb
+++ b/exercises/concept/boutique-inventory/.meta/exemplar.rb
@@ -13,24 +13,23 @@ class BoutiqueInventory
 
   def out_of_stock
     items.select do |item|
-      item[:quantity_by_size].none? {|size, quantity| quantity > 0 }
+      item[:quantity_by_size].none? { |_size, quantity| quantity.positive? }
     end
   end
 
   def stock_for_item(name)
-    items.find {|i|i[:name] == name}[:quantity_by_size]
+    items.find { |i| i[:name] == name }[:quantity_by_size]
   end
 
   def total_stock
     items.sum do |item|
-      item[:quantity_by_size].sum {|_,quantity| quantity }
+      item[:quantity_by_size].sum { |_, quantity| quantity }
 
       # This would also be acceptable, but isn't explicitly
       # taught in this exercise:
-      #item[:quantity_by_size].values.sum
+      # item[:quantity_by_size].values.sum
     end
   end
-
 
   private
   attr_reader :items

--- a/exercises/concept/boutique-inventory/.meta/exemplar.rb
+++ b/exercises/concept/boutique-inventory/.meta/exemplar.rb
@@ -4,10 +4,7 @@ class BoutiqueInventory
   end
 
   def item_names
-    items.
-      reject { |item| item[:quantity_by_size].keys&.empty? }.
-      map { |item| item[:name] }.
-      sort
+    items.map { |item| item[:name] }.sort
   end
 
   def cheap

--- a/exercises/concept/boutique-inventory/.meta/exemplar.rb
+++ b/exercises/concept/boutique-inventory/.meta/exemplar.rb
@@ -4,7 +4,10 @@ class BoutiqueInventory
   end
 
   def item_names
-    items.map { |item| item[:name] }.sort
+    items.
+      reject { |item| item[:quantity_by_size].keys&.empty? }.
+      map { |item| item[:name] }.
+      sort
   end
 
   def cheap

--- a/exercises/concept/boutique-inventory/boutique_inventory_test.rb
+++ b/exercises/concept/boutique-inventory/boutique_inventory_test.rb
@@ -6,16 +6,9 @@ class BoutiqueInventoryTest < Minitest::Test
     assert_empty BoutiqueInventory.new([]).item_names
   end
 
-  def test_one_item_name_out_of_stock
+  def test_one_item
     items = [
       { price: 65.00, name: "Red Brown Dress", quantity_by_size: {} }
-    ]
-    assert_empty BoutiqueInventory.new(items).item_names
-  end
-
-  def test_one_item_name_in_stock
-    items = [
-      { price: 65.00, name: "Red Brown Dress", quantity_by_size: { s: 1 } }
     ]
     names = ["Red Brown Dress"]
     assert_equal names, BoutiqueInventory.new(items).item_names
@@ -25,7 +18,7 @@ class BoutiqueInventoryTest < Minitest::Test
     items = [
       { price: 65.00, name: "Red Brown Dress", quantity_by_size: { s: 1 } },
       { price: 50.00, name: "Red Short Skirt", quantity_by_size: { m: 1 } },
-      { price: 29.99, name: "Black Short Skirt", quantity_by_size: { l: 1 } }
+      { price: 29.99, name: "Black Short Skirt", quantity_by_size: {} }
     ]
     names = ["Black Short Skirt", "Red Brown Dress", "Red Short Skirt"]
     assert_equal names, BoutiqueInventory.new(items).item_names

--- a/exercises/concept/boutique-inventory/boutique_inventory_test.rb
+++ b/exercises/concept/boutique-inventory/boutique_inventory_test.rb
@@ -6,9 +6,16 @@ class BoutiqueInventoryTest < Minitest::Test
     assert_empty BoutiqueInventory.new([]).item_names
   end
 
-  def test_one_item_name
+  def test_one_item_name_out_of_stock
     items = [
       { price: 65.00, name: "Red Brown Dress", quantity_by_size: {} }
+    ]
+    assert_empty BoutiqueInventory.new(items).item_names
+  end
+
+  def test_one_item_name_in_stock
+    items = [
+      { price: 65.00, name: "Red Brown Dress", quantity_by_size: { s: 1 } }
     ]
     names = ["Red Brown Dress"]
     assert_equal names, BoutiqueInventory.new(items).item_names
@@ -16,9 +23,9 @@ class BoutiqueInventoryTest < Minitest::Test
 
   def test_three_item_names
     items = [
-      { price: 65.00, name: "Red Brown Dress", quantity_by_size: {} },
-      { price: 50.00, name: "Red Short Skirt", quantity_by_size: {} },
-      { price: 29.99, name: "Black Short Skirt", quantity_by_size: {} }
+      { price: 65.00, name: "Red Brown Dress", quantity_by_size: { s: 1 } },
+      { price: 50.00, name: "Red Short Skirt", quantity_by_size: { m: 1 } },
+      { price: 29.99, name: "Black Short Skirt", quantity_by_size: { l: 1 } }
     ]
     names = ["Black Short Skirt", "Red Brown Dress", "Red Short Skirt"]
     assert_equal names, BoutiqueInventory.new(items).item_names

--- a/exercises/concept/boutique-inventory/boutique_inventory_test.rb
+++ b/exercises/concept/boutique-inventory/boutique_inventory_test.rb
@@ -6,7 +6,7 @@ class BoutiqueInventoryTest < Minitest::Test
     assert_empty BoutiqueInventory.new([]).item_names
   end
 
-  def test_one_item
+  def test_one_item_name
     items = [
       { price: 65.00, name: "Red Brown Dress", quantity_by_size: {} }
     ]


### PR DESCRIPTION
fixes: #1315

* addresses rubocops in the files touched
* updated the [instructions.md](./exercises/concept/boutique-inventory/.docs/instructions.md) to remove ambiguity about stock levels
* updated tests to reflect that stock levels do not impact `item_name` determination
