### PR TITLE
Fix: Make Scrabble last test instantiate and call instance instead static

### DIFF
--- a/exercises/practice/scrabble-score/scrabble_score_test.rb
+++ b/exercises/practice/scrabble-score/scrabble_score_test.rb
@@ -43,6 +43,6 @@ class ScrabbleTest < Minitest::Test
 
   def test_convenient_scoring
     skip
-    assert_equal 13, Scrabble.score('alacrity')
+    assert_equal 13, Scrabble.new('alacrity').score
   end
 end


### PR DESCRIPTION
All other tests methods instantiate Scrabble and then call .score on the instance, but the last test called .score as a static method. This change makes the last test consistent with the rest.