### PR TITLE
Make the desired class methods private

### DIFF
--- a/exercises/practice/all-your-base/.meta/example.rb
+++ b/exercises/practice/all-your-base/.meta/example.rb
@@ -1,4 +1,5 @@
 class BaseConverter
+
   def self.convert(base_from, number_array, base_to)
     fail ArgumentError if invalid_inputs?(base_from, number_array, base_to)
     return [0] unless number_array.any?
@@ -6,29 +7,34 @@ class BaseConverter
     convert_from_canonical_base(number_in_canonical_base, base_to)
   end
 
-  private_class_method
+  class << self
 
-  def self.invalid_inputs?(base_from, number_array, base_to)
-    number_array.any? { |number| number < 0 || number >= base_from } ||
-      base_from <= 1 || base_to <= 1
-  end
+    private
 
-  def self.convert_to_canonical_base(number_array, base)
-    total = 0
-    number_array.reverse.each_with_index do |number, index|
-      total += number * base**index
+    def invalid_inputs?(base_from, number_array, base_to)
+      number_array.any? { |number| number < 0 || number >= base_from } ||
+        base_from <= 1 || base_to <= 1
     end
-    total
-  end
 
-  def self.convert_from_canonical_base(number, base_to)
-    result = []
-    current_number = number
-    while current_number >= base_to
+    def convert_to_canonical_base(number_array, base)
+      total = 0
+      number_array.reverse.each_with_index do |number, index|
+        total += number * base**index
+      end
+      total
+    end
+
+    def convert_from_canonical_base(number, base_to)
+      result = []
+      current_number = number
+      while current_number >= base_to
+        result << current_number % base_to
+        current_number /= base_to
+      end
       result << current_number % base_to
-      current_number /= base_to
+      result.reverse
     end
-    result << current_number % base_to
-    result.reverse
+
   end
+
 end


### PR DESCRIPTION
The `private_class_method` directive needs a list of method names (strings
are converted to symbols for that list) in order to make the methods
private.  It does not work the same as the familiar `private` method
used at the instance level.

This change creates meta-class instance methods as a group and applies
the familiar `private` directive to the methods that follow that
directive.
