### PR TITLE
protein translation private class method

### DIFF
--- a/exercises/practice/protein-translation/.meta/example.rb
+++ b/exercises/practice/protein-translation/.meta/example.rb
@@ -15,8 +15,6 @@ class Translation
     end
   end
 
-  private
-
   def self.lookups
     {
       ['AUG']             => 'Methionine',
@@ -29,5 +27,7 @@ class Translation
       %w(UAA UAG UGA)     => 'STOP'
     }
   end
+
+  private_class_method :lookups
 
 end

--- a/exercises/practice/protein-translation/.meta/example.rb
+++ b/exercises/practice/protein-translation/.meta/example.rb
@@ -3,9 +3,9 @@ class InvalidCodonError < StandardError; end
 class Translation
 
   def self.of_codon(codon)
-    found_key = lookups.keys.find { |sequences| sequences.include?(codon) }
-    fail InvalidCodonError if lookups[found_key].nil?
-    lookups[found_key]
+    found = lookups.keys.find { |sequences| sequences.include?(codon) }
+    fail InvalidCodonError if lookups[found].nil?
+    lookups[found]
   end
 
   def self.of_rna(sequence)

--- a/exercises/practice/protein-translation/.meta/example.rb
+++ b/exercises/practice/protein-translation/.meta/example.rb
@@ -4,7 +4,7 @@ class Translation
 
   def self.of_codon(codon)
     found = lookups.keys.find { |sequences| sequences.include?(codon) }
-    fail InvalidCodonError if lookups[found].nil?
+    fail InvalidCodonError unless lookups[found]
     lookups[found]
   end
 

--- a/exercises/practice/protein-translation/.meta/example.rb
+++ b/exercises/practice/protein-translation/.meta/example.rb
@@ -1,6 +1,7 @@
 class InvalidCodonError < StandardError; end
 
 class Translation
+
   def self.of_codon(codon)
     found_key = lookups.keys.find { |sequences| sequences.include?(codon) }
     fail InvalidCodonError if lookups[found_key].nil?
@@ -28,4 +29,5 @@ class Translation
       %w(UAA UAG UGA)     => 'STOP'
     }
   end
+
 end


### PR DESCRIPTION
The class was not private, since `private` only effects the methods at
the `instance` level.

Includes the following changes:

- Detach methods from class definition
- remove redundant _key part of variable name
- No need for `.nil?` check explicitly
- Make class method private
