### PR TITLE
collatz-conjecture: test invalid positive values

### DIFF
--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.rb
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.rb
@@ -36,7 +36,7 @@ class CollatzConjectureTest < Minitest::Test
       CollatzConjecture.steps(-15)
     end
   end
-  
+
   def test_positive_value_but_less_than_one_is_an_error
     skip
     assert_raises(ArgumentError) do

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.rb
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.rb
@@ -36,4 +36,11 @@ class CollatzConjectureTest < Minitest::Test
       CollatzConjecture.steps(-15)
     end
   end
+  
+  def test_positive_value_but_less_than_one_is_an_error
+    skip
+    assert_raises(ArgumentError) do
+      CollatzConjecture.steps(0.5)
+    end
+  end
 end


### PR DESCRIPTION
From a mentoring discussion with @kotp :

> The tests that exist are not enforcing that we use only valid numbers, it only touches on zero and negative numbers, but it is not inclusive of the numbers that are not valid.