### PR TITLE
Sync series exercise with problem specifications

### DIFF
--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -30,6 +30,10 @@ description = "slices of a long series"
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
 
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
+include = false
+
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"
 


### PR DESCRIPTION
This explicitly skips the test case for 'way too large' since in Ruby there's no practical difference between 'too large' and 'way too large'.