### PR TITLE
Add an exclusion for rubocop ABC metric

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,7 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Exclude:
     - "exercises/**/*_test.rb"
+    - "test/tasks/*"
 
 Metrics/MethodLength:
   # We probably want to bring this down but let's start here for now


### PR DESCRIPTION
In pull request #1356 we added some top-level
exclusions, and removed some explicit rubocop
disable directives.

I forgot to check that the disabled directives
all were redundant, and ended up removing a couple that weren't covered by the top-level exclusion.

Since we don't care too hard about the ABC metric
for tests, this adds an additional top-level
exclusion that covers these tests.