### PR TITLE
Remove problem-specifications version comments

### DIFF
--- a/exercises/practice/acronym/acronym_test.rb
+++ b/exercises/practice/acronym/acronym_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'acronym'
 
-# Common test data version: 1.7.0 cacf1f1
 class AcronymTest < Minitest::Test
   def test_basic
     # skip

--- a/exercises/practice/affine-cipher/affine_cipher_test.rb
+++ b/exercises/practice/affine-cipher/affine_cipher_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'affine_cipher'
 
-# Common test data version: 2.0.0 8026923
 class AffineCipherTest < Minitest::Test
   def test_encode_yes
     # skip

--- a/exercises/practice/all-your-base/all_your_base_test.rb
+++ b/exercises/practice/all-your-base/all_your_base_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'all_your_base'
 
-# Common test data version: 2.3.0 c21ffd7
 class AllYourBaseTest < Minitest::Test
   def test_single_bit_one_to_decimal
     # skip

--- a/exercises/practice/allergies/allergies_test.rb
+++ b/exercises/practice/allergies/allergies_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'allergies'
 
-# Common test data version: 1.2.0 17a2ab2
 class AllergiesTest < Minitest::Test
   def test_no_allergies_means_not_allergic
     # skip

--- a/exercises/practice/alphametics/alphametics_test.rb
+++ b/exercises/practice/alphametics/alphametics_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'alphametics'
 
-# Common test data version: 1.3.0 361cf3c
 class AlphameticsTest < Minitest::Test
   def test_puzzle_with_three_letters
     # skip

--- a/exercises/practice/anagram/anagram_test.rb
+++ b/exercises/practice/anagram/anagram_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'anagram'
 
-# Common test data version: 1.5.0 49a36fe
 class AnagramTest < Minitest::Test
   def test_no_matches
     # skip

--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.rb
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'armstrong_numbers'
 
-# Common test data version: 1.1.0 b3c2522
 class ArmstrongNumbersTest < Minitest::Test
   def test_zero_is_an_armstrong_number
     # skip

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.rb
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'atbash_cipher'
 
-# Common test data version: 1.2.0 d5238bd
 class AtbashCipherTest < Minitest::Test
   def test_encode_yes
     # skip

--- a/exercises/practice/beer-song/beer_song_test.rb
+++ b/exercises/practice/beer-song/beer_song_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'beer_song'
 
-# Common test data version: 2.1.0 87a334d
 class BeerSongTest < Minitest::Test
   def test_first_generic_verse
     # skip

--- a/exercises/practice/binary-search/binary_search_test.rb
+++ b/exercises/practice/binary-search/binary_search_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'binary_search'
 
-# Common test data version: 1.3.0 bfb218f
 class BinarySearchTest < Minitest::Test
   def test_finds_a_value_in_an_array_with_one_element
     # skip

--- a/exercises/practice/binary/binary_test.rb
+++ b/exercises/practice/binary/binary_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'binary'
 
-# Common test data version: 1.1.0 dd3c07e
 class BinaryTest < Minitest::Test
   def test_binary_0_is_decimal_0
     # skip

--- a/exercises/practice/bob/bob_test.rb
+++ b/exercises/practice/bob/bob_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'bob'
 
-# Common test data version: 1.6.0 42b9d45
 class BobTest < Minitest::Test
   def test_stating_something
     # skip

--- a/exercises/practice/book-store/book_store_test.rb
+++ b/exercises/practice/book-store/book_store_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'book_store'
 
-# Common test data version: 1.4.0 33c6b60
 class BookStoreTest < Minitest::Test
   def test_only_a_single_book
     # skip

--- a/exercises/practice/bowling/bowling_test.rb
+++ b/exercises/practice/bowling/bowling_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'bowling'
 
-# Common test data version: 1.2.0 1806718
 class BowlingTest < Minitest::Test
   def test_should_be_able_to_score_a_game_with_all_zeros
     # skip

--- a/exercises/practice/change/change_test.rb
+++ b/exercises/practice/change/change_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'change'
 
-# Common test data version: 1.3.0 258c807
 class ChangeTest < Minitest::Test
   def test_single_coin_change
     # skip

--- a/exercises/practice/clock/clock_test.rb
+++ b/exercises/practice/clock/clock_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'clock'
 
-# Common test data version: 2.4.0 b344762
 class ClockTest < Minitest::Test
   def test_on_the_hour
     # skip

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.rb
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'collatz_conjecture'
 
-# Common test data version: 1.2.1 d94e348
 class CollatzConjectureTest < Minitest::Test
   def test_zero_steps_for_one
     # skip

--- a/exercises/practice/complex-numbers/complex_numbers_test.rb
+++ b/exercises/practice/complex-numbers/complex_numbers_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'complex_numbers'
 
-# Common test data version: 1.3.0 1e1c9ca
 class ComplexNumbersTest < Minitest::Test
   def test_real_part_of_a_purely_real_number
     # skip

--- a/exercises/practice/connect/connect_test.rb
+++ b/exercises/practice/connect/connect_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'connect'
 
-# Common test data version: 1.1.0 a02d64d
 class ConnectTest < Minitest::Test
   def test_an_empty_board_has_no_winner
     # skip

--- a/exercises/practice/crypto-square/crypto_square_test.rb
+++ b/exercises/practice/crypto-square/crypto_square_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'crypto_square'
 
-# Common test data version: 3.2.0 e00dfb3
 class CryptoSquareTest < Minitest::Test
   def test_empty_plaintext_results_in_an_empty_ciphertext
     # skip

--- a/exercises/practice/custom-set/custom_set_test.rb
+++ b/exercises/practice/custom-set/custom_set_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'custom_set'
 
-# Common test data version: 1.3.0 1ef368e
 class CustomSetTest < Minitest::Test
   def test_sets_with_no_elements_are_empty
     # skip

--- a/exercises/practice/darts/darts_test.rb
+++ b/exercises/practice/darts/darts_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'darts'
 
-# Common test data version: 2.2.0 f60c43b
 class DartsTest < Minitest::Test
   def test_missed_target
     # skip

--- a/exercises/practice/difference-of-squares/difference_of_squares_test.rb
+++ b/exercises/practice/difference-of-squares/difference_of_squares_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'difference_of_squares'
 
-# Common test data version: 1.2.0 1b6851d
 class DifferenceOfSquaresTest < Minitest::Test
   def test_square_of_sum_1
     # skip

--- a/exercises/practice/dominoes/dominoes_test.rb
+++ b/exercises/practice/dominoes/dominoes_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'dominoes'
 
-# Common test data version: 2.1.0 b5bc74d
 class DominoesTest < Minitest::Test
   def test_empty_input_empty_output
     # skip

--- a/exercises/practice/etl/etl_test.rb
+++ b/exercises/practice/etl/etl_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'etl'
 
-# Common test data version: 1.0.0 ca9ed58
 class EtlTest < Minitest::Test
   def test_a_single_letter
     # skip

--- a/exercises/practice/flatten-array/flatten_array_test.rb
+++ b/exercises/practice/flatten-array/flatten_array_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'flatten_array'
 
-# Common test data version: 1.2.0 0290376
 class FlattenArrayTest < Minitest::Test
   def test_no_nesting
     # skip

--- a/exercises/practice/gigasecond/gigasecond_test.rb
+++ b/exercises/practice/gigasecond/gigasecond_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'gigasecond'
 
-# Common test data version: 1.1.0 5506bac
 class GigasecondTest < Minitest::Test
   def test_date_only_specification_of_time
     # skip

--- a/exercises/practice/grains/grains_test.rb
+++ b/exercises/practice/grains/grains_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'grains'
 
-# Common test data version: 1.2.0 2ec42ab
 class GrainsTest < Minitest::Test
   def test_1
     # skip

--- a/exercises/practice/grep/grep_test.rb
+++ b/exercises/practice/grep/grep_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'grep'
 
-# Common test data version: 1.2.0 4f2efaa
 class GrepTest < Minitest::Test
   def setup
     IO.write 'iliad.txt', <<~ILIAD

--- a/exercises/practice/hamming/hamming_test.rb
+++ b/exercises/practice/hamming/hamming_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'hamming'
 
-# Common test data version: 2.2.0 4c453c8
 class HammingTest < Minitest::Test
   def test_empty_strands
     # skip

--- a/exercises/practice/hello-world/hello_world_test.rb
+++ b/exercises/practice/hello-world/hello_world_test.rb
@@ -11,7 +11,6 @@ rescue LoadError => e
   exit 1
 end
 
-# Common test data version: 1.1.0 be3ae66
 class HelloWorldTest < Minitest::Test
   def test_say_hi
     # skip

--- a/exercises/practice/high-scores/high_scores_test.rb
+++ b/exercises/practice/high-scores/high_scores_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'high_scores'
 
-# Common test data version: 5.0.0 7dfb96c
 class HighScoresTest < Minitest::Test
   def test_list_of_scores
     # skip

--- a/exercises/practice/isbn-verifier/isbn_verifier_test.rb
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'isbn_verifier'
 
-# Common test data version: 2.7.0 3134243
 class IsbnVerifierTest < Minitest::Test
   def test_valid_isbn_number
     # skip

--- a/exercises/practice/isogram/isogram_test.rb
+++ b/exercises/practice/isogram/isogram_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'isogram'
 
-# Common test data version: 1.7.0 74869e8
 class IsogramTest < Minitest::Test
   def test_empty_string
     # skip

--- a/exercises/practice/largest-series-product/largest_series_product_test.rb
+++ b/exercises/practice/largest-series-product/largest_series_product_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'largest_series_product'
 
-# Common test data version: 1.2.0 85da7a5
 class LargestSeriesProductTest < Minitest::Test
   def test_finds_the_largest_product_if_span_equals_length
     # skip

--- a/exercises/practice/leap/leap_test.rb
+++ b/exercises/practice/leap/leap_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'leap'
 
-# Common test data version: 1.4.0 3134d31
 class Date
   def leap?
     raise "Implement this yourself instead of using Ruby's implementation."

--- a/exercises/practice/luhn/luhn_test.rb
+++ b/exercises/practice/luhn/luhn_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'luhn'
 
-# Common test data version: 1.4.0 4a80663
 class LuhnTest < Minitest::Test
   def test_single_digit_strings_can_not_be_valid
     # skip

--- a/exercises/practice/matching-brackets/matching_brackets_test.rb
+++ b/exercises/practice/matching-brackets/matching_brackets_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'matching_brackets'
 
-# Common test data version: 1.5.0 20dd164
 class MatchingBracketsTest < Minitest::Test
   def test_paired_square_brackets
     # skip

--- a/exercises/practice/meetup/meetup_test.rb
+++ b/exercises/practice/meetup/meetup_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'meetup'
 
-# Common test data version: 1.1.0 56cdfa5
 class MeetupTest < Minitest::Test
   def test_monteenth_of_may_2013
     # skip

--- a/exercises/practice/microwave/microwave_test.rb
+++ b/exercises/practice/microwave/microwave_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'microwave'
 
-# Common test data version: 1.7.0 cacf1f1
 class MicrowaveTest < Minitest::Test
   def test_one_second
     assert_equal '00:01', Microwave.new(1).timer

--- a/exercises/practice/nth-prime/nth_prime_test.rb
+++ b/exercises/practice/nth-prime/nth_prime_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'nth_prime'
 
-# Common test data version: 2.1.0 4a3ba76
 class NthPrimeTest < Minitest::Test
   def test_first_prime
     # skip

--- a/exercises/practice/ocr-numbers/ocr_numbers_test.rb
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'ocr_numbers'
 
-# Common test data version: 1.2.0 965ecad
 class OcrNumbersTest < Minitest::Test
   def test_recognizes_0
     # skip

--- a/exercises/practice/pangram/pangram_test.rb
+++ b/exercises/practice/pangram/pangram_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'pangram'
 
-# Common test data version: 1.4.1 2c020bc
 class PangramTest < Minitest::Test
   def test_sentence_empty
     # skip

--- a/exercises/practice/phone-number/phone_number_test.rb
+++ b/exercises/practice/phone-number/phone_number_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'phone_number'
 
-# Common test data version: 1.6.1 fc57696
 class PhoneNumberTest < Minitest::Test
   def test_cleans_the_number
     # skip

--- a/exercises/practice/pig-latin/pig_latin_test.rb
+++ b/exercises/practice/pig-latin/pig_latin_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'pig_latin'
 
-# Common test data version: 1.2.0 d77de78
 class PigLatinTest < Minitest::Test
   def test_word_beginning_with_a
     # skip

--- a/exercises/practice/queen-attack/queen_attack_test.rb
+++ b/exercises/practice/queen-attack/queen_attack_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'queen_attack'
 
-# Common test data version: 2.2.0 aaadbac
 class QueenAttackTest < Minitest::Test
   def test_queen_with_a_valid_position
     # skip

--- a/exercises/practice/raindrops/raindrops_test.rb
+++ b/exercises/practice/raindrops/raindrops_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'raindrops'
 
-# Common test data version: 1.1.0 99de15d
 class RaindropsTest < Minitest::Test
   def test_the_sound_for_1_is_1
     # skip

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.rb
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'resistor_color_duo'
 
-# Common test data version: 2.1.0 00dda3a
 class ResistorColorDuoTest < Minitest::Test
   def test_brown_and_black
     # skip

--- a/exercises/practice/resistor-color-trio/resistor_color_trio_test.rb
+++ b/exercises/practice/resistor-color-trio/resistor_color_trio_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'resistor_color_trio'
 
-# Common test data version: 1.1.0 2c41a51
 class ResistorColorTrioTest < Minitest::Test
   def test_orange_and_orange_and_black
     # skip

--- a/exercises/practice/resistor-color/resistor_color_test.rb
+++ b/exercises/practice/resistor-color/resistor_color_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'resistor_color'
 
-# Common test data version: 1.0.0 edf1778
 class ResistorColorTest < Minitest::Test
   def test_black
     # skip

--- a/exercises/practice/rna-transcription/rna_transcription_test.rb
+++ b/exercises/practice/rna-transcription/rna_transcription_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'rna_transcription'
 
-# Common test data version: 1.3.0 294c831
 class RnaTranscriptionTest < Minitest::Test
   def test_empty_rna_sequence
     # skip

--- a/exercises/practice/roman-numerals/roman_numerals_test.rb
+++ b/exercises/practice/roman-numerals/roman_numerals_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'roman_numerals'
 
-# Common test data version: 1.2.0 3c78ac4
 class RomanNumeralsTest < Minitest::Test
   def test_1_is_a_single_i
     # skip

--- a/exercises/practice/rotational-cipher/rotational_cipher_test.rb
+++ b/exercises/practice/rotational-cipher/rotational_cipher_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'rotational_cipher'
 
-# Common test data version: 1.2.0 cf23851
 class RotationalCipherTest < Minitest::Test
   def test_rotate_a_by_0_same_output_as_input
     # skip

--- a/exercises/practice/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/practice/run-length-encoding/run_length_encoding_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'run_length_encoding'
 
-# Common test data version: 1.1.0 1b7900e
 class RunLengthEncodingTest < Minitest::Test
   def test_encode_empty_string
     # skip

--- a/exercises/practice/say/say_test.rb
+++ b/exercises/practice/say/say_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'say'
 
-# Common test data version: 1.2.0 a0cee46
 class SayTest < Minitest::Test
   def test_zero
     # skip

--- a/exercises/practice/sieve/sieve_test.rb
+++ b/exercises/practice/sieve/sieve_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'sieve'
 
-# Common test data version: 1.1.0 8bbb634
 class SieveTest < Minitest::Test
   def test_no_primes_under_two
     # skip

--- a/exercises/practice/space-age/space_age_test.rb
+++ b/exercises/practice/space-age/space_age_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'space_age'
 
-# Common test data version: 1.1.0 8d4df79
 class SpaceAgeTest < Minitest::Test
   # assert_in_delta will pass if the difference
   # between the values being compared is less

--- a/exercises/practice/sum-of-multiples/sum_of_multiples_test.rb
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'sum_of_multiples'
 
-# Common test data version: 1.4.1 8f89751
 class SumOfMultiplesTest < Minitest::Test
   def test_no_multiples_within_limit
     # skip

--- a/exercises/practice/tournament/tournament_test.rb
+++ b/exercises/practice/tournament/tournament_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'tournament'
 
-# Common test data version: 1.4.0 ee01fe0
 class TournamentTest < Minitest::Test
   def test_just_the_header_if_no_input
     # skip

--- a/exercises/practice/transpose/transpose_test.rb
+++ b/exercises/practice/transpose/transpose_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'transpose'
 
-# Common test data version: 1.1.0 92bc877
 class TransposeTest < Minitest::Test
   def test_empty_string
     # skip

--- a/exercises/practice/triangle/triangle_test.rb
+++ b/exercises/practice/triangle/triangle_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'triangle'
 
-# Common test data version: 1.2.0 55f89ca
 class TriangleTest < Minitest::Test
   def test_triangle_is_equilateral_if_all_sides_are_equal
     # skip

--- a/exercises/practice/two-bucket/two_bucket_test.rb
+++ b/exercises/practice/two-bucket/two_bucket_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'two_bucket'
 
-# Common test data version: 1.4.0 edbc86b
 class TwoBucketTest < Minitest::Test
   def test_bucket_one_size_3_bucket_two_size_5_goal_1_start_with_bucket_one
     # skip

--- a/exercises/practice/two-fer/two_fer_test.rb
+++ b/exercises/practice/two-fer/two_fer_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'two_fer'
 
-# Common test data version: 1.2.0 4fc1acb
 class TwoFerTest < Minitest::Test
   def test_no_name_given
     # skip

--- a/exercises/practice/word-count/word_count_test.rb
+++ b/exercises/practice/word-count/word_count_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'word_count'
 
-# Common test data version: 1.2.0 77623ec
 class WordCountTest < Minitest::Test
   def test_count_one_word
     # skip

--- a/exercises/practice/wordy/wordy_test.rb
+++ b/exercises/practice/wordy/wordy_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'wordy'
 
-# Common test data version: 1.2.0 86d0069
 class WordyTest < Minitest::Test
   def test_addition
     # skip

--- a/exercises/practice/zipper/zipper_test.rb
+++ b/exercises/practice/zipper/zipper_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative 'zipper'
 
-# Common test data version: 1.1.0 6fb5601
 class ZipperTest < Minitest::Test
   def test_data_is_retained
     # skip


### PR DESCRIPTION
The problem-specifications are no longer versioned.

This removes the version comment from all the test files that were generated, as the tests.toml file acts as the canonical reference as to which tests have been implemented or not.