### PR TITLE
Update allergies to match problem-specifications

### DIFF
--- a/exercises/practice/allergies/.docs/instructions.md
+++ b/exercises/practice/allergies/.docs/instructions.md
@@ -21,8 +21,8 @@ So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
 
 Now, given just that score of 34, your program should be able to say:
 
-- Whether Tom is allergic to any one of those allergens listed above.
-- All the allergens Tom is allergic to.
+* Whether Tom is allergic to any one of those allergens listed above.
+* All the allergens Tom is allergic to.
 
 Note: a given score may include allergens **not** listed above (i.e.
 allergens that score 256, 512, 1024, etc.).  Your program should

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -10,148 +10,151 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
-description = "not allergic to anything"
+description = "testing for eggs allergy -> not allergic to anything"
 
 [07ced27b-1da5-4c2e-8ae2-cb2791437546]
-description = "allergic only to eggs"
+description = "testing for eggs allergy -> allergic only to eggs"
 
 [5035b954-b6fa-4b9b-a487-dae69d8c5f96]
-description = "allergic to eggs and something else"
+description = "testing for eggs allergy -> allergic to eggs and something else"
 
 [64a6a83a-5723-4b5b-a896-663307403310]
-description = "allergic to something, but not eggs"
+description = "testing for eggs allergy -> allergic to something, but not eggs"
 
 [90c8f484-456b-41c4-82ba-2d08d93231c6]
-description = "allergic to everything"
+description = "testing for eggs allergy -> allergic to everything"
 
 [d266a59a-fccc-413b-ac53-d57cb1f0db9d]
-description = "not allergic to anything"
+description = "testing for peanuts allergy -> not allergic to anything"
 
 [ea210a98-860d-46b2-a5bf-50d8995b3f2a]
-description = "allergic only to peanuts"
+description = "testing for peanuts allergy -> allergic only to peanuts"
 
 [eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
-description = "allergic to peanuts and something else"
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
 
 [9152058c-ce39-4b16-9b1d-283ec6d25085]
-description = "allergic to something, but not peanuts"
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
 
 [d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
-description = "allergic to everything"
+description = "testing for peanuts allergy -> allergic to everything"
 
 [b948b0a1-cbf7-4b28-a244-73ff56687c80]
-description = "not allergic to anything"
+description = "testing for shellfish allergy -> not allergic to anything"
 
 [9ce9a6f3-53e9-4923-85e0-73019047c567]
-description = "allergic only to shellfish"
+description = "testing for shellfish allergy -> allergic only to shellfish"
 
 [b272fca5-57ba-4b00-bd0c-43a737ab2131]
-description = "allergic to shellfish and something else"
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
 
 [21ef8e17-c227-494e-8e78-470a1c59c3d8]
-description = "allergic to something, but not shellfish"
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
 
 [cc789c19-2b5e-4c67-b146-625dc8cfa34e]
-description = "allergic to everything"
+description = "testing for shellfish allergy -> allergic to everything"
 
 [651bde0a-2a74-46c4-ab55-02a0906ca2f5]
-description = "not allergic to anything"
+description = "testing for strawberries allergy -> not allergic to anything"
 
 [b649a750-9703-4f5f-b7f7-91da2c160ece]
-description = "allergic only to strawberries"
+description = "testing for strawberries allergy -> allergic only to strawberries"
 
 [50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
-description = "allergic to strawberries and something else"
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
 
 [23dd6952-88c9-48d7-a7d5-5d0343deb18d]
-description = "allergic to something, but not strawberries"
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
 
 [74afaae2-13b6-43a2-837a-286cd42e7d7e]
-description = "allergic to everything"
+description = "testing for strawberries allergy -> allergic to everything"
 
 [c49a91ef-6252-415e-907e-a9d26ef61723]
-description = "not allergic to anything"
+description = "testing for tomatoes allergy -> not allergic to anything"
 
 [b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
-description = "allergic only to tomatoes"
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
 
 [1ca50eb1-f042-4ccf-9050-341521b929ec]
-description = "allergic to tomatoes and something else"
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
 
 [e9846baa-456b-4eff-8025-034b9f77bd8e]
-description = "allergic to something, but not tomatoes"
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
 
 [b2414f01-f3ad-4965-8391-e65f54dad35f]
-description = "allergic to everything"
+description = "testing for tomatoes allergy -> allergic to everything"
 
 [978467ab-bda4-49f7-b004-1d011ead947c]
-description = "not allergic to anything"
+description = "testing for chocolate allergy -> not allergic to anything"
 
 [59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
-description = "allergic only to chocolate"
+description = "testing for chocolate allergy -> allergic only to chocolate"
 
 [b0a7c07b-2db7-4f73-a180-565e07040ef1]
-description = "allergic to chocolate and something else"
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
 
 [f5506893-f1ae-482a-b516-7532ba5ca9d2]
-description = "allergic to something, but not chocolate"
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
 
 [02debb3d-d7e2-4376-a26b-3c974b6595c6]
-description = "allergic to everything"
+description = "testing for chocolate allergy -> allergic to everything"
 
 [17f4a42b-c91e-41b8-8a76-4797886c2d96]
-description = "not allergic to anything"
+description = "testing for pollen allergy -> not allergic to anything"
 
 [7696eba7-1837-4488-882a-14b7b4e3e399]
-description = "allergic only to pollen"
+description = "testing for pollen allergy -> allergic only to pollen"
 
 [9a49aec5-fa1f-405d-889e-4dfc420db2b6]
-description = "allergic to pollen and something else"
+description = "testing for pollen allergy -> allergic to pollen and something else"
 
 [3cb8e79f-d108-4712-b620-aa146b1954a9]
-description = "allergic to something, but not pollen"
+description = "testing for pollen allergy -> allergic to something, but not pollen"
 
 [1dc3fe57-7c68-4043-9d51-5457128744b2]
-description = "allergic to everything"
+description = "testing for pollen allergy -> allergic to everything"
 
 [d3f523d6-3d50-419b-a222-d4dfd62ce314]
-description = "not allergic to anything"
+description = "testing for cats allergy -> not allergic to anything"
 
 [eba541c3-c886-42d3-baef-c048cb7fcd8f]
-description = "allergic only to cats"
+description = "testing for cats allergy -> allergic only to cats"
 
 [ba718376-26e0-40b7-bbbe-060287637ea5]
-description = "allergic to cats and something else"
+description = "testing for cats allergy -> allergic to cats and something else"
 
 [3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
-description = "allergic to something, but not cats"
+description = "testing for cats allergy -> allergic to something, but not cats"
 
 [1faabb05-2b98-4995-9046-d83e4a48a7c1]
-description = "allergic to everything"
+description = "testing for cats allergy -> allergic to everything"
 
 [f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
-description = "no allergies"
+description = "list when: -> no allergies"
 
 [9e1a4364-09a6-4d94-990f-541a94a4c1e8]
-description = "just eggs"
+description = "list when: -> just eggs"
 
 [8851c973-805e-4283-9e01-d0c0da0e4695]
-description = "just peanuts"
+description = "list when: -> just peanuts"
 
 [2c8943cb-005e-435f-ae11-3e8fb558ea98]
-description = "just strawberries"
+description = "list when: -> just strawberries"
 
 [6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
-description = "eggs and peanuts"
+description = "list when: -> eggs and peanuts"
 
 [19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
-description = "more than eggs but not peanuts"
+description = "list when: -> more than eggs but not peanuts"
 
 [4b68f470-067c-44e4-889f-c9fe28917d2f]
-description = "lots of stuff"
+description = "list when: -> lots of stuff"
 
 [0881b7c5-9efa-4530-91bd-68370d054bc7]
-description = "everything"
+description = "list when: -> everything"
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
-description = "no allergen score parts"
+description = "list when: -> no allergen score parts"
+
+[93c2df3e-4f55-4fed-8116-7513092819cd]
+description = "list when: -> no allergen score parts without highest valid score"

--- a/exercises/practice/allergies/allergies_test.rb
+++ b/exercises/practice/allergies/allergies_test.rb
@@ -2,97 +2,303 @@ require 'minitest/autorun'
 require_relative 'allergies'
 
 class AllergiesTest < Minitest::Test
-  def test_no_allergies_means_not_allergic
+  def test_testing_for_eggs_allergy_not_allergic_to_anything
     # skip
     allergies = Allergies.new(0)
-    refute allergies.allergic_to?('peanuts')
-    refute allergies.allergic_to?('cats')
-    refute allergies.allergic_to?('strawberries')
+    refute allergies.allergic_to?("eggs"), "Tom is not allergic, but it says he is."
   end
 
-  def test_is_allergic_to_eggs
+  def test_testing_for_eggs_allergy_allergic_only_to_eggs
     skip
     allergies = Allergies.new(1)
-    assert allergies.allergic_to?('eggs')
+    assert allergies.allergic_to?("eggs"), "Tom is allergic, but it says he is not."
   end
 
-  def test_allergic_to_eggs_in_addition_to_other_stuff
-    skip
-    allergies = Allergies.new(5)
-    assert allergies.allergic_to?('eggs')
-    assert allergies.allergic_to?('shellfish')
-    refute allergies.allergic_to?('strawberries')
-  end
-
-  def test_allergic_to_strawberries_but_not_peanuts
-    skip
-    allergies = Allergies.new(9)
-    assert allergies.allergic_to?('eggs')
-    refute allergies.allergic_to?('peanuts')
-    refute allergies.allergic_to?('shellfish')
-    assert allergies.allergic_to?('strawberries')
-  end
-
-  def test_no_allergies_at_all
-    skip
-    allergies = Allergies.new(0)
-    expected_items = []
-    assert_equal expected_items, allergies.list.sort
-  end
-
-  def test_allergic_to_just_eggs
-    skip
-    allergies = Allergies.new(1)
-    expected_items = ["eggs"]
-    assert_equal expected_items, allergies.list.sort
-  end
-
-  def test_allergic_to_just_peanuts
-    skip
-    allergies = Allergies.new(2)
-    expected_items = ["peanuts"]
-    assert_equal expected_items, allergies.list.sort
-  end
-
-  def test_allergic_to_just_strawberries
-    skip
-    allergies = Allergies.new(8)
-    expected_items = ["strawberries"]
-    assert_equal expected_items, allergies.list.sort
-  end
-
-  def test_allergic_to_eggs_and_peanuts
+  def test_testing_for_eggs_allergy_allergic_to_eggs_and_something_else
     skip
     allergies = Allergies.new(3)
-    expected_items = %w[eggs peanuts]
-    assert_equal expected_items, allergies.list.sort
+    assert allergies.allergic_to?("eggs"), "Tom is allergic, but it says he is not."
   end
 
-  def test_allergic_to_more_than_eggs_but_not_peanuts
+  def test_testing_for_eggs_allergy_allergic_to_something_but_not_eggs
     skip
-    allergies = Allergies.new(5)
-    expected_items = %w[eggs shellfish]
-    assert_equal expected_items, allergies.list.sort
+    allergies = Allergies.new(2)
+    refute allergies.allergic_to?("eggs"), "Tom is not allergic, but it says he is."
   end
 
-  def test_allergic_to_lots_of_stuff
-    skip
-    allergies = Allergies.new(248)
-    expected_items = %w[cats chocolate pollen strawberries tomatoes]
-    assert_equal expected_items, allergies.list.sort
-  end
-
-  def test_allergic_to_everything
+  def test_testing_for_eggs_allergy_allergic_to_everything
     skip
     allergies = Allergies.new(255)
-    expected_items = %w[cats chocolate eggs peanuts pollen shellfish strawberries tomatoes]
-    assert_equal expected_items, allergies.list.sort
+    assert allergies.allergic_to?("eggs"), "Tom is allergic, but it says he is not."
   end
 
-  def test_ignore_non_allergen_score_parts
+  def test_testing_for_peanuts_allergy_not_allergic_to_anything
     skip
-    allergies = Allergies.new(509)
-    expected_items = %w[cats chocolate eggs pollen shellfish strawberries tomatoes]
-    assert_equal expected_items, allergies.list.sort
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("peanuts"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_peanuts_allergy_allergic_only_to_peanuts
+    skip
+    allergies = Allergies.new(2)
+    assert allergies.allergic_to?("peanuts"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_peanuts_allergy_allergic_to_peanuts_and_something_else
+    skip
+    allergies = Allergies.new(7)
+    assert allergies.allergic_to?("peanuts"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_peanuts_allergy_allergic_to_something_but_not_peanuts
+    skip
+    allergies = Allergies.new(5)
+    refute allergies.allergic_to?("peanuts"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_peanuts_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("peanuts"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_shellfish_allergy_not_allergic_to_anything
+    skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("shellfish"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_shellfish_allergy_allergic_only_to_shellfish
+    skip
+    allergies = Allergies.new(4)
+    assert allergies.allergic_to?("shellfish"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_shellfish_allergy_allergic_to_shellfish_and_something_else
+    skip
+    allergies = Allergies.new(14)
+    assert allergies.allergic_to?("shellfish"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_shellfish_allergy_allergic_to_something_but_not_shellfish
+    skip
+    allergies = Allergies.new(10)
+    refute allergies.allergic_to?("shellfish"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_shellfish_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("shellfish"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_strawberries_allergy_not_allergic_to_anything
+    skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("strawberries"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_strawberries_allergy_allergic_only_to_strawberries
+    skip
+    allergies = Allergies.new(8)
+    assert allergies.allergic_to?("strawberries"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_strawberries_allergy_allergic_to_strawberries_and_something_else
+    skip
+    allergies = Allergies.new(28)
+    assert allergies.allergic_to?("strawberries"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_strawberries_allergy_allergic_to_something_but_not_strawberries
+    skip
+    allergies = Allergies.new(20)
+    refute allergies.allergic_to?("strawberries"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_strawberries_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("strawberries"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_tomatoes_allergy_not_allergic_to_anything
+    skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("tomatoes"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_tomatoes_allergy_allergic_only_to_tomatoes
+    skip
+    allergies = Allergies.new(16)
+    assert allergies.allergic_to?("tomatoes"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_tomatoes_allergy_allergic_to_tomatoes_and_something_else
+    skip
+    allergies = Allergies.new(56)
+    assert allergies.allergic_to?("tomatoes"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_tomatoes_allergy_allergic_to_something_but_not_tomatoes
+    skip
+    allergies = Allergies.new(40)
+    refute allergies.allergic_to?("tomatoes"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_tomatoes_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("tomatoes"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_chocolate_allergy_not_allergic_to_anything
+    skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("chocolate"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_chocolate_allergy_allergic_only_to_chocolate
+    skip
+    allergies = Allergies.new(32)
+    assert allergies.allergic_to?("chocolate"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_chocolate_allergy_allergic_to_chocolate_and_something_else
+    skip
+    allergies = Allergies.new(112)
+    assert allergies.allergic_to?("chocolate"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_chocolate_allergy_allergic_to_something_but_not_chocolate
+    skip
+    allergies = Allergies.new(80)
+    refute allergies.allergic_to?("chocolate"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_chocolate_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("chocolate"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_pollen_allergy_not_allergic_to_anything
+    skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("pollen"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_pollen_allergy_allergic_only_to_pollen
+    skip
+    allergies = Allergies.new(64)
+    assert allergies.allergic_to?("pollen"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_pollen_allergy_allergic_to_pollen_and_something_else
+    skip
+    allergies = Allergies.new(224)
+    assert allergies.allergic_to?("pollen"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_pollen_allergy_allergic_to_something_but_not_pollen
+    skip
+    allergies = Allergies.new(160)
+    refute allergies.allergic_to?("pollen"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_pollen_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("pollen"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_cats_allergy_not_allergic_to_anything
+    skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?("cats"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_cats_allergy_allergic_only_to_cats
+    skip
+    allergies = Allergies.new(128)
+    assert allergies.allergic_to?("cats"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_cats_allergy_allergic_to_cats_and_something_else
+    skip
+    allergies = Allergies.new(192)
+    assert allergies.allergic_to?("cats"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_testing_for_cats_allergy_allergic_to_something_but_not_cats
+    skip
+    allergies = Allergies.new(64)
+    refute allergies.allergic_to?("cats"), "Tom is not allergic, but it says he is."
+  end
+
+  def test_testing_for_cats_allergy_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert allergies.allergic_to?("cats"), "Tom is allergic, but it says he is not."
+  end
+
+  def test_list_when_no_allergies
+    skip
+    expected = []
+    assert_equal expected, Allergies.new(0).list
+  end
+
+  def test_list_when_just_eggs
+    skip
+    expected = ["eggs"]
+    assert_equal expected, Allergies.new(1).list
+  end
+
+  def test_list_when_just_peanuts
+    skip
+    expected = ["peanuts"]
+    assert_equal expected, Allergies.new(2).list
+  end
+
+  def test_list_when_just_strawberries
+    skip
+    expected = ["strawberries"]
+    assert_equal expected, Allergies.new(8).list
+  end
+
+  def test_list_when_eggs_and_peanuts
+    skip
+    expected = %w[eggs peanuts]
+    assert_equal expected, Allergies.new(3).list
+  end
+
+  def test_list_when_more_than_eggs_but_not_peanuts
+    skip
+    expected = %w[eggs shellfish]
+    assert_equal expected, Allergies.new(5).list
+  end
+
+  def test_list_when_lots_of_stuff
+    skip
+    expected = %w[strawberries tomatoes chocolate pollen cats]
+    assert_equal expected, Allergies.new(248).list
+  end
+
+  def test_list_when_everything
+    skip
+    expected = %w[eggs peanuts shellfish strawberries tomatoes chocolate pollen cats]
+    assert_equal expected, Allergies.new(255).list
+  end
+
+  def test_list_when_no_allergen_score_parts
+    skip
+    expected = %w[eggs shellfish strawberries tomatoes chocolate pollen cats]
+    assert_equal expected, Allergies.new(509).list
+  end
+
+  def test_list_when_no_allergen_score_parts_without_highest_valid_score
+    skip
+    expected = ["eggs"]
+    assert_equal expected, Allergies.new(257).list
   end
 end


### PR DESCRIPTION
This syncs the docs as well as the test list (tests.toml) with the data from problem-specifications, adding one missing test.

I regenerated the test suite from scratch, making individual tests instead of grouping them as we did before. It looks like the choice to group the tests was based on a previous version of the canonical data, and that we didn't have a strong philosophical preference for doing it that way.

I added custom messages to the asserts and refutes (per #386), and am happy to tweak those if anyone has any suggestion for improvements there.