### PR TITLE
Update bowling from problem-specifications

### DIFF
--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Score a bowling game",
+  "blurb": "Score a bowling game.",
   "authors": [
     "bernardoamc"
   ],
@@ -27,6 +27,6 @@
       ".meta/example.rb"
     ]
   },
-  "source": "The Bowling Game Kata at but UncleBob",
+  "source": "The Bowling Game Kata from UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
 }

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -45,6 +45,9 @@ description = "rolling a spare with the two roll bonus does not get a bonus roll
 [576faac1-7cff-4029-ad72-c16bcada79b5]
 description = "strikes with the two roll bonus do not get bonus rolls"
 
+[efb426ec-7e15-42e6-9b96-b4fca3ec2359]
+description = "last two strikes followed by only last bonus with non strike points"
+
 [72e24404-b6c6-46af-b188-875514c0377b]
 description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
 

--- a/exercises/practice/bowling/bowling_test.rb
+++ b/exercises/practice/bowling/bowling_test.rb
@@ -98,12 +98,12 @@ class BowlingTest < Minitest::Test
     assert_equal 30, game.score
   end
 
-  def test_a_spare_followed_by_a_strike_should_not_get_bonus_from_next_frame
+  def test_last_two_strikes_followed_by_only_last_bonus_with_non_strike_points
     skip
     game = Game.new
-    rolls = [5, 5, 10, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 0, 1]
     rolls.each { |pins| game.roll(pins) }
-    assert_equal 42, game.score
+    assert_equal 31, game.score
   end
 
   def test_a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get_a_bonus


### PR DESCRIPTION
This syncs the metadata and tests.toml with the changes in problem-specifications.

It also regenerates the tests based on tests.toml.