### PR TITLE
Simple Calculator: replace `**` operator with a truly bogus operator

### DIFF
--- a/exercises/concept/simple-calculator/simple_calculator_test.rb
+++ b/exercises/concept/simple-calculator/simple_calculator_test.rb
@@ -27,7 +27,7 @@ class SimpleCalculatorTest < Minitest::Test
   end
 
   def test_raises_exception_for_non_valid_operations
-    assert_raises(SimpleCalculator::UnsupportedOperation) { SimpleCalculator.calculate(1, 2, '**') }
+    assert_raises(SimpleCalculator::UnsupportedOperation) { SimpleCalculator.calculate(1, 2, '*******') }
   end
 
   def test_raises_exception_when_operation_is_nil


### PR DESCRIPTION
In [my solution](https://exercism.org/mentoring/external_requests/29bd4863cb604480b2b73a10ada25bfe) wanted to make simple calculator a bit more generic, but this test required me to hardcode an unnecessary condition.