### PR TITLE
Sync space-age with problem-specs

### DIFF
--- a/exercises/practice/space-age/.docs/instructions.md
+++ b/exercises/practice/space-age/.docs/instructions.md
@@ -2,17 +2,18 @@
 
 Given an age in seconds, calculate how old someone would be on:
 
-   - Mercury: orbital period 0.2408467 Earth years
-   - Venus: orbital period 0.61519726 Earth years
-   - Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
-   - Mars: orbital period 1.8808158 Earth years
-   - Jupiter: orbital period 11.862615 Earth years
-   - Saturn: orbital period 29.447498 Earth years
-   - Uranus: orbital period 84.016846 Earth years
-   - Neptune: orbital period 164.79132 Earth years
+- Mercury: orbital period 0.2408467 Earth years
+- Venus: orbital period 0.61519726 Earth years
+- Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
+- Mars: orbital period 1.8808158 Earth years
+- Jupiter: orbital period 11.862615 Earth years
+- Saturn: orbital period 29.447498 Earth years
+- Uranus: orbital period 84.016846 Earth years
+- Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
 be able to say that they're 31.69 Earth-years old.
 
-If you're wondering why Pluto didn't make the cut, go watch [this
-youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
+
+[pluto-video]: http://www.youtube.com/watch?v=Z_2gbGXzFbs

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -32,3 +32,7 @@ description = "age on Uranus"
 
 [80096d30-a0d4-4449-903e-a381178355d8]
 description = "age on Neptune"
+
+[57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
+description = "invalid planet causes error"
+include = false


### PR DESCRIPTION
There was a new test upstream for an error case.

We have not previously introduced error handling for this exercise, and I do not think that adding error handling here makes the exercise more interesting.

I've therefore chosen to exclude the new test on this track.