### PR TITLE
Sync anagram with problem-specifications

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,8 +1,13 @@
 # Instructions
 
-An anagram is a rearrangement of letters to form a new word.
-Given a word and a list of candidates, select the sublist of anagrams of the given word.
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
 
-Given `"listen"` and a list of candidates like `"enlists" "google"
-"inlets" "banana"` the program should return a list containing
-`"inlets"`.
+Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -14,6 +14,11 @@ description = "no matches"
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
+include = false
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"
@@ -47,6 +52,24 @@ description = "anagrams must use all letters exactly once"
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
+include = false
+
+[68934ed0-010b-4ef9-857a-20c9012d1ebf]
+description = "words are not anagrams of themselves"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
+description = "words are not anagrams of themselves even if letter case is partially different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
+description = "words are not anagrams of themselves even if letter case is completely different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
+include = false
+
+[33d3f67e-fbb9-49d3-a90e-0beb00861da7]
+description = "words other than themselves can be anagrams"
+reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"

--- a/exercises/practice/anagram/anagram_test.rb
+++ b/exercises/practice/anagram/anagram_test.rb
@@ -4,7 +4,7 @@ require_relative 'anagram'
 class AnagramTest < Minitest::Test
   def test_no_matches
     # skip
-    detector = Anagram.new('diaper')
+    detector = Anagram.new("diaper")
     anagrams = detector.match(%w[hello world zombies pants])
     expected = []
     assert_equal expected, anagrams
@@ -12,15 +12,15 @@ class AnagramTest < Minitest::Test
 
   def test_detects_two_anagrams
     skip
-    detector = Anagram.new('master')
-    anagrams = detector.match(%w[stream pigeon maters])
-    expected = %w[maters stream]
-    assert_equal expected, anagrams.sort
+    detector = Anagram.new("solemn")
+    anagrams = detector.match(%w[lemons cherry melons])
+    expected = %w[lemons melons]
+    assert_equal expected, anagrams
   end
 
   def test_does_not_detect_anagram_subsets
     skip
-    detector = Anagram.new('good')
+    detector = Anagram.new("good")
     anagrams = detector.match(%w[dog goody])
     expected = []
     assert_equal expected, anagrams
@@ -28,7 +28,7 @@ class AnagramTest < Minitest::Test
 
   def test_detects_anagram
     skip
-    detector = Anagram.new('listen')
+    detector = Anagram.new("listen")
     anagrams = detector.match(%w[enlists google inlets banana])
     expected = ["inlets"]
     assert_equal expected, anagrams
@@ -36,23 +36,23 @@ class AnagramTest < Minitest::Test
 
   def test_detects_three_anagrams
     skip
-    detector = Anagram.new('allergy')
+    detector = Anagram.new("allergy")
     anagrams = detector.match(%w[gallery ballerina regally clergy largely leading])
-    expected = %w[gallery largely regally]
-    assert_equal expected, anagrams.sort
+    expected = %w[gallery regally largely]
+    assert_equal expected, anagrams
   end
 
   def test_detects_multiple_anagrams_with_different_case
     skip
-    detector = Anagram.new('nose')
+    detector = Anagram.new("nose")
     anagrams = detector.match(%w[Eons ONES])
     expected = %w[Eons ONES]
-    assert_equal expected, anagrams.sort
+    assert_equal expected, anagrams
   end
 
   def test_does_not_detect_non_anagrams_with_identical_checksum
     skip
-    detector = Anagram.new('mass')
+    detector = Anagram.new("mass")
     anagrams = detector.match(["last"])
     expected = []
     assert_equal expected, anagrams
@@ -60,7 +60,7 @@ class AnagramTest < Minitest::Test
 
   def test_detects_anagrams_case_insensitively
     skip
-    detector = Anagram.new('Orchestra')
+    detector = Anagram.new("Orchestra")
     anagrams = detector.match(%w[cashregister Carthorse radishes])
     expected = ["Carthorse"]
     assert_equal expected, anagrams
@@ -68,7 +68,7 @@ class AnagramTest < Minitest::Test
 
   def test_detects_anagrams_using_case_insensitive_subject
     skip
-    detector = Anagram.new('Orchestra')
+    detector = Anagram.new("Orchestra")
     anagrams = detector.match(%w[cashregister carthorse radishes])
     expected = ["carthorse"]
     assert_equal expected, anagrams
@@ -76,7 +76,7 @@ class AnagramTest < Minitest::Test
 
   def test_detects_anagrams_using_case_insensitive_possible_matches
     skip
-    detector = Anagram.new('orchestra')
+    detector = Anagram.new("orchestra")
     anagrams = detector.match(%w[cashregister Carthorse radishes])
     expected = ["Carthorse"]
     assert_equal expected, anagrams
@@ -84,7 +84,7 @@ class AnagramTest < Minitest::Test
 
   def test_does_not_detect_an_anagram_if_the_original_word_is_repeated
     skip
-    detector = Anagram.new('go')
+    detector = Anagram.new("go")
     anagrams = detector.match(["go Go GO"])
     expected = []
     assert_equal expected, anagrams
@@ -92,24 +92,40 @@ class AnagramTest < Minitest::Test
 
   def test_anagrams_must_use_all_letters_exactly_once
     skip
-    detector = Anagram.new('tapper')
+    detector = Anagram.new("tapper")
     anagrams = detector.match(["patter"])
     expected = []
     assert_equal expected, anagrams
   end
 
-  def test_words_are_not_anagrams_of_themselves_case_insensitive
+  def test_words_are_not_anagrams_of_themselves
     skip
-    detector = Anagram.new('BANANA')
-    anagrams = detector.match(%w[BANANA Banana banana])
+    detector = Anagram.new("BANANA")
+    anagrams = detector.match(["BANANA"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_words_are_not_anagrams_of_themselves_even_if_letter_case_is_partially_different
+    skip
+    detector = Anagram.new("BANANA")
+    anagrams = detector.match(["Banana"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_words_are_not_anagrams_of_themselves_even_if_letter_case_is_completely_different
+    skip
+    detector = Anagram.new("BANANA")
+    anagrams = detector.match(["banana"])
     expected = []
     assert_equal expected, anagrams
   end
 
   def test_words_other_than_themselves_can_be_anagrams
     skip
-    detector = Anagram.new('LISTEN')
-    anagrams = detector.match(%w[Listen Silent LISTEN])
+    detector = Anagram.new("LISTEN")
+    anagrams = detector.match(%w[LISTEN Silent])
     expected = ["Silent"]
     assert_equal expected, anagrams
   end


### PR DESCRIPTION
This sync applied some reimplemented exercises that changed the data being used.

Two notes on the choices I made:

1. I generated this with double quotes rather than single quotes. We do not have the Rubocop StringLiterals enabled, so I could not autocorrect to use single quotes. I personally don't think it makes a difference, but thought I should call it out.
2. I explicitly did not call the 'sort' method on the values returned. Our reference implementation still passes, but it does mean that we're changing the design of the exercise to no longer require that people return the values in sorted order, but rather to return them in the order that the candidates were passed in. I think this makes more sense, but it could break some people's earlier solutions.