### PR TITLE
Remove rubocop directive in user-facing test suite

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,11 @@ Metrics/MethodLength:
     - "test/**/*"
     - "exercises/**/*_test.rb"
 
+Naming/MethodName:
+  Enabled: true
+  Exclude:
+    - "exercises/practice/protein-translation/protein_translation_test.rb"
+
 Naming/PredicateName:
   Enabled: true
   Exclude:

--- a/exercises/practice/protein-translation/protein_translation_test.rb
+++ b/exercises/practice/protein-translation/protein_translation_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'protein_translation'
 
 class TranslationTest < Minitest::Test
-  def test_AUG_translates_to_methionine # rubocop:disable Naming/MethodName
+  def test_AUG_translates_to_methionine
     assert_equal 'Methionine', Translation.of_codon('AUG')
   end
 


### PR DESCRIPTION
Rubocop is an internal tool, and should not be exposed to students.

If they wish to apply rubocop rules to their own code, then it should be up to them to install rubocop and add their own preferred configuration.

This removes one last rubocop disable directive from an exercise test suite, adding an explicit configuration for the rule (which is a reasonable rule), and explicitly disabling the rule for the test suite that violates it intentionally.

I believe that our current Rubocop setup is now good enough for our needs, and that we can close #443.
I imagine that we may run into a few more things we will want to change, but I think it's worth opening an issue to discuss for individual questions that arise rather than trying to do a big overhaul all at once.