### PR TITLE
Give credit to author of book-store exercise

### DIFF
--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "authors": [
-
+    "jgr"
   ],
   "contributors": [
     "cadwallion",


### PR DESCRIPTION
jdr implemented book-store in #762.

This is the last exercise that was missing authors in the .meta/config.json.

Closes #1067