### PR TITLE
Delete deprecated topics from track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -179,10 +179,7 @@
         "prerequisites": [
 
         ],
-        "difficulty": 1,
-        "topics": [
-          "strings"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "two-fer",
@@ -196,11 +193,7 @@
           "basics",
           "strings"
         ],
-        "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "strings"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "resistor-color-duo",
@@ -214,11 +207,7 @@
           "strings",
           "numbers"
         ],
-        "difficulty": 1,
-        "topics": [
-          "array",
-          "loops"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "acronym",
@@ -232,12 +221,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 1,
-        "topics": [
-          "regular_expressions",
-          "strings",
-          "transforming"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "high-scores",
@@ -254,10 +238,7 @@
           "constructors",
           "numbers"
         ],
-        "difficulty": 2,
-        "topics": [
-          "arrays"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "matrix",
@@ -274,14 +255,7 @@
           "numbers",
           "instance-variables"
         ],
-        "difficulty": 4,
-        "topics": [
-          "arrays",
-          "exception_handling",
-          "matrices",
-          "strings",
-          "type_conversion"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "series",
@@ -298,12 +272,7 @@
           "loops",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "enumerable",
-          "loops"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "word-count",
@@ -318,12 +287,7 @@
           "hashes",
           "numbers"
         ],
-        "difficulty": 3,
-        "topics": [
-          "enumerable",
-          "hash",
-          "loops"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "hamming",
@@ -342,12 +306,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 1,
-        "topics": [
-          "equality",
-          "loops",
-          "strings"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "raindrops",
@@ -363,12 +322,7 @@
           "numbers",
           "casting"
         ],
-        "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "filtering",
-          "strings"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "isogram",
@@ -382,12 +336,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 2,
-        "topics": [
-          "regular_expressions",
-          "sequences",
-          "strings"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "scrabble-score",
@@ -400,12 +349,7 @@
           "numbers",
           "strings"
         ],
-        "difficulty": 2,
-        "topics": [
-          "loops",
-          "maps",
-          "strings"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "luhn",
@@ -419,12 +363,7 @@
           "loops",
           "numbers"
         ],
-        "difficulty": 2,
-        "topics": [
-          "algorithms",
-          "integers",
-          "strings"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "clock",
@@ -439,12 +378,7 @@
           "equality",
           "numbers"
         ],
-        "difficulty": 3,
-        "topics": [
-          "equality",
-          "text_formatting",
-          "time"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "twelve-days",
@@ -458,14 +392,7 @@
           "loops",
           "strings"
         ],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "pattern_recognition",
-          "sequences",
-          "strings",
-          "text_formatting"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "tournament",
@@ -477,16 +404,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 3,
-        "topics": [
-          "integers",
-          "parsing",
-          "records",
-          "sorting",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "gigasecond",
@@ -499,10 +417,7 @@
           "time",
           "numbers"
         ],
-        "difficulty": 1,
-        "topics": [
-          "time"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "resistor-color",
@@ -516,10 +431,7 @@
           "integers",
           "strings"
         ],
-        "difficulty": 1,
-        "topics": [
-          "arrays"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "rna-transcription",
@@ -532,11 +444,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 2,
-        "topics": [
-          "maps",
-          "transforming"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "leap",
@@ -552,13 +460,7 @@
           "conditionals",
           "numbers"
         ],
-        "difficulty": 1,
-        "topics": [
-          "booleans",
-          "conditionals",
-          "integers",
-          "logic"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "pangram",
@@ -572,11 +474,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 2,
-        "topics": [
-          "loops",
-          "strings"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "space-age",
@@ -592,11 +490,7 @@
           "constructors",
           "numbers"
         ],
-        "difficulty": 2,
-        "topics": [
-          "floating_point_numbers",
-          "if_else_statements"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "triangle",
@@ -610,12 +504,7 @@
           "conditionals",
           "booleans"
         ],
-        "difficulty": 3,
-        "topics": [
-          "booleans",
-          "conditionals",
-          "logic"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "difference-of-squares",
@@ -630,11 +519,7 @@
           "numbers",
           "math-operators"
         ],
-        "difficulty": 2,
-        "topics": [
-          "algorithms",
-          "math"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "anagram",
@@ -650,13 +535,7 @@
           "arrays",
           "classes"
         ],
-        "difficulty": 5,
-        "topics": [
-          "filtering",
-          "parsing",
-          "sorting",
-          "strings"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "sum-of-multiples",
@@ -673,11 +552,7 @@
           "enumeration",
           "conditionals"
         ],
-        "difficulty": 5,
-        "topics": [
-          "loops",
-          "math"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "transpose",
@@ -690,12 +565,7 @@
           "strings",
           "loops"
         ],
-        "difficulty": 5,
-        "topics": [
-          "loops",
-          "strings",
-          "transforming"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "armstrong-numbers",
@@ -709,10 +579,7 @@
           "booleans",
           "casting"
         ],
-        "difficulty": 3,
-        "topics": [
-          "math"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "flatten-array",
@@ -727,11 +594,7 @@
           "enumerable",
           "enumeration"
         ],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "recursion"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "phone-number",
@@ -743,14 +606,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "regular_expressions",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "grains",
@@ -767,11 +623,7 @@
           "loops",
           "exceptions"
         ],
-        "difficulty": 4,
-        "topics": [
-          "bitwise_operations",
-          "math"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "resistor-color-trio",
@@ -786,10 +638,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "loops"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "saddle-points",
@@ -803,13 +652,7 @@
           "enumerable",
           "numbers"
         ],
-        "difficulty": 5,
-        "topics": [
-          "arrays",
-          "integers",
-          "matrices",
-          "searching"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "etl",
@@ -824,12 +667,7 @@
           "numbers",
           "hashes"
         ],
-        "difficulty": 4,
-        "topics": [
-          "loops",
-          "maps",
-          "transforming"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "nucleotide-count",
@@ -846,12 +684,7 @@
           "enumeration",
           "exceptions"
         ],
-        "difficulty": 4,
-        "topics": [
-          "maps",
-          "parsing",
-          "strings"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "pythagorean-triplet",
@@ -868,11 +701,7 @@
           "enumerable",
           "generic-methods"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "math"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "collatz-conjecture",
@@ -890,13 +719,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "control_flow_loops",
-          "integers",
-          "math"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "sieve",
@@ -909,14 +732,7 @@
           "arrays",
           "numbers"
         ],
-        "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "integers",
-          "loops",
-          "math",
-          "sorting"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "proverb",
@@ -930,12 +746,7 @@
           "arrays",
           "loops"
         ],
-        "difficulty": 4,
-        "topics": [
-          "arrays",
-          "loops",
-          "strings"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "palindrome-products",
@@ -949,11 +760,7 @@
           "numbers",
           "loops"
         ],
-        "difficulty": 6,
-        "topics": [
-          "algorithms",
-          "math"
-        ]
+        "difficulty": 6
       },
       {
         "slug": "accumulate",
@@ -970,10 +777,7 @@
           "enumeration",
           "enumerable"
         ],
-        "difficulty": 1,
-        "topics": [
-          "arrays"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "bob",
@@ -986,11 +790,7 @@
           "strings",
           "conditionals"
         ],
-        "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "strings"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "strain",
@@ -1005,12 +805,7 @@
           "numbers",
           "higher-order-functions"
         ],
-        "difficulty": 2,
-        "topics": [
-          "arrays",
-          "filtering",
-          "loops"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "nth-prime",
@@ -1023,12 +818,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "integers",
-          "math"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "perfect-numbers",
@@ -1042,13 +832,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "filtering",
-          "integers",
-          "math"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "alphametics",
@@ -1061,12 +845,7 @@
           "strings",
           "lazy-evaluation"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "searching"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "binary-search",
@@ -1080,13 +859,7 @@
           "numbers",
           "loops"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "searching",
-          "sorting"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "two-bucket",
@@ -1102,12 +875,7 @@
           "instance-variables",
           "numbers"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "searching"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "matching-brackets",
@@ -1121,11 +889,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 7,
-        "topics": [
-          "parsing",
-          "strings"
-        ]
+        "difficulty": 7
       },
       {
         "slug": "all-your-base",
@@ -1142,12 +906,7 @@
           "math-operators",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "integers",
-          "math",
-          "transforming"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "scale-generator",
@@ -1161,11 +920,7 @@
           "arrays",
           "enumeration"
         ],
-        "difficulty": 3,
-        "topics": [
-          "pattern_matching",
-          "strings"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "allergies",
@@ -1182,11 +937,7 @@
           "bit-manipulation",
           "classes"
         ],
-        "difficulty": 4,
-        "topics": [
-          "bitwise_operations",
-          "enumeration"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "rail-fence-cipher",
@@ -1201,16 +952,7 @@
           "numbers",
           "strings"
         ],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "cryptography",
-          "loops",
-          "sorting",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "run-length-encoding",
@@ -1225,12 +967,7 @@
           "enumeration",
           "booleans"
         ],
-        "difficulty": 4,
-        "topics": [
-          "parsing",
-          "strings",
-          "transforming"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "minesweeper",
@@ -1245,14 +982,7 @@
           "conditionals",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "arrays",
-          "games",
-          "loops",
-          "matrices",
-          "transforming"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "robot-simulator",
@@ -1271,14 +1001,7 @@
           "conditionals",
           "exceptions"
         ],
-        "difficulty": 6,
-        "topics": [
-          "concurrency",
-          "loops",
-          "sequences",
-          "strings",
-          "structs"
-        ]
+        "difficulty": 6
       },
       {
         "slug": "beer-song",
@@ -1292,12 +1015,7 @@
           "numbers",
           "loops"
         ],
-        "difficulty": 3,
-        "topics": [
-          "loops",
-          "strings",
-          "text_formatting"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "protein-translation",
@@ -1313,12 +1031,7 @@
           "arrays",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "filtering",
-          "maps",
-          "sequences"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "wordy",
@@ -1333,14 +1046,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "integers",
-          "parsing",
-          "strings",
-          "type_conversion"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "secret-handshake",
@@ -1354,12 +1060,7 @@
           "bit-manipulation",
           "arrays"
         ],
-        "difficulty": 5,
-        "topics": [
-          "arrays",
-          "bitwise_operations",
-          "integers"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "atbash-cipher",
@@ -1372,13 +1073,7 @@
           "strings",
           "enumeration"
         ],
-        "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "cryptography",
-          "strings",
-          "transforming"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "crypto-square",
@@ -1391,14 +1086,7 @@
           "strings",
           "enumerable"
         ],
-        "difficulty": 3,
-        "topics": [
-          "cryptography",
-          "filtering",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "list-ops",
@@ -1414,13 +1102,7 @@
           "arrays",
           "higher-order-functions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "functional_programming",
-          "arrays",
-          "recursion",
-          "type_conversion"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "robot-name",
@@ -1435,10 +1117,7 @@
           "strings",
           "classes"
         ],
-        "difficulty": 3,
-        "topics": [
-          "randomness"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "simple-cipher",
@@ -1457,14 +1136,7 @@
           "loops",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "cryptography",
-          "interfaces",
-          "strings",
-          "transforming"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "dominoes",
@@ -1478,12 +1150,7 @@
           "numbers",
           "booleans"
         ],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "searching"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "pig-latin",
@@ -1495,12 +1162,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 4,
-        "topics": [
-          "conditionals",
-          "strings",
-          "transforming"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "simple-linked-list",
@@ -1514,11 +1176,7 @@
           "instance-variables",
           "numbers"
         ],
-        "difficulty": 4,
-        "topics": [
-          "arrays",
-          "loops"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "binary-search-tree",
@@ -1536,15 +1194,7 @@
           "constructors",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "recursion",
-          "searching",
-          "sorting",
-          "structs",
-          "trees"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "change",
@@ -1559,13 +1209,7 @@
           "arrays",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "loops",
-          "searching"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "circular-buffer",
@@ -1581,11 +1225,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "queues",
-          "structs"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "grade-school",
@@ -1601,12 +1241,7 @@
           "enumerable",
           "ordering"
         ],
-        "difficulty": 5,
-        "topics": [
-          "arrays",
-          "sorting",
-          "structs"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "roman-numerals",
@@ -1621,11 +1256,7 @@
           "loops",
           "numbers"
         ],
-        "difficulty": 2,
-        "topics": [
-          "numbers",
-          "transforming"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "rotational-cipher",
@@ -1638,12 +1269,7 @@
           "strings",
           "numbers"
         ],
-        "difficulty": 2,
-        "topics": [
-          "cryptography",
-          "integers",
-          "strings"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "affine-cipher",
@@ -1657,12 +1283,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "cryptography",
-          "math",
-          "strings"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "kindergarten-garden",
@@ -1679,14 +1300,7 @@
           "recursion",
           "meta-programming"
         ],
-        "difficulty": 4,
-        "topics": [
-          "parsing",
-          "records",
-          "searching",
-          "strings",
-          "structs"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "largest-series-product",
@@ -1703,13 +1317,7 @@
           "loops",
           "exceptions"
         ],
-        "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "integers",
-          "math",
-          "sequences"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "prime-factors",
@@ -1724,12 +1332,7 @@
           "arrays",
           "loops"
         ],
-        "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "integers",
-          "math"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "custom-set",
@@ -1748,12 +1351,7 @@
           "booleans",
           "constructors"
         ],
-        "difficulty": 4,
-        "topics": [
-          "filtering",
-          "loops",
-          "sets"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "house",
@@ -1766,12 +1364,7 @@
           "strings",
           "numbers"
         ],
-        "difficulty": 4,
-        "topics": [
-          "recursion",
-          "strings",
-          "text_formatting"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "linked-list",
@@ -1784,11 +1377,7 @@
           "numbers",
           "classes"
         ],
-        "difficulty": 4,
-        "topics": [
-          "data_structure",
-          "pointer"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "poker",
@@ -1803,15 +1392,7 @@
           "ordering",
           "conditionals"
         ],
-        "difficulty": 5,
-        "topics": [
-          "equality",
-          "games",
-          "parsing",
-          "pattern_matching",
-          "sequences",
-          "strings"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "isbn-verifier",
@@ -1825,10 +1406,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 2,
-        "topics": [
-          "arrays"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "complex-numbers",
@@ -1845,10 +1423,7 @@
           "immutability",
           "math-operators"
         ],
-        "difficulty": 3,
-        "topics": [
-          "math"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "meetup",
@@ -1862,13 +1437,7 @@
           "dates",
           "time"
         ],
-        "difficulty": 3,
-        "topics": [
-          "dates",
-          "time",
-          "transforming",
-          "type_conversion"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "diamond",
@@ -1880,14 +1449,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "strings",
-          "text_formatting"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "bowling",
@@ -1903,12 +1465,7 @@
           "nil",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "conditionals"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "ocr-numbers",
@@ -1923,11 +1480,7 @@
           "conditionals",
           "exceptions"
         ],
-        "difficulty": 7,
-        "topics": [
-          "parsing",
-          "pattern_recognition"
-        ]
+        "difficulty": 7
       },
       {
         "slug": "say",
@@ -1944,13 +1497,7 @@
           "conditionals",
           "exceptions"
         ],
-        "difficulty": 7,
-        "topics": [
-          "numbers",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "difficulty": 7
       },
       {
         "slug": "zipper",
@@ -1966,10 +1513,7 @@
           "classes",
           "equality"
         ],
-        "difficulty": 7,
-        "topics": [
-          "data_structures"
-        ]
+        "difficulty": 7
       },
       {
         "slug": "grep",
@@ -1982,15 +1526,7 @@
           "conditionals",
           "strings"
         ],
-        "difficulty": 8,
-        "topics": [
-          "files",
-          "parsing",
-          "pattern_matching",
-          "regular_expressions",
-          "strings",
-          "text_formatting"
-        ]
+        "difficulty": 8
       },
       {
         "slug": "food-chain",
@@ -2006,14 +1542,7 @@
           "conditionals",
           "loops"
         ],
-        "difficulty": 4,
-        "topics": [
-          "conditionals",
-          "loops",
-          "recursion",
-          "strings",
-          "text_formatting"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "pascals-triangle",
@@ -2027,13 +1556,7 @@
           "enumerable",
           "numbers"
         ],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "math",
-          "recursion"
-        ]
+        "difficulty": 4
       },
       {
         "slug": "queen-attack",
@@ -2051,13 +1574,7 @@
           "math-operators",
           "exceptions"
         ],
-        "difficulty": 5,
-        "topics": [
-          "booleans",
-          "errors",
-          "games",
-          "logic"
-        ]
+        "difficulty": 5
       },
       {
         "slug": "book-store",
@@ -2075,13 +1592,7 @@
           "enumerable",
           "loops"
         ],
-        "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "floating_point_numbers",
-          "integers",
-          "arrays"
-        ]
+        "difficulty": 8
       },
       {
         "slug": "connect",
@@ -2096,14 +1607,7 @@
           "arrays",
           "conditionals"
         ],
-        "difficulty": 9,
-        "topics": [
-          "arrays",
-          "games",
-          "graphs",
-          "loops",
-          "searching"
-        ]
+        "difficulty": 9
       },
       {
         "slug": "binary",
@@ -2116,7 +1620,6 @@
 
         ],
         "difficulty": 1,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -2130,7 +1633,6 @@
 
         ],
         "difficulty": 1,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -2144,7 +1646,6 @@
 
         ],
         "difficulty": 1,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -2158,7 +1659,6 @@
 
         ],
         "difficulty": 1,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -2172,7 +1672,6 @@
 
         ],
         "difficulty": 1,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -2185,12 +1684,7 @@
         "prerequisites": [
           "string-formatting"
         ],
-        "difficulty": 2,
-        "topics": [
-          "math",
-          "strings",
-          "interpolation"
-        ]
+        "difficulty": 2
       },
       {
         "slug": "darts",
@@ -2204,11 +1698,7 @@
           "floating-point-numbers",
           "conditionals"
         ],
-        "difficulty": 3,
-        "topics": [
-          "math",
-          "geometry"
-        ]
+        "difficulty": 3
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -20,10 +20,18 @@
     "average_run_time": 2.0
   },
   "files": {
-    "solution": ["%{snake_slug}.rb"],
-    "test": ["%{snake_slug}_test.rb"],
-    "example": [".meta/solutions/%{snake_slug}.rb"],
-    "exemplar": [".meta/exemplar.rb"]
+    "solution": [
+      "%{snake_slug}.rb"
+    ],
+    "test": [
+      "%{snake_slug}_test.rb"
+    ],
+    "example": [
+      ".meta/solutions/%{snake_slug}.rb"
+    ],
+    "exemplar": [
+      ".meta/exemplar.rb"
+    ]
   },
   "exercises": {
     "concept": [
@@ -31,78 +39,133 @@
         "slug": "lasagna",
         "name": "Lasagna",
         "uuid": "9d2a67a8-0eef-48bb-b8eb-4a6ff0437d21",
-        "concepts": ["basics"],
-        "prerequisites": []
+        "concepts": [
+          "basics"
+        ],
+        "prerequisites": [
+
+        ]
       },
       {
         "slug": "amusement-park",
         "name": "Amusement Park",
         "uuid": "6905e411-ae01-46b6-a31c-8867b768856e",
-        "concepts": ["instance-variables", "nil"],
-        "prerequisites": ["basics"]
+        "concepts": [
+          "instance-variables",
+          "nil"
+        ],
+        "prerequisites": [
+          "basics"
+        ]
       },
       {
         "slug": "amusement-park-improvements",
         "name": "Amusement Park Improvements",
         "uuid": "06ea7869-4907-454d-a5e5-9d5b71098b17",
-        "concepts": ["booleans"],
-        "prerequisites": ["instance-variables", "nil"]
+        "concepts": [
+          "booleans"
+        ],
+        "prerequisites": [
+          "instance-variables",
+          "nil"
+        ]
       },
       {
         "slug": "log-line-parser",
         "name": "Log line Parser",
         "uuid": "13e2d7d8-0c03-4bdf-9fe2-8dfe884a9eb6",
-        "concepts": ["strings"],
-        "prerequisites": ["basics"]
+        "concepts": [
+          "strings"
+        ],
+        "prerequisites": [
+          "basics"
+        ]
       },
       {
         "slug": "assembly-line",
         "name": "Assembly Line",
         "uuid": "d7108eb2-326c-446d-9140-228e0f220975",
-        "concepts": ["numbers", "floating-point-numbers", "conditionals"],
-        "prerequisites": ["booleans"]
+        "concepts": [
+          "numbers",
+          "floating-point-numbers",
+          "conditionals"
+        ],
+        "prerequisites": [
+          "booleans"
+        ]
       },
       {
         "slug": "savings-account",
         "name": "Savings Account",
         "uuid": "970d3f26-1891-40c7-9550-42d529f5780f",
-        "concepts": ["loops", "modules"],
-        "prerequisites": ["numbers", "floating-point-numbers", "conditionals"]
+        "concepts": [
+          "loops",
+          "modules"
+        ],
+        "prerequisites": [
+          "numbers",
+          "floating-point-numbers",
+          "conditionals"
+        ]
       },
       {
         "slug": "bird-count",
         "name": "Bird Count",
         "uuid": "874e7d1f-d047-4183-875a-5345896f9fc1",
-        "concepts": ["arrays", "enumeration"],
-        "prerequisites": ["instance-variables", "booleans", "conditionals"]
+        "concepts": [
+          "arrays",
+          "enumeration"
+        ],
+        "prerequisites": [
+          "instance-variables",
+          "booleans",
+          "conditionals"
+        ]
       },
       {
         "slug": "boutique-inventory",
         "name": "Boutique Inventory",
         "uuid": "9f3a89f2-196b-4d53-8481-1360b565c797",
-        "concepts": ["advanced-enumeration"],
-        "prerequisites": ["enumeration"]
+        "concepts": [
+          "advanced-enumeration"
+        ],
+        "prerequisites": [
+          "enumeration"
+        ]
       },
       {
         "slug": "boutique-inventory-improvements",
         "name": "Boutique Inventory Improvements",
         "uuid": "cf415960-ceff-4a1c-b65a-c4b5b1a80155",
-        "concepts": ["ostruct"],
-        "prerequisites": ["advanced-enumeration"]
+        "concepts": [
+          "ostruct"
+        ],
+        "prerequisites": [
+          "advanced-enumeration"
+        ]
       },
       {
         "slug": "moviegoer",
         "name": "Moviegoer",
         "uuid": "2aa6c375-8a73-4f5f-ac8f-9db22a86e1f6",
-        "concepts": ["ternary-operator"],
-        "prerequisites": ["conditionals", "exceptions"]
+        "concepts": [
+          "ternary-operator"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "exceptions"
+        ]
       },
       {
         "slug": "simple-calculator",
         "name": "Simple Calculator",
         "uuid": "ef6dca29-a990-4a6e-8b2c-4703fd0f751a",
-        "concepts": ["exceptions"],
-        "prerequisites": ["basics"]
+        "concepts": [
+          "exceptions"
+        ],
+        "prerequisites": [
+          "basics"
+        ]
       }
     ],
     "practice": [
@@ -110,53 +173,107 @@
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "4fe19484-4414-471b-a106-73c776c61388",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+
+        ],
+        "prerequisites": [
+
+        ],
         "difficulty": 1,
-        "topics": ["strings"]
+        "topics": [
+          "strings"
+        ]
       },
       {
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "1304b188-6d08-4361-be40-c6b1b88e5e54",
-        "practices": ["basics", "strings"],
-        "prerequisites": ["basics", "strings"],
+        "practices": [
+          "basics",
+          "strings"
+        ],
+        "prerequisites": [
+          "basics",
+          "strings"
+        ],
         "difficulty": 1,
-        "topics": ["conditionals", "strings"]
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "57b0c57e-26a5-4ccf-aaf2-2fefddd918c1",
-        "practices": ["arrays"],
-        "prerequisites": ["arrays", "strings", "numbers"],
+        "practices": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers"
+        ],
         "difficulty": 1,
-        "topics": ["array", "loops"]
+        "topics": [
+          "array",
+          "loops"
+        ]
       },
       {
         "slug": "acronym",
         "name": "Acronym",
         "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
-        "practices": ["strings", "regular-expressions"],
-        "prerequisites": ["strings", "booleans"],
+        "practices": [
+          "strings",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "booleans"
+        ],
         "difficulty": 1,
-        "topics": ["regular_expressions", "strings", "transforming"]
+        "topics": [
+          "regular_expressions",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "high-scores",
         "name": "High Scores",
         "uuid": "9124339c-94fb-46eb-aad2-25944214799d",
-        "practices": ["arrays", "ordering", "advanced-enumeration"],
-        "prerequisites": ["arrays", "ordering", "constructors", "numbers"],
+        "practices": [
+          "arrays",
+          "ordering",
+          "advanced-enumeration"
+        ],
+        "prerequisites": [
+          "arrays",
+          "ordering",
+          "constructors",
+          "numbers"
+        ],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "matrix",
         "name": "Matrix",
         "uuid": "3de21c18-a533-4150-8a73-49df8fcb8c61",
-        "practices": ["instance-variables", "classes", "arrays"],
-        "prerequisites": ["arrays", "classes", "numbers", "instance-variables"],
+        "practices": [
+          "instance-variables",
+          "classes",
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "classes",
+          "numbers",
+          "instance-variables"
+        ],
         "difficulty": 4,
         "topics": [
           "arrays",
@@ -170,7 +287,10 @@
         "slug": "series",
         "name": "Series",
         "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
-        "practices": ["arrays", "exceptions"],
+        "practices": [
+          "arrays",
+          "exceptions"
+        ],
         "prerequisites": [
           "arrays",
           "strings",
@@ -179,16 +299,31 @@
           "exceptions"
         ],
         "difficulty": 3,
-        "topics": ["arrays", "enumerable", "loops"]
+        "topics": [
+          "arrays",
+          "enumerable",
+          "loops"
+        ]
       },
       {
         "slug": "word-count",
         "name": "Word Count",
         "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
-        "practices": ["hashes", "regular-expressions"],
-        "prerequisites": ["strings", "hashes", "numbers"],
+        "practices": [
+          "hashes",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "hashes",
+          "numbers"
+        ],
         "difficulty": 3,
-        "topics": ["enumerable", "hash", "loops"]
+        "topics": [
+          "enumerable",
+          "hash",
+          "loops"
+        ]
       },
       {
         "slug": "hamming",
@@ -208,59 +343,121 @@
           "exceptions"
         ],
         "difficulty": 1,
-        "topics": ["equality", "loops", "strings"]
+        "topics": [
+          "equality",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "raindrops",
         "name": "Raindrops",
         "uuid": "efad2cea-1e0b-4fb8-a452-a8e91be73638",
-        "practices": ["conditionals", "casting"],
-        "prerequisites": ["strings", "conditionals", "numbers", "casting"],
+        "practices": [
+          "conditionals",
+          "casting"
+        ],
+        "prerequisites": [
+          "strings",
+          "conditionals",
+          "numbers",
+          "casting"
+        ],
         "difficulty": 1,
-        "topics": ["conditionals", "filtering", "strings"]
+        "topics": [
+          "conditionals",
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "isogram",
         "name": "Isogram",
         "uuid": "a79eb8cd-d2db-48f5-a7dc-055039dcee62",
-        "practices": ["strings", "sets"],
-        "prerequisites": ["strings", "booleans"],
+        "practices": [
+          "strings",
+          "sets"
+        ],
+        "prerequisites": [
+          "strings",
+          "booleans"
+        ],
         "difficulty": 2,
-        "topics": ["regular_expressions", "sequences", "strings"]
+        "topics": [
+          "regular_expressions",
+          "sequences",
+          "strings"
+        ]
       },
       {
         "slug": "scrabble-score",
         "name": "Scrabble Score",
         "uuid": "d934ebce-9ac3-4a41-bcb8-d70480170438",
-        "practices": ["hashes"],
-        "prerequisites": ["numbers", "strings"],
+        "practices": [
+          "hashes"
+        ],
+        "prerequisites": [
+          "numbers",
+          "strings"
+        ],
         "difficulty": 2,
-        "topics": ["loops", "maps", "strings"]
+        "topics": [
+          "loops",
+          "maps",
+          "strings"
+        ]
       },
       {
         "slug": "luhn",
         "name": "Luhn",
         "uuid": "bee97539-b8c1-460e-aa14-9336008df2b6",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "loops", "numbers"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "loops",
+          "numbers"
+        ],
         "difficulty": 2,
-        "topics": ["algorithms", "integers", "strings"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "clock",
         "name": "Clock",
         "uuid": "f95ebf09-0f32-4e60-867d-60cb81dd9a62",
-        "practices": ["equality", "numbers"],
-        "prerequisites": ["classes", "equality", "numbers"],
+        "practices": [
+          "equality",
+          "numbers"
+        ],
+        "prerequisites": [
+          "classes",
+          "equality",
+          "numbers"
+        ],
         "difficulty": 3,
-        "topics": ["equality", "text_formatting", "time"]
+        "topics": [
+          "equality",
+          "text_formatting",
+          "time"
+        ]
       },
       {
         "slug": "twelve-days",
         "name": "Twelve Days",
         "uuid": "eeb64dda-b79f-4920-8fa3-04810e8d37ab",
-        "practices": ["strings"],
-        "prerequisites": ["numbers", "loops", "strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "numbers",
+          "loops",
+          "strings"
+        ],
         "difficulty": 4,
         "topics": [
           "algorithms",
@@ -274,8 +471,12 @@
         "slug": "tournament",
         "name": "Tournament",
         "uuid": "486becee-9d85-4139-ab89-db254d385ade",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 3,
         "topics": [
           "integers",
@@ -291,52 +492,100 @@
         "slug": "gigasecond",
         "name": "Gigasecond",
         "uuid": "0fb594a1-193b-4ccf-8de2-eb6a81708b29",
-        "practices": ["time"],
-        "prerequisites": ["time", "numbers"],
+        "practices": [
+          "time"
+        ],
+        "prerequisites": [
+          "time",
+          "numbers"
+        ],
         "difficulty": 1,
-        "topics": ["time"]
+        "topics": [
+          "time"
+        ]
       },
       {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "685634dd-0b38-40bc-b0ad-e8aa2904035f",
-        "practices": ["arrays"],
-        "prerequisites": ["arrays", "integers", "strings"],
+        "practices": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "integers",
+          "strings"
+        ],
         "difficulty": 1,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "rna-transcription",
         "name": "RNA Transcription",
         "uuid": "41f66d2a-1883-4a2c-875f-663c46fa88aa",
-        "practices": ["strings", "advanced-enumeration"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings",
+          "advanced-enumeration"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 2,
-        "topics": ["maps", "transforming"]
+        "topics": [
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "leap",
         "name": "Leap",
         "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
-        "practices": ["math-operators", "conditionals", "numbers"],
-        "prerequisites": ["math-operators", "conditionals", "numbers"],
+        "practices": [
+          "math-operators",
+          "conditionals",
+          "numbers"
+        ],
+        "prerequisites": [
+          "math-operators",
+          "conditionals",
+          "numbers"
+        ],
         "difficulty": 1,
-        "topics": ["booleans", "conditionals", "integers", "logic"]
+        "topics": [
+          "booleans",
+          "conditionals",
+          "integers",
+          "logic"
+        ]
       },
       {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
-        "practices": ["strings", "sets"],
-        "prerequisites": ["strings", "booleans"],
+        "practices": [
+          "strings",
+          "sets"
+        ],
+        "prerequisites": [
+          "strings",
+          "booleans"
+        ],
         "difficulty": 2,
-        "topics": ["loops", "strings"]
+        "topics": [
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "space-age",
         "name": "Space Age",
         "uuid": "c971a2b5-ccd4-4e55-9fc7-33e991bc0676",
-        "practices": ["floating-point-numbers", "classes"],
+        "practices": [
+          "floating-point-numbers",
+          "classes"
+        ],
         "prerequisites": [
           "floating-point-numbers",
           "classes",
@@ -344,40 +593,80 @@
           "numbers"
         ],
         "difficulty": 2,
-        "topics": ["floating_point_numbers", "if_else_statements"]
+        "topics": [
+          "floating_point_numbers",
+          "if_else_statements"
+        ]
       },
       {
         "slug": "triangle",
         "name": "Triangle",
         "uuid": "5c797eb2-155d-47ca-8f85-2ba5803f9713",
-        "practices": ["floating-point-numbers"],
-        "prerequisites": ["floating-point-numbers", "conditionals", "booleans"],
+        "practices": [
+          "floating-point-numbers"
+        ],
+        "prerequisites": [
+          "floating-point-numbers",
+          "conditionals",
+          "booleans"
+        ],
         "difficulty": 3,
-        "topics": ["booleans", "conditionals", "logic"]
+        "topics": [
+          "booleans",
+          "conditionals",
+          "logic"
+        ]
       },
       {
         "slug": "difference-of-squares",
         "name": "Difference of Squares",
         "uuid": "f1e4ee0c-8718-43f2-90a5-fb1e915288da",
-        "practices": ["advanced-enumeration", "math-operators", "numbers"],
-        "prerequisites": ["numbers", "math-operators"],
+        "practices": [
+          "advanced-enumeration",
+          "math-operators",
+          "numbers"
+        ],
+        "prerequisites": [
+          "numbers",
+          "math-operators"
+        ],
         "difficulty": 2,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "anagram",
         "name": "Anagram",
         "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
-        "practices": ["classes", "arrays", "strings"],
-        "prerequisites": ["strings", "arrays", "classes"],
+        "practices": [
+          "classes",
+          "arrays",
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "arrays",
+          "classes"
+        ],
         "difficulty": 5,
-        "topics": ["filtering", "parsing", "sorting", "strings"]
+        "topics": [
+          "filtering",
+          "parsing",
+          "sorting",
+          "strings"
+        ]
       },
       {
         "slug": "sum-of-multiples",
         "name": "Sum of Multiples",
         "uuid": "4fc25295-5d6a-4d13-9b87-064167d8980e",
-        "practices": ["enumerable", "enumeration", "numbers"],
+        "practices": [
+          "enumerable",
+          "enumeration",
+          "numbers"
+        ],
         "prerequisites": [
           "enumerable",
           "numbers",
@@ -385,41 +674,75 @@
           "conditionals"
         ],
         "difficulty": 5,
-        "topics": ["loops", "math"]
+        "topics": [
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "transpose",
         "name": "Transpose",
         "uuid": "4a6bc7d3-5d3b-4ad8-96ae-783e17af7c32",
-        "practices": ["loops"],
-        "prerequisites": ["strings", "loops"],
+        "practices": [
+          "loops"
+        ],
+        "prerequisites": [
+          "strings",
+          "loops"
+        ],
         "difficulty": 5,
-        "topics": ["loops", "strings", "transforming"]
+        "topics": [
+          "loops",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "armstrong-numbers",
         "name": "Armstrong Numbers",
         "uuid": "77c5c7e6-265a-4f1a-9bc4-851f8f825420",
-        "practices": ["casting"],
-        "prerequisites": ["numbers", "booleans", "casting"],
+        "practices": [
+          "casting"
+        ],
+        "prerequisites": [
+          "numbers",
+          "booleans",
+          "casting"
+        ],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "flatten-array",
         "name": "Flatten Array",
         "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
-        "practices": ["enumerable", "recursion", "enumeration"],
-        "prerequisites": ["enumerable", "enumeration"],
+        "practices": [
+          "enumerable",
+          "recursion",
+          "enumeration"
+        ],
+        "prerequisites": [
+          "enumerable",
+          "enumeration"
+        ],
         "difficulty": 3,
-        "topics": ["arrays", "recursion"]
+        "topics": [
+          "arrays",
+          "recursion"
+        ]
       },
       {
         "slug": "phone-number",
         "name": "Phone Number",
         "uuid": "b68665d5-14ef-4351-ac4a-c28a80c27b3d",
-        "practices": ["regular-expressions"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 3,
         "topics": [
           "conditionals",
@@ -433,7 +756,10 @@
         "slug": "grains",
         "name": "Grains",
         "uuid": "22519f53-4516-43bc-915e-07d58e48f617",
-        "practices": ["integral-numbers", "math-operators"],
+        "practices": [
+          "integral-numbers",
+          "math-operators"
+        ],
         "prerequisites": [
           "integral-numbers",
           "math-operators",
@@ -442,40 +768,77 @@
           "exceptions"
         ],
         "difficulty": 4,
-        "topics": ["bitwise_operations", "math"]
+        "topics": [
+          "bitwise_operations",
+          "math"
+        ]
       },
       {
         "slug": "resistor-color-trio",
         "name": "Resistor Color Trio",
         "uuid": "2df14b68-75c8-4984-8ae2-ecd2cb7ed1d4",
-        "practices": ["strings"],
-        "prerequisites": ["arrays", "strings", "numbers", "exceptions"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 5,
-        "topics": ["loops"]
+        "topics": [
+          "loops"
+        ]
       },
       {
         "slug": "saddle-points",
         "name": "Saddle Points",
         "uuid": "38bb4ac6-a5ec-4448-8b86-cdaff13a8be3",
-        "practices": ["arrays"],
-        "prerequisites": ["arrays", "enumerable", "numbers"],
+        "practices": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "enumerable",
+          "numbers"
+        ],
         "difficulty": 5,
-        "topics": ["arrays", "integers", "matrices", "searching"]
+        "topics": [
+          "arrays",
+          "integers",
+          "matrices",
+          "searching"
+        ]
       },
       {
         "slug": "etl",
         "name": "ETL",
         "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
-        "practices": ["advanced-enumeration", "hashes"],
-        "prerequisites": ["strings", "numbers", "hashes"],
+        "practices": [
+          "advanced-enumeration",
+          "hashes"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "hashes"
+        ],
         "difficulty": 4,
-        "topics": ["loops", "maps", "transforming"]
+        "topics": [
+          "loops",
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "nucleotide-count",
         "name": "Nucleotide Count",
         "uuid": "8ad2bffd-1d79-4e1f-8ef3-ece0214d2804",
-        "practices": ["hashes", "exceptions"],
+        "practices": [
+          "hashes",
+          "exceptions"
+        ],
         "prerequisites": [
           "hashes",
           "strings",
@@ -484,13 +847,20 @@
           "exceptions"
         ],
         "difficulty": 4,
-        "topics": ["maps", "parsing", "strings"]
+        "topics": [
+          "maps",
+          "parsing",
+          "strings"
+        ]
       },
       {
         "slug": "pythagorean-triplet",
         "name": "Pythagorean Triplet",
         "uuid": "43aad536-0e24-464c-9554-cbc2699d0543",
-        "practices": ["classes", "constructors"],
+        "practices": [
+          "classes",
+          "constructors"
+        ],
         "prerequisites": [
           "classes",
           "constructors",
@@ -499,112 +869,233 @@
           "generic-methods"
         ],
         "difficulty": 5,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "collatz-conjecture",
         "name": "Collatz Conjecture",
         "uuid": "af961c87-341c-4dd3-a1eb-272501b9b0e4",
-        "practices": ["recursion", "loops", "conditionals", "numbers"],
-        "prerequisites": ["conditionals", "loops", "numbers", "exceptions"],
+        "practices": [
+          "recursion",
+          "loops",
+          "conditionals",
+          "numbers"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "loops",
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 1,
-        "topics": ["conditionals", "control_flow_loops", "integers", "math"]
+        "topics": [
+          "conditionals",
+          "control_flow_loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "sieve",
         "name": "Sieve",
         "uuid": "80f9af5a-ea29-4937-9333-b4494aaf2446",
-        "practices": ["arrays"],
-        "prerequisites": ["arrays", "numbers"],
+        "practices": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "numbers"
+        ],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "loops", "math", "sorting"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "loops",
+          "math",
+          "sorting"
+        ]
       },
       {
         "slug": "proverb",
         "name": "Proverb",
         "uuid": "3c5193ab-6471-4be2-9d24-1d2b51ad822a",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "arrays", "loops"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "arrays",
+          "loops"
+        ],
         "difficulty": 4,
-        "topics": ["arrays", "loops", "strings"]
+        "topics": [
+          "arrays",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "palindrome-products",
         "name": "Palindrome Products",
         "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
-        "practices": ["loops"],
-        "prerequisites": ["enumerable", "numbers", "loops"],
+        "practices": [
+          "loops"
+        ],
+        "prerequisites": [
+          "enumerable",
+          "numbers",
+          "loops"
+        ],
         "difficulty": 6,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "accumulate",
         "name": "Accumulate",
         "uuid": "2c71fc3a-2c93-402b-b091-697b795ce3ba",
-        "practices": ["lambdas", "enumeration", "blocks", "enumerable"],
-        "prerequisites": ["lambdas", "enumeration", "enumerable"],
+        "practices": [
+          "lambdas",
+          "enumeration",
+          "blocks",
+          "enumerable"
+        ],
+        "prerequisites": [
+          "lambdas",
+          "enumeration",
+          "enumerable"
+        ],
         "difficulty": 1,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "bob",
         "name": "Bob",
         "uuid": "70fec82e-3038-468f-96ef-bfb48ce03ef3",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "conditionals"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "conditionals"
+        ],
         "difficulty": 5,
-        "topics": ["conditionals", "strings"]
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
       },
       {
         "slug": "strain",
         "name": "Strain",
         "uuid": "ac0966a9-822b-45be-91d9-36f6706ea76f",
-        "practices": ["higher-order-functions", "blocks", "lazy-evaluation"],
-        "prerequisites": ["numbers", "higher-order-functions"],
+        "practices": [
+          "higher-order-functions",
+          "blocks",
+          "lazy-evaluation"
+        ],
+        "prerequisites": [
+          "numbers",
+          "higher-order-functions"
+        ],
         "difficulty": 2,
-        "topics": ["arrays", "filtering", "loops"]
+        "topics": [
+          "arrays",
+          "filtering",
+          "loops"
+        ]
       },
       {
         "slug": "nth-prime",
         "name": "Nth Prime",
         "uuid": "16baef71-6234-4928-a2d4-a19eb8e110b8",
-        "practices": ["lazy-evaluation"],
-        "prerequisites": ["numbers", "exceptions"],
+        "practices": [
+          "lazy-evaluation"
+        ],
+        "prerequisites": [
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "perfect-numbers",
         "name": "Perfect Numbers",
         "uuid": "76ad732a-6e58-403b-ac65-9091d355241f",
-        "practices": ["numbers"],
-        "prerequisites": ["symbols", "numbers", "exceptions"],
+        "practices": [
+          "numbers"
+        ],
+        "prerequisites": [
+          "symbols",
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 4,
-        "topics": ["algorithms", "filtering", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "filtering",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "alphametics",
         "name": "Alphametics",
         "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
-        "practices": ["lazy-evaluation"],
-        "prerequisites": ["strings", "lazy-evaluation"],
+        "practices": [
+          "lazy-evaluation"
+        ],
+        "prerequisites": [
+          "strings",
+          "lazy-evaluation"
+        ],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "searching"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "searching"
+        ]
       },
       {
         "slug": "binary-search",
         "name": "Binary Search",
         "uuid": "b1ba445d-4908-4922-acc0-de3a0ec92c53",
-        "practices": ["loops"],
-        "prerequisites": ["arrays", "numbers", "loops"],
+        "practices": [
+          "loops"
+        ],
+        "prerequisites": [
+          "arrays",
+          "numbers",
+          "loops"
+        ],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "searching", "sorting"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "searching",
+          "sorting"
+        ]
       },
       {
         "slug": "two-bucket",
         "name": "Two Bucket",
         "uuid": "e5a2d445-437d-46a8-889b-fbcd62c70fa9",
-        "practices": ["instance-variables", "constructors"],
+        "practices": [
+          "instance-variables",
+          "constructors"
+        ],
         "prerequisites": [
           "symbols",
           "constructors",
@@ -612,22 +1103,38 @@
           "numbers"
         ],
         "difficulty": 5,
-        "topics": ["algorithms", "conditionals", "searching"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "searching"
+        ]
       },
       {
         "slug": "matching-brackets",
         "name": "Matching Brackets",
         "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
-        "practices": ["stacks"],
-        "prerequisites": ["stacks", "strings", "booleans"],
+        "practices": [
+          "stacks"
+        ],
+        "prerequisites": [
+          "stacks",
+          "strings",
+          "booleans"
+        ],
         "difficulty": 7,
-        "topics": ["parsing", "strings"]
+        "topics": [
+          "parsing",
+          "strings"
+        ]
       },
       {
         "slug": "all-your-base",
         "name": "All Your Base",
         "uuid": "3ce4bd3e-0380-498a-8d0a-b79cf3fedc10",
-        "practices": ["loops", "math-operators"],
+        "practices": [
+          "loops",
+          "math-operators"
+        ],
         "prerequisites": [
           "numbers",
           "loops",
@@ -636,22 +1143,38 @@
           "exceptions"
         ],
         "difficulty": 3,
-        "topics": ["integers", "math", "transforming"]
+        "topics": [
+          "integers",
+          "math",
+          "transforming"
+        ]
       },
       {
         "slug": "scale-generator",
         "name": "Scale Generator",
         "uuid": "4134d491-8ec5-480b-aa61-37a02689db1f",
-        "practices": ["enumeration"],
-        "prerequisites": ["strings", "arrays", "enumeration"],
+        "practices": [
+          "enumeration"
+        ],
+        "prerequisites": [
+          "strings",
+          "arrays",
+          "enumeration"
+        ],
         "difficulty": 3,
-        "topics": ["pattern_matching", "strings"]
+        "topics": [
+          "pattern_matching",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
         "name": "Allergies",
         "uuid": "7a67a62f-9331-4776-a5b5-aaba7ad1e1e6",
-        "practices": ["bit-manipulation", "symbols"],
+        "practices": [
+          "bit-manipulation",
+          "symbols"
+        ],
         "prerequisites": [
           "symbols",
           "arrays",
@@ -660,14 +1183,24 @@
           "classes"
         ],
         "difficulty": 4,
-        "topics": ["bitwise_operations", "enumeration"]
+        "topics": [
+          "bitwise_operations",
+          "enumeration"
+        ]
       },
       {
         "slug": "rail-fence-cipher",
         "name": "Rail Fence Cipher",
         "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
-        "practices": ["constructors"],
-        "prerequisites": ["classes", "constructors", "numbers", "strings"],
+        "practices": [
+          "constructors"
+        ],
+        "prerequisites": [
+          "classes",
+          "constructors",
+          "numbers",
+          "strings"
+        ],
         "difficulty": 4,
         "topics": [
           "algorithms",
@@ -683,25 +1216,52 @@
         "slug": "run-length-encoding",
         "name": "Run-Length Encoding",
         "uuid": "9d6a8c89-41c1-4c4e-b24c-476ba0dfa5f9",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "conditionals", "enumeration", "booleans"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "conditionals",
+          "enumeration",
+          "booleans"
+        ],
         "difficulty": 4,
-        "topics": ["parsing", "strings", "transforming"]
+        "topics": [
+          "parsing",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "minesweeper",
         "name": "Minesweeper",
         "uuid": "9d6808fb-d367-4df9-a1f0-47ff83b75544",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "arrays", "conditionals", "exceptions"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "arrays",
+          "conditionals",
+          "exceptions"
+        ],
         "difficulty": 5,
-        "topics": ["arrays", "games", "loops", "matrices", "transforming"]
+        "topics": [
+          "arrays",
+          "games",
+          "loops",
+          "matrices",
+          "transforming"
+        ]
       },
       {
         "slug": "robot-simulator",
         "name": "Robot Simulator",
         "uuid": "724e6a6e-2e6e-45a9-ab0e-0d8d50a06085",
-        "practices": ["conditionals", "constructors"],
+        "practices": [
+          "conditionals",
+          "constructors"
+        ],
         "prerequisites": [
           "symbols",
           "classes",
@@ -712,32 +1272,67 @@
           "exceptions"
         ],
         "difficulty": 6,
-        "topics": ["concurrency", "loops", "sequences", "strings", "structs"]
+        "topics": [
+          "concurrency",
+          "loops",
+          "sequences",
+          "strings",
+          "structs"
+        ]
       },
       {
         "slug": "beer-song",
         "name": "Beer Song",
         "uuid": "e4f0873a-e834-4b28-9902-795f52f76adb",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "numbers", "loops"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "loops"
+        ],
         "difficulty": 3,
-        "topics": ["loops", "strings", "text_formatting"]
+        "topics": [
+          "loops",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "protein-translation",
         "name": "Protein Translation",
         "uuid": "607a3515-e53b-427f-8e3b-1e22912fa29a",
-        "practices": ["loops", "advanced-enumeration"],
-        "prerequisites": ["strings", "loops", "arrays", "exceptions"],
+        "practices": [
+          "loops",
+          "advanced-enumeration"
+        ],
+        "prerequisites": [
+          "strings",
+          "loops",
+          "arrays",
+          "exceptions"
+        ],
         "difficulty": 3,
-        "topics": ["filtering", "maps", "sequences"]
+        "topics": [
+          "filtering",
+          "maps",
+          "sequences"
+        ]
       },
       {
         "slug": "wordy",
         "name": "Wordy",
         "uuid": "cb58e4cf-e3af-469c-9f2d-02557b9f61ed",
-        "practices": ["conditionals", "regular-expressions"],
-        "prerequisites": ["strings", "numbers", "exceptions"],
+        "practices": [
+          "conditionals",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 3,
         "topics": [
           "conditionals",
@@ -751,26 +1346,51 @@
         "slug": "secret-handshake",
         "name": "Secret Handshake",
         "uuid": "c1ebad1b-d5aa-465a-b5ef-9e717ab5db9e",
-        "practices": ["bit-manipulation"],
-        "prerequisites": ["strings", "bit-manipulation", "arrays"],
+        "practices": [
+          "bit-manipulation"
+        ],
+        "prerequisites": [
+          "strings",
+          "bit-manipulation",
+          "arrays"
+        ],
         "difficulty": 5,
-        "topics": ["arrays", "bitwise_operations", "integers"]
+        "topics": [
+          "arrays",
+          "bitwise_operations",
+          "integers"
+        ]
       },
       {
         "slug": "atbash-cipher",
         "name": "Atbash Cipher",
         "uuid": "1e737640-9785-4a47-866a-46298104d891",
-        "practices": ["enumeration"],
-        "prerequisites": ["strings", "enumeration"],
+        "practices": [
+          "enumeration"
+        ],
+        "prerequisites": [
+          "strings",
+          "enumeration"
+        ],
         "difficulty": 3,
-        "topics": ["algorithms", "cryptography", "strings", "transforming"]
+        "topics": [
+          "algorithms",
+          "cryptography",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "crypto-square",
         "name": "Crypto Square",
         "uuid": "86f8e33d-31b7-43e3-8ea3-2e391133704a",
-        "practices": ["enumerable"],
-        "prerequisites": ["strings", "enumerable"],
+        "practices": [
+          "enumerable"
+        ],
+        "prerequisites": [
+          "strings",
+          "enumerable"
+        ],
         "difficulty": 3,
         "topics": [
           "cryptography",
@@ -784,8 +1404,16 @@
         "slug": "list-ops",
         "name": "List Ops",
         "uuid": "f62e8acb-8370-46e1-ad7f-a6a2644f8602",
-        "practices": ["higher-order-functions", "arrays", "parameters"],
-        "prerequisites": ["parameters", "arrays", "higher-order-functions"],
+        "practices": [
+          "higher-order-functions",
+          "arrays",
+          "parameters"
+        ],
+        "prerequisites": [
+          "parameters",
+          "arrays",
+          "higher-order-functions"
+        ],
         "difficulty": 3,
         "topics": [
           "functional_programming",
@@ -798,16 +1426,29 @@
         "slug": "robot-name",
         "name": "Robot Name",
         "uuid": "76a0fd0a-cc65-4be3-acc8-7348bb67ad5a",
-        "practices": ["randomness", "classes"],
-        "prerequisites": ["randomness", "strings", "classes"],
+        "practices": [
+          "randomness",
+          "classes"
+        ],
+        "prerequisites": [
+          "randomness",
+          "strings",
+          "classes"
+        ],
         "difficulty": 3,
-        "topics": ["randomness"]
+        "topics": [
+          "randomness"
+        ]
       },
       {
         "slug": "simple-cipher",
         "name": "Simple Cipher",
         "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
-        "practices": ["classes", "instance-variables", "randomness"],
+        "practices": [
+          "classes",
+          "instance-variables",
+          "randomness"
+        ],
         "prerequisites": [
           "strings",
           "classes",
@@ -829,34 +1470,64 @@
         "slug": "dominoes",
         "name": "Dominoes",
         "uuid": "705f3eb6-55a9-476c-b3f2-e9f3cb0bbe37",
-        "practices": ["lazy-evaluation"],
-        "prerequisites": ["enumerable", "numbers", "booleans"],
+        "practices": [
+          "lazy-evaluation"
+        ],
+        "prerequisites": [
+          "enumerable",
+          "numbers",
+          "booleans"
+        ],
         "difficulty": 4,
-        "topics": ["algorithms", "arrays", "searching"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "searching"
+        ]
       },
       {
         "slug": "pig-latin",
         "name": "Pig Latin",
         "uuid": "efc0e498-891a-4e91-a6aa-fae635573a83",
-        "practices": ["regular-expressions"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 4,
-        "topics": ["conditionals", "strings", "transforming"]
+        "topics": [
+          "conditionals",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "simple-linked-list",
         "name": "Simple Linked List",
         "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
-        "practices": ["instance-variables", "enumerable"],
-        "prerequisites": ["instance-variables", "numbers"],
+        "practices": [
+          "instance-variables",
+          "enumerable"
+        ],
+        "prerequisites": [
+          "instance-variables",
+          "numbers"
+        ],
         "difficulty": 4,
-        "topics": ["arrays", "loops"]
+        "topics": [
+          "arrays",
+          "loops"
+        ]
       },
       {
         "slug": "binary-search-tree",
         "name": "Binary Search Tree",
         "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
-        "practices": ["instance-variables", "constructors"],
+        "practices": [
+          "instance-variables",
+          "constructors"
+        ],
         "prerequisites": [
           "enumerable",
           "instance-variables",
@@ -879,61 +1550,127 @@
         "slug": "change",
         "name": "Change",
         "uuid": "dc6c3e44-1027-4d53-9653-ba06824f8bcf",
-        "practices": ["exceptions", "advanced-enumeration"],
-        "prerequisites": ["numbers", "arrays", "exceptions"],
+        "practices": [
+          "exceptions",
+          "advanced-enumeration"
+        ],
+        "prerequisites": [
+          "numbers",
+          "arrays",
+          "exceptions"
+        ],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "loops", "searching"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "loops",
+          "searching"
+        ]
       },
       {
         "slug": "circular-buffer",
         "name": "Circular Buffer",
         "uuid": "f3419fe3-a5f5-4bc9-bc40-49f450b8981e",
-        "practices": ["queues", "exceptions"],
-        "prerequisites": ["queues", "classes", "numbers", "exceptions"],
+        "practices": [
+          "queues",
+          "exceptions"
+        ],
+        "prerequisites": [
+          "queues",
+          "classes",
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 5,
-        "topics": ["queues", "structs"]
+        "topics": [
+          "queues",
+          "structs"
+        ]
       },
       {
         "slug": "grade-school",
         "name": "Grade School",
         "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
-        "practices": ["hashes", "ordering"],
-        "prerequisites": ["strings", "numbers", "enumerable", "ordering"],
+        "practices": [
+          "hashes",
+          "ordering"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "enumerable",
+          "ordering"
+        ],
         "difficulty": 5,
-        "topics": ["arrays", "sorting", "structs"]
+        "topics": [
+          "arrays",
+          "sorting",
+          "structs"
+        ]
       },
       {
         "slug": "roman-numerals",
         "name": "Roman Numerals",
         "uuid": "b7ca9519-c33b-418b-a4ef-858a3d4d6855",
-        "practices": ["numbers", "loops"],
-        "prerequisites": ["strings", "loops", "numbers"],
+        "practices": [
+          "numbers",
+          "loops"
+        ],
+        "prerequisites": [
+          "strings",
+          "loops",
+          "numbers"
+        ],
         "difficulty": 2,
-        "topics": ["numbers", "transforming"]
+        "topics": [
+          "numbers",
+          "transforming"
+        ]
       },
       {
         "slug": "rotational-cipher",
         "name": "Rotational Cipher",
         "uuid": "af5ccf14-eff2-4dc6-b1db-e209cddca62a",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "numbers"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers"
+        ],
         "difficulty": 2,
-        "topics": ["cryptography", "integers", "strings"]
+        "topics": [
+          "cryptography",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "affine-cipher",
         "name": "Affine Cipher",
         "uuid": "d1267415-aff5-411d-b267-49a4a2c8fda2",
-        "practices": ["enumeration"],
-        "prerequisites": ["strings", "numbers", "exceptions"],
+        "practices": [
+          "enumeration"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "exceptions"
+        ],
         "difficulty": 3,
-        "topics": ["cryptography", "math", "strings"]
+        "topics": [
+          "cryptography",
+          "math",
+          "strings"
+        ]
       },
       {
         "slug": "kindergarten-garden",
         "name": "Kindergarten Garden",
         "uuid": "04bde625-e363-4d8b-880f-db7bf86286eb",
-        "practices": ["symbols"],
+        "practices": [
+          "symbols"
+        ],
         "prerequisites": [
           "strings",
           "symbols",
@@ -943,13 +1680,22 @@
           "meta-programming"
         ],
         "difficulty": 4,
-        "topics": ["parsing", "records", "searching", "strings", "structs"]
+        "topics": [
+          "parsing",
+          "records",
+          "searching",
+          "strings",
+          "structs"
+        ]
       },
       {
         "slug": "largest-series-product",
         "name": "Largest Series Product",
         "uuid": "7cb55328-1b11-4544-94c0-945444d9a6a4",
-        "practices": ["integral-numbers", "math-operators"],
+        "practices": [
+          "integral-numbers",
+          "math-operators"
+        ],
         "prerequisites": [
           "integral-numbers",
           "math-operators",
@@ -958,22 +1704,42 @@
           "exceptions"
         ],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "math", "sequences"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math",
+          "sequences"
+        ]
       },
       {
         "slug": "prime-factors",
         "name": "Prime Factors",
         "uuid": "a18daa31-88d3-45ba-84ca-f1d52fe23a79",
-        "practices": ["integral-numbers", "loops"],
-        "prerequisites": ["integral-numbers", "arrays", "loops"],
+        "practices": [
+          "integral-numbers",
+          "loops"
+        ],
+        "prerequisites": [
+          "integral-numbers",
+          "arrays",
+          "loops"
+        ],
         "difficulty": 3,
-        "topics": ["algorithms", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "custom-set",
         "name": "Custom Set",
         "uuid": "4f74b3cd-f995-4b8c-9b57-23f073261d0e",
-        "practices": ["sets", "immutability", "constructors"],
+        "practices": [
+          "sets",
+          "immutability",
+          "constructors"
+        ],
         "prerequisites": [
           "sets",
           "arrays",
@@ -983,32 +1749,60 @@
           "constructors"
         ],
         "difficulty": 4,
-        "topics": ["filtering", "loops", "sets"]
+        "topics": [
+          "filtering",
+          "loops",
+          "sets"
+        ]
       },
       {
         "slug": "house",
         "name": "House",
         "uuid": "df5d771a-e57b-4a96-8a29-9bd4ce7f88d2",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "numbers"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers"
+        ],
         "difficulty": 4,
-        "topics": ["recursion", "strings", "text_formatting"]
+        "topics": [
+          "recursion",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "linked-list",
         "name": "Linked List",
         "uuid": "92c9aafc-791d-4aaf-a136-9bee14f6ff95",
-        "practices": [],
-        "prerequisites": ["numbers", "classes"],
+        "practices": [
+
+        ],
+        "prerequisites": [
+          "numbers",
+          "classes"
+        ],
         "difficulty": 4,
-        "topics": ["data_structure", "pointer"]
+        "topics": [
+          "data_structure",
+          "pointer"
+        ]
       },
       {
         "slug": "poker",
         "name": "Poker",
         "uuid": "9a59ba44-34f5-410b-a1e6-9a5c47c52d9e",
-        "practices": ["ordering"],
-        "prerequisites": ["enumerable", "strings", "ordering", "conditionals"],
+        "practices": [
+          "ordering"
+        ],
+        "prerequisites": [
+          "enumerable",
+          "strings",
+          "ordering",
+          "conditionals"
+        ],
         "difficulty": 5,
         "topics": [
           "equality",
@@ -1023,16 +1817,28 @@
         "slug": "isbn-verifier",
         "name": "ISBN Verifier",
         "uuid": "a0aac827-8f7a-4065-9d05-a57009f5668d",
-        "practices": ["strings", "regular-expressions"],
-        "prerequisites": ["strings", "booleans"],
+        "practices": [
+          "strings",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "booleans"
+        ],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "complex-numbers",
         "name": "Complex Numbers",
         "uuid": "d75bd7c0-52c5-44f2-a046-f63cb332425f",
-        "practices": ["structs", "immutability", "math-operators"],
+        "practices": [
+          "structs",
+          "immutability",
+          "math-operators"
+        ],
         "prerequisites": [
           "numbers",
           "structs",
@@ -1040,23 +1846,40 @@
           "math-operators"
         ],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "meetup",
         "name": "Meetup",
         "uuid": "8120e133-9561-4f82-8081-10c19f7f6ba3",
-        "practices": ["dates", "time"],
-        "prerequisites": ["dates", "time"],
+        "practices": [
+          "dates",
+          "time"
+        ],
+        "prerequisites": [
+          "dates",
+          "time"
+        ],
         "difficulty": 3,
-        "topics": ["dates", "time", "transforming", "type_conversion"]
+        "topics": [
+          "dates",
+          "time",
+          "transforming",
+          "type_conversion"
+        ]
       },
       {
         "slug": "diamond",
         "name": "Diamond",
         "uuid": "c55c75fb-6140-4042-967a-39c75b7781bd",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 4,
         "topics": [
           "algorithms",
@@ -1070,25 +1893,50 @@
         "slug": "bowling",
         "name": "Bowling",
         "uuid": "051f0825-8357-4ca6-b24f-40a373deac19",
-        "practices": ["nil", "classes"],
-        "prerequisites": ["numbers", "classes", "nil", "exceptions"],
+        "practices": [
+          "nil",
+          "classes"
+        ],
+        "prerequisites": [
+          "numbers",
+          "classes",
+          "nil",
+          "exceptions"
+        ],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "conditionals"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "conditionals"
+        ]
       },
       {
         "slug": "ocr-numbers",
         "name": "OCR Numbers",
         "uuid": "dd13bb29-589c-497d-9580-3f288f353fb2",
-        "practices": ["strings"],
-        "prerequisites": ["strings", "loops", "conditionals", "exceptions"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "loops",
+          "conditionals",
+          "exceptions"
+        ],
         "difficulty": 7,
-        "topics": ["parsing", "pattern_recognition"]
+        "topics": [
+          "parsing",
+          "pattern_recognition"
+        ]
       },
       {
         "slug": "say",
         "name": "Say",
         "uuid": "2a410923-6445-41fc-9cf3-a60209e1c1c2",
-        "practices": ["integral-numbers", "conditionals"],
+        "practices": [
+          "integral-numbers",
+          "conditionals"
+        ],
         "prerequisites": [
           "integral-numbers",
           "strings",
@@ -1097,23 +1945,43 @@
           "exceptions"
         ],
         "difficulty": 7,
-        "topics": ["numbers", "strings", "text_formatting", "transforming"]
+        "topics": [
+          "numbers",
+          "strings",
+          "text_formatting",
+          "transforming"
+        ]
       },
       {
         "slug": "zipper",
         "name": "Zipper",
         "uuid": "239b8e79-2983-4ce0-9dda-9bb999e79d11",
-        "practices": ["immutability", "equality", "recursion"],
-        "prerequisites": ["numbers", "classes", "equality"],
+        "practices": [
+          "immutability",
+          "equality",
+          "recursion"
+        ],
+        "prerequisites": [
+          "numbers",
+          "classes",
+          "equality"
+        ],
         "difficulty": 7,
-        "topics": ["data_structures"]
+        "topics": [
+          "data_structures"
+        ]
       },
       {
         "slug": "grep",
         "name": "Grep",
         "uuid": "4ad4ea80-945d-4b37-b40c-bd05bed82266",
-        "practices": ["conditionals"],
-        "prerequisites": ["conditionals", "strings"],
+        "practices": [
+          "conditionals"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "strings"
+        ],
         "difficulty": 8,
         "topics": [
           "files",
@@ -1128,8 +1996,16 @@
         "slug": "food-chain",
         "name": "Food Chain",
         "uuid": "6f0919eb-2160-4cca-8504-286acc2ae9c8",
-        "practices": ["strings", "conditionals"],
-        "prerequisites": ["strings", "numbers", "conditionals", "loops"],
+        "practices": [
+          "strings",
+          "conditionals"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "conditionals",
+          "loops"
+        ],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -1143,16 +2019,30 @@
         "slug": "pascals-triangle",
         "name": "Pascal's Triangle",
         "uuid": "4ff8b056-f27d-4bdf-b7af-214448db4260",
-        "practices": ["enumerable"],
-        "prerequisites": ["loops", "enumerable", "numbers"],
+        "practices": [
+          "enumerable"
+        ],
+        "prerequisites": [
+          "loops",
+          "enumerable",
+          "numbers"
+        ],
         "difficulty": 4,
-        "topics": ["algorithms", "arrays", "math", "recursion"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "math",
+          "recursion"
+        ]
       },
       {
         "slug": "queen-attack",
         "name": "Queen Attack",
         "uuid": "2ce9b158-e730-4c86-8639-bd08af9f80f4",
-        "practices": ["constructors", "math-operators"],
+        "practices": [
+          "constructors",
+          "math-operators"
+        ],
         "prerequisites": [
           "classes",
           "constructors",
@@ -1162,7 +2052,12 @@
           "exceptions"
         ],
         "difficulty": 5,
-        "topics": ["booleans", "errors", "games", "logic"]
+        "topics": [
+          "booleans",
+          "errors",
+          "games",
+          "logic"
+        ]
       },
       {
         "slug": "book-store",
@@ -1181,23 +2076,45 @@
           "loops"
         ],
         "difficulty": 8,
-        "topics": ["algorithms", "floating_point_numbers", "integers", "arrays"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers",
+          "integers",
+          "arrays"
+        ]
       },
       {
         "slug": "connect",
         "name": "Connect",
         "uuid": "538a6768-bae5-437c-9cdf-765d73a79643",
-        "practices": ["symbols"],
-        "prerequisites": ["strings", "symbols", "arrays", "conditionals"],
+        "practices": [
+          "symbols"
+        ],
+        "prerequisites": [
+          "strings",
+          "symbols",
+          "arrays",
+          "conditionals"
+        ],
         "difficulty": 9,
-        "topics": ["arrays", "games", "graphs", "loops", "searching"]
+        "topics": [
+          "arrays",
+          "games",
+          "graphs",
+          "loops",
+          "searching"
+        ]
       },
       {
         "slug": "binary",
         "name": "Binary",
         "uuid": "43bc27ed-d2fa-4173-8665-4459b71c9a3a",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+
+        ],
+        "prerequisites": [
+
+        ],
         "difficulty": 1,
         "topics": null,
         "status": "deprecated"
@@ -1206,8 +2123,12 @@
         "slug": "hexadecimal",
         "name": "Hexadecimal",
         "uuid": "6984cc14-91f8-47a7-b7e2-4b210a5dbc5c",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+
+        ],
+        "prerequisites": [
+
+        ],
         "difficulty": 1,
         "topics": null,
         "status": "deprecated"
@@ -1216,8 +2137,12 @@
         "slug": "octal",
         "name": "Octal",
         "uuid": "cae4e000-3aac-41f7-b727-f9cce12d058d",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+
+        ],
+        "prerequisites": [
+
+        ],
         "difficulty": 1,
         "topics": null,
         "status": "deprecated"
@@ -1226,8 +2151,12 @@
         "slug": "point-mutations",
         "name": "Point Mutations",
         "uuid": "89bd3d71-000f-4cd9-9a84-ad1b22ddbd33",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+
+        ],
+        "prerequisites": [
+
+        ],
         "difficulty": 1,
         "topics": null,
         "status": "deprecated"
@@ -1236,8 +2165,12 @@
         "slug": "trinary",
         "name": "Trinary",
         "uuid": "f6735416-4be6-4eb8-b6b9-cb61671ce25e",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+
+        ],
+        "prerequisites": [
+
+        ],
         "difficulty": 1,
         "topics": null,
         "status": "deprecated"
@@ -1246,19 +2179,36 @@
         "slug": "microwave",
         "name": "Microwave",
         "uuid": "34e715a6-4d22-4b74-a26a-409283ac419c",
-        "practices": ["string-formatting"],
-        "prerequisites": ["string-formatting"],
+        "practices": [
+          "string-formatting"
+        ],
+        "prerequisites": [
+          "string-formatting"
+        ],
         "difficulty": 2,
-        "topics": ["math", "strings", "interpolation"]
+        "topics": [
+          "math",
+          "strings",
+          "interpolation"
+        ]
       },
       {
         "slug": "darts",
         "name": "Darts",
         "uuid": "15b73808-78a4-4854-b7cf-82a478107024",
-        "practices": ["floating-point-numbers", "conditionals"],
-        "prerequisites": ["floating-point-numbers", "conditionals"],
+        "practices": [
+          "floating-point-numbers",
+          "conditionals"
+        ],
+        "prerequisites": [
+          "floating-point-numbers",
+          "conditionals"
+        ],
         "difficulty": 3,
-        "topics": ["math", "geometry"]
+        "topics": [
+          "math",
+          "geometry"
+        ]
       }
     ]
   },


### PR DESCRIPTION
This is a scripted change.

Since `configlet fmt` doesn't yet operate on the track config, I went ahead and did a Ruby `JSON.pretty_generate` on it in the first commit so that the second will be easy to verify.

The topics entry is deprecated. We kept it around in order to be able to populate the practices and prerequisites fields.

Since practices and prerequisites now have values, the topics can be deleted.