### PR TITLE
Sync two-bucket with problem-specifications

### DIFF
--- a/exercises/practice/two-bucket/.docs/instructions.md
+++ b/exercises/practice/two-bucket/.docs/instructions.md
@@ -1,30 +1,46 @@
 # Instructions
 
-Given two buckets of different size, demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
+Given two buckets of different size and which bucket to fill first, determine how many actions are required to measure an exact number of liters by strategically transferring fluid between the buckets.
 
-Since this mathematical problem is fairly subject to interpretation / individual approach, the tests have been written specifically to expect one overarching solution.
+There are some rules that your solution must follow:
 
-To help, the tests provide you with which bucket to fill first. That means, when starting with the larger bucket full, you are NOT allowed at any point to have the smaller bucket full and the larger bucket empty (aka, the opposite starting point); that would defeat the purpose of comparing both approaches!
+- You can only do one action at a time.
+- There are only 3 possible actions:
+  1. Pouring one bucket into the other bucket until either:
+     a) the first bucket is empty
+     b) the second bucket is full
+  2. Emptying a bucket and doing nothing to the other.
+  3. Filling a bucket and doing nothing to the other.
+- After an action, you may not arrive at a state where the starting bucket is empty and the other bucket is full.
 
 Your program will take as input:
+
 - the size of bucket one
 - the size of bucket two
 - the desired number of liters to reach
 - which bucket to fill first, either bucket one or bucket two
 
 Your program should determine:
-- the total number of "moves" it should take to reach the desired number of liters, including the first fill
-- which bucket should end up with the desired number of liters (let's say this is bucket A) - either bucket one or bucket two
-- how many liters are left in the other bucket (bucket B)
 
-Note: any time a change is made to either or both buckets counts as one (1) move.
+- the total number of actions it should take to reach the desired number of liters, including the first fill of the starting bucket
+- which bucket should end up with the desired number of liters - either bucket one or bucket two
+- how many liters are left in the other bucket
+
+Note: any time a change is made to either or both buckets counts as one (1) action.
 
 Example:
-Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let's say bucket one, at a given step, is holding 7 liters, and bucket two is holding 8 liters (7,8). If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one "move". Instead, if you had poured from bucket one into bucket two until bucket two was full, leaving you with 4 liters in bucket one and 11 liters in bucket two (4,11), that would count as only one "move" as well.
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters.
+Let's say at a given step, bucket one is holding 7 liters and bucket two is holding 8 liters (7,8).
+If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one action.
+Instead, if you had poured from bucket one into bucket two until bucket two was full, resulting in 4 liters in bucket one and 11 liters in bucket two (4,11), that would also only count as one action.
 
-To conclude, the only valid moves are:
-- pouring from either bucket to another
-- emptying either bucket and doing nothing to the other
-- filling either bucket and doing nothing to the other
+Another Example:
+Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.
+You are told you must start with bucket one.
+So your first action is to fill bucket one.
+You choose to empty bucket one for your second action.
+For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
 
-Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.
+Written with <3 at [Fullstack Academy][fulstack] by Lindsay Levine.
+
+[fullstack]: http://www.fullstackacademy.com/

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -26,3 +26,14 @@ description = "Measure one step using bucket one of size 1 and bucket two of siz
 
 [eb329c63-5540-4735-b30b-97f7f4df0f84]
 description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
+
+[449be72d-b10a-4f4b-a959-ca741e333b72]
+description = "Not possible to reach the goal"
+include = false
+
+[aac38b7a-77f4-4d62-9b91-8846d533b054]
+description = "With the same buckets but a different goal, then it is possible"
+
+[74633132-0ccf-49de-8450-af4ab2e3b299]
+description = "Goal larger than both buckets is impossible"
+include = false

--- a/exercises/practice/two-bucket/two_bucket_test.rb
+++ b/exercises/practice/two-bucket/two_bucket_test.rb
@@ -2,51 +2,59 @@ require 'minitest/autorun'
 require_relative 'two_bucket'
 
 class TwoBucketTest < Minitest::Test
-  def test_bucket_one_size_3_bucket_two_size_5_goal_1_start_with_bucket_one
+  def test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5_start_with_bucket_one
     # skip
-    subject = TwoBucket.new(3, 5, 1, 'one')
+    subject = TwoBucket.new(3, 5, 1, "one")
     assert_equal 4, subject.moves
-    assert_equal 'one', subject.goal_bucket
+    assert_equal "one", subject.goal_bucket
     assert_equal 5, subject.other_bucket
   end
 
-  def test_bucket_one_size_3_bucket_two_size_5_goal_1_start_with_bucket_two
+  def test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5_start_with_bucket_two
     skip
-    subject = TwoBucket.new(3, 5, 1, 'two')
+    subject = TwoBucket.new(3, 5, 1, "two")
     assert_equal 8, subject.moves
-    assert_equal 'two', subject.goal_bucket
+    assert_equal "two", subject.goal_bucket
     assert_equal 3, subject.other_bucket
   end
 
-  def test_bucket_one_size_7_bucket_two_size_11_goal_2_start_with_bucket_one
+  def test_measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11_start_with_bucket_one
     skip
-    subject = TwoBucket.new(7, 11, 2, 'one')
+    subject = TwoBucket.new(7, 11, 2, "one")
     assert_equal 14, subject.moves
-    assert_equal 'one', subject.goal_bucket
+    assert_equal "one", subject.goal_bucket
     assert_equal 11, subject.other_bucket
   end
 
-  def test_bucket_one_size_7_bucket_two_size_11_goal_2_start_with_bucket_two
+  def test_measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11_start_with_bucket_two
     skip
-    subject = TwoBucket.new(7, 11, 2, 'two')
+    subject = TwoBucket.new(7, 11, 2, "two")
     assert_equal 18, subject.moves
-    assert_equal 'two', subject.goal_bucket
+    assert_equal "two", subject.goal_bucket
     assert_equal 7, subject.other_bucket
   end
 
-  def test_bucket_one_size_1_bucket_two_size_3_goal_3_start_with_bucket_two
+  def test_measure_one_step_using_bucket_one_of_size_1_and_bucket_two_of_size_3_start_with_bucket_two
     skip
-    subject = TwoBucket.new(1, 3, 3, 'two')
+    subject = TwoBucket.new(1, 3, 3, "two")
     assert_equal 1, subject.moves
-    assert_equal 'two', subject.goal_bucket
+    assert_equal "two", subject.goal_bucket
     assert_equal 0, subject.other_bucket
   end
 
-  def test_bucket_one_size_2_bucket_two_size_3_goal_3_start_with_bucket_one
+  def test_measure_using_bucket_one_of_size_2_and_bucket_two_of_size_3_start_with_bucket_one_and_end_with_bucket_two
     skip
-    subject = TwoBucket.new(2, 3, 3, 'one')
+    subject = TwoBucket.new(2, 3, 3, "one")
     assert_equal 2, subject.moves
-    assert_equal 'two', subject.goal_bucket
+    assert_equal "two", subject.goal_bucket
     assert_equal 2, subject.other_bucket
+  end
+
+  def test_with_the_same_buckets_but_a_different_goal_then_it_is_possible
+    skip
+    subject = TwoBucket.new(6, 15, 9, "one")
+    assert_equal 10, subject.moves
+    assert_equal "two", subject.goal_bucket
+    assert_equal 0, subject.other_bucket
   end
 end


### PR DESCRIPTION
When syncing the tests.toml there were three possible new tests. Two of them added error handling, which I decided to exclude, as I don't think error handling makes this exercise more interesting.

Regenerating changed from single quotes to double quotes, which I think is fine, since we haven't taken a strong stance on that from the Rubocop perspective.