### PR TITLE
Sync roman-numerals with problem-specifications

### DIFF
--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -2,17 +2,15 @@
 
 Write a function to convert from normal numbers to Roman Numerals.
 
-The Romans were a clever bunch. They conquered most of Europe and ruled
-it for hundreds of years. They invented concrete and straight roads and
-even bikinis. One thing they never discovered though was the number
-zero. This made writing and dating extensive histories of their exploits
-slightly more challenging, but the system of numbers they came up with
-is still in use today. For example the BBC uses Roman numerals to date
-their programmes.
+The Romans were a clever bunch.
+They conquered most of Europe and ruled it for hundreds of years.
+They invented concrete and straight roads and even bikinis.
+One thing they never discovered though was the number zero.
+This made writing and dating extensive histories of their exploits slightly more challenging, but the system of numbers they came up with is still in use today.
+For example the BBC uses Roman numerals to date their programs.
 
-The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
-these letters have lots of straight lines and are hence easy to hack
-into stone tablets).
+The Romans wrote numbers using letters - I, V, X, L, C, D, M.
+(notice these letters have lots of straight lines and are hence easy to hack into stone tablets).
 
 ```text
  1  => I
@@ -20,12 +18,10 @@ into stone tablets).
  7  => VII
 ```
 
-There is no need to be able to convert numbers larger than about 3000.
+The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
-Wikipedia says: Modern Roman numerals ... are written by expressing each
-digit separately starting with the left most digit and skipping any
-digit with a value of zero.
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero.
 
 To see this in practice, consider the example of 1990.
 
@@ -40,4 +36,6 @@ In Roman numerals 1990 is MCMXC:
 2000=MM
 8=VIII
 
-See also: http://www.novaroma.org/via_romana/numbers.html
+Learn more about [Roman numberals on Wikipedia][roman-numerals].
+
+[roman-numerals]: https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -10,58 +10,79 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
-description = "1 is a single I"
+description = "1 is I"
 
 [f088f064-2d35-4476-9a41-f576da3f7b03]
-description = "2 is two I's"
+description = "2 is II"
 
 [b374a79c-3bea-43e6-8db8-1286f79c7106]
-description = "3 is three I's"
+description = "3 is III"
 
 [05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
-description = "4, being 5 - 1, is IV"
+description = "4 is IV"
 
 [57c0f9ad-5024-46ab-975d-de18c430b290]
-description = "5 is a single V"
+description = "5 is V"
 
 [20a2b47f-e57f-4797-a541-0b3825d7f249]
-description = "6, being 5 + 1, is VI"
+description = "6 is VI"
 
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
-description = "9, being 10 - 1, is IX"
+description = "9 is IX"
 
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
-description = "20 is two X's"
+description = "27 is XXVII"
 
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
-description = "48 is not 50 - 2 but rather 40 + 8"
+description = "48 is XLVIII"
 
 [607ead62-23d6-4c11-a396-ef821e2e5f75]
-description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
+description = "49 is XLIX"
 
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
-description = "50 is a single L"
+description = "59 is LIX"
 
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
-description = "90, being 100 - 10, is XC"
+description = "93 is XCIII"
 
 [30494be1-9afb-4f84-9d71-db9df18b55e3]
-description = "100 is a single C"
+description = "141 is CXLI"
 
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
-description = "60, being 50 + 10, is LX"
+description = "163 is CLXIII"
 
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
-description = "400, being 500 - 100, is CD"
+description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
-description = "500 is a single D"
+description = "575 is DLXXV"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
-description = "900, being 1000 - 100, is CM"
+description = "911 is CMXI"
 
 [e6de6d24-f668-41c0-88d7-889c0254d173]
-description = "1000 is a single M"
+description = "1024 is MXXIV"
 
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
-description = "3000 is three M's"
+description = "3000 is MMM"
+
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
+
+[efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
+description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/roman_numerals_test.rb
+++ b/exercises/practice/roman-numerals/roman_numerals_test.rb
@@ -2,98 +2,133 @@ require 'minitest/autorun'
 require_relative 'roman_numerals'
 
 class RomanNumeralsTest < Minitest::Test
-  def test_1_is_a_single_i
+  def test_1_is_i
     # skip
-    assert_equal 'I', 1.to_roman
+    assert_equal "I", 1.to_roman
   end
 
-  def test_2_is_two_i_s
+  def test_2_is_ii
     skip
-    assert_equal 'II', 2.to_roman
+    assert_equal "II", 2.to_roman
   end
 
-  def test_3_is_three_i_s
+  def test_3_is_iii
     skip
-    assert_equal 'III', 3.to_roman
+    assert_equal "III", 3.to_roman
   end
 
-  def test_4_being_5_1_is_iv
+  def test_4_is_iv
     skip
-    assert_equal 'IV', 4.to_roman
+    assert_equal "IV", 4.to_roman
   end
 
-  def test_5_is_a_single_v
+  def test_5_is_v
     skip
-    assert_equal 'V', 5.to_roman
+    assert_equal "V", 5.to_roman
   end
 
-  def test_6_being_5_1_is_vi
+  def test_6_is_vi
     skip
-    assert_equal 'VI', 6.to_roman
+    assert_equal "VI", 6.to_roman
   end
 
-  def test_9_being_10_1_is_ix
+  def test_9_is_ix
     skip
-    assert_equal 'IX', 9.to_roman
+    assert_equal "IX", 9.to_roman
   end
 
-  def test_20_is_two_x_s
+  def test_27_is_xxvii
     skip
-    assert_equal 'XXVII', 27.to_roman
+    assert_equal "XXVII", 27.to_roman
   end
 
-  def test_48_is_not_50_2_but_rather_40_8
+  def test_48_is_xlviii
     skip
-    assert_equal 'XLVIII', 48.to_roman
+    assert_equal "XLVIII", 48.to_roman
   end
 
-  def test_49_is_not_40_5_4_but_rather_50_10_10_1
+  def test_49_is_xlix
     skip
-    assert_equal 'XLIX', 49.to_roman
+    assert_equal "XLIX", 49.to_roman
   end
 
-  def test_50_is_a_single_l
+  def test_59_is_lix
     skip
-    assert_equal 'LIX', 59.to_roman
+    assert_equal "LIX", 59.to_roman
   end
 
-  def test_90_being_100_10_is_xc
+  def test_93_is_xciii
     skip
-    assert_equal 'XCIII', 93.to_roman
+    assert_equal "XCIII", 93.to_roman
   end
 
-  def test_100_is_a_single_c
+  def test_141_is_cxli
     skip
-    assert_equal 'CXLI', 141.to_roman
+    assert_equal "CXLI", 141.to_roman
   end
 
-  def test_60_being_50_10_is_lx
+  def test_163_is_clxiii
     skip
-    assert_equal 'CLXIII', 163.to_roman
+    assert_equal "CLXIII", 163.to_roman
   end
 
-  def test_400_being_500_100_is_cd
+  def test_402_is_cdii
     skip
-    assert_equal 'CDII', 402.to_roman
+    assert_equal "CDII", 402.to_roman
   end
 
-  def test_500_is_a_single_d
+  def test_575_is_dlxxv
     skip
-    assert_equal 'DLXXV', 575.to_roman
+    assert_equal "DLXXV", 575.to_roman
   end
 
-  def test_900_being_1000_100_is_cm
+  def test_911_is_cmxi
     skip
-    assert_equal 'CMXI', 911.to_roman
+    assert_equal "CMXI", 911.to_roman
   end
 
-  def test_1000_is_a_single_m
+  def test_1024_is_mxxiv
     skip
-    assert_equal 'MXXIV', 1024.to_roman
+    assert_equal "MXXIV", 1024.to_roman
   end
 
-  def test_3000_is_three_m_s
+  def test_3000_is_mmm
     skip
-    assert_equal 'MMM', 3000.to_roman
+    assert_equal "MMM", 3000.to_roman
+  end
+
+  def test_16_is_xvi
+    skip
+    assert_equal "XVI", 16.to_roman
+  end
+
+  def test_66_is_lxvi
+    skip
+    assert_equal "LXVI", 66.to_roman
+  end
+
+  def test_166_is_clxvi
+    skip
+    assert_equal "CLXVI", 166.to_roman
+  end
+
+  def test_666_is_dclxvi
+    skip
+    assert_equal "DCLXVI", 666.to_roman
+  end
+
+  def test_1666_is_mdclxvi
+    skip
+    assert_equal "MDCLXVI", 1666.to_roman
+  end
+
+  def test_3001_is_mmmi
+    skip
+    assert_equal "MMMI", 3001.to_roman
+  end
+
+  def test_3999_is_mmmcmxcix
+    skip
+    assert_equal "MMMCMXCIX", 3999.to_roman
   end
 end


### PR DESCRIPTION
This added a few new tests.

When I regenerated the single quotes were replaced with double-quotes, which seems fine.