### PR TITLE
Sync flatten-array with problem-specifications

### DIFF
--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -4,7 +4,7 @@ Take a nested list and return a single flattened list with all values except nil
 
 The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
 
-For Example
+For example:
 
 input: [1,[2,3,null,4],[null],5]
 

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Take a nested list and return a single list with all values except nil/null",
+  "blurb": "Take a nested list and return a single list with all values except nil/null.",
   "authors": [
     "dougtebay"
   ],

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -9,8 +9,14 @@
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
 
+[8c71dabd-da60-422d-a290-4a571471fb14]
+description = "empty"
+
 [d268b919-963c-442d-9f07-82b93f1b518c]
 description = "no nesting"
+
+[3f15bede-c856-479e-bb71-1684b20c6a30]
+description = "flattens a nested array"
 
 [c84440cc-bb3a-48a6-862c-94cf23f2815d]
 description = "flattens array with just integers present"
@@ -20,6 +26,18 @@ description = "5 level nesting"
 
 [d572bdba-c127-43ed-bdcd-6222ac83d9f7]
 description = "6 level nesting"
+
+[0705a8e5-dc86-4cec-8909-150c5e54fa9c]
+description = "null values are omitted from the final result"
+include = false
+
+[c6cf26de-8ccd-4410-84bd-b9efd88fd2bc]
+description = "consecutive null values at the front of the list are omitted from the final result"
+include = false
+
+[382c5242-587e-4577-b8ce-a5fb51e385a1]
+description = "consecutive null values in the middle of the list are omitted from the final result"
+include = false
 
 [ef1d4790-1b1e-4939-a179-51ace0829dbd]
 description = "6 level nest list with null values"

--- a/exercises/practice/flatten-array/flatten_array_test.rb
+++ b/exercises/practice/flatten-array/flatten_array_test.rb
@@ -2,10 +2,20 @@ require 'minitest/autorun'
 require_relative 'flatten_array'
 
 class FlattenArrayTest < Minitest::Test
-  def test_no_nesting
+  def test_empty
     # skip
+    assert_empty FlattenArray.flatten([])
+  end
+
+  def test_no_nesting
+    skip
     flat_array = FlattenArray.flatten([0, 1, 2])
     assert_equal [0, 1, 2], flat_array
+  end
+
+  def test_flattens_a_nested_array
+    skip
+    assert_empty FlattenArray.flatten([[[]]])
   end
 
   def test_flattens_array_with_just_integers_present
@@ -26,15 +36,14 @@ class FlattenArrayTest < Minitest::Test
     assert_equal [1, 2, 3, 4, 5, 6, 7, 8], flat_array
   end
 
-  def test_6_level_nest_list_with_nil_values
+  def test_6_level_nest_list_with_null_values
     skip
     flat_array = FlattenArray.flatten([0, 2, [[2, 3], 8, [[100]], nil, [[nil]]], -2])
     assert_equal [0, 2, 2, 3, 8, 100, -2], flat_array
   end
 
-  def test_all_values_in_nested_list_are_nil
+  def test_all_values_in_nested_list_are_null
     skip
-    flat_array = FlattenArray.flatten([nil, [[[nil]]], nil, nil, [[nil, nil], nil], nil])
-    assert_empty flat_array
+    assert_empty FlattenArray.flatten([nil, [[[nil]]], nil, nil, [[nil, nil], nil], nil])
   end
 end


### PR DESCRIPTION
Syncing brought in new docs, metadata, and tests to the tests.toml.

I chose to exclude tests for "null-like" values, as Ruby only has nil and these are already thoroughly tested.

When regenerating the tests I inlined the variable for tests where asserting that the result is an empty array.