### PR TITLE
Sync crypto-square with problem-specifications

### DIFF
--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -12,6 +12,9 @@
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
 
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
+
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
 

--- a/exercises/practice/crypto-square/crypto_square_test.rb
+++ b/exercises/practice/crypto-square/crypto_square_test.rb
@@ -4,43 +4,49 @@ require_relative 'crypto_square'
 class CryptoSquareTest < Minitest::Test
   def test_empty_plaintext_results_in_an_empty_ciphertext
     # skip
-    plaintext = ''
+    plaintext = ""
+    assert_equal "", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_normalization_results_in_empty_plaintext
+    skip
+    plaintext = "... --- ..."
     assert_equal "", Crypto.new(plaintext).ciphertext
   end
 
   def test_lowercase
     skip
-    plaintext = 'A'
+    plaintext = "A"
     assert_equal "a", Crypto.new(plaintext).ciphertext
   end
 
   def test_remove_spaces
     skip
-    plaintext = '  b '
+    plaintext = "  b "
     assert_equal "b", Crypto.new(plaintext).ciphertext
   end
 
   def test_remove_punctuation
     skip
-    plaintext = '@1,%!'
+    plaintext = "@1,%!"
     assert_equal "1", Crypto.new(plaintext).ciphertext
   end
 
   def test_9_character_plaintext_results_in_3_chunks_of_3_characters
     skip
-    plaintext = 'This is fun!'
+    plaintext = "This is fun!"
     assert_equal "tsf hiu isn", Crypto.new(plaintext).ciphertext
   end
 
   def test_8_character_plaintext_results_in_3_chunks_the_last_one_with_a_trailing_space
     skip
-    plaintext = 'Chill out.'
+    plaintext = "Chill out."
     assert_equal "clu hlt io ", Crypto.new(plaintext).ciphertext
   end
 
   def test_54_character_plaintext_results_in_7_chunks_the_last_two_with_trailing_spaces
     skip
-    plaintext = 'If man was meant to stay on the ground, god would have given us roots.'
+    plaintext = "If man was meant to stay on the ground, god would have given us roots."
     assert_equal "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ", Crypto.new(plaintext).ciphertext
   end
 end


### PR DESCRIPTION
Regenerating the test suite added a new test.

As before, it also replaced single quotes with double quotes.