### PR TITLE
Sync high-scores with problem-specifications

### DIFF
--- a/exercises/practice/high-scores/.docs/instructions.md
+++ b/exercises/practice/high-scores/.docs/instructions.md
@@ -2,4 +2,5 @@
 
 Manage a game player's High Score list.
 
-Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.
+Your task is to build a high-score component of the classic Frogger game, one of the highest selling and most addictive games of all time, and a classic of the arcade era.
+Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Manage a player's High Score list",
+  "blurb": "Manage a player's High Score list.",
   "authors": [
     "pgaspar"
   ],

--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -19,16 +19,32 @@ description = "Latest score"
 description = "Personal best"
 
 [3d996a97-c81c-4642-9afc-80b80dc14015]
-description = "Personal top three from a list of scores"
+description = "Top 3 scores -> Personal top three from a list of scores"
 
 [1084ecb5-3eb4-46fe-a816-e40331a4e83a]
-description = "Personal top highest to lowest"
+description = "Top 3 scores -> Personal top highest to lowest"
 
 [e6465b6b-5a11-4936-bfe3-35241c4f4f16]
-description = "Personal top when there is a tie"
+description = "Top 3 scores -> Personal top when there is a tie"
 
 [f73b02af-c8fd-41c9-91b9-c86eaa86bce2]
-description = "Personal top when there are less than 3"
+description = "Top 3 scores -> Personal top when there are less than 3"
 
 [16608eae-f60f-4a88-800e-aabce5df2865]
-description = "Personal top when there is only one"
+description = "Top 3 scores -> Personal top when there is only one"
+
+[2df075f9-fec9-4756-8f40-98c52a11504f]
+description = "Top 3 scores -> Latest score after personal top scores"
+include = false
+
+[809c4058-7eb1-4206-b01e-79238b9b71bc]
+description = "Top 3 scores -> Scores after personal top scores"
+include = false
+
+[ddb0efc0-9a86-4f82-bc30-21ae0bdc6418]
+description = "Top 3 scores -> Latest score after personal best"
+include = false
+
+[6a0fd2d1-4cc4-46b9-a5bb-2fb667ca2364]
+description = "Top 3 scores -> Scores after personal best"
+include = false

--- a/exercises/practice/high-scores/high_scores_test.rb
+++ b/exercises/practice/high-scores/high_scores_test.rb
@@ -5,57 +5,49 @@ class HighScoresTest < Minitest::Test
   def test_list_of_scores
     # skip
     scores = [30, 50, 20, 70]
-    expected = [30, 50, 20, 70]
-    assert_equal expected, HighScores.new(scores).scores
+    assert_equal [30, 50, 20, 70], HighScores.new(scores).scores
   end
 
   def test_latest_score
     skip
     scores = [100, 0, 90, 30]
-    expected = 30
-    assert_equal expected, HighScores.new(scores).latest
+    assert_equal 30, HighScores.new(scores).latest
   end
 
   def test_personal_best
     skip
     scores = [40, 100, 70]
-    expected = 100
-    assert_equal expected, HighScores.new(scores).personal_best
+    assert_equal 100, HighScores.new(scores).personal_best
   end
 
-  def test_personal_top_three_from_a_list_of_scores
+  def test_top_3_scores_personal_top_three_from_a_list_of_scores
     skip
     scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
-    expected = [100, 90, 70]
-    assert_equal expected, HighScores.new(scores).personal_top_three
+    assert_equal [100, 90, 70], HighScores.new(scores).personal_top_three
   end
 
-  def test_personal_top_highest_to_lowest
+  def test_top_3_scores_personal_top_highest_to_lowest
     skip
     scores = [20, 10, 30]
-    expected = [30, 20, 10]
-    assert_equal expected, HighScores.new(scores).personal_top_three
+    assert_equal [30, 20, 10], HighScores.new(scores).personal_top_three
   end
 
-  def test_personal_top_when_there_is_a_tie
+  def test_top_3_scores_personal_top_when_there_is_a_tie
     skip
     scores = [40, 20, 40, 30]
-    expected = [40, 40, 30]
-    assert_equal expected, HighScores.new(scores).personal_top_three
+    assert_equal [40, 40, 30], HighScores.new(scores).personal_top_three
   end
 
-  def test_personal_top_when_there_are_less_than_3
+  def test_top_3_scores_personal_top_when_there_are_less_than_3
     skip
     scores = [30, 70]
-    expected = [70, 30]
-    assert_equal expected, HighScores.new(scores).personal_top_three
+    assert_equal [70, 30], HighScores.new(scores).personal_top_three
   end
 
-  def test_personal_top_when_there_is_only_one
+  def test_top_3_scores_personal_top_when_there_is_only_one
     skip
     scores = [40]
-    expected = [40]
-    assert_equal expected, HighScores.new(scores).personal_top_three
+    assert_equal [40], HighScores.new(scores).personal_top_three
   end
 
   def test_latest_score_is_not_the_personal_best


### PR DESCRIPTION
There were a slew of new tests for methods that were not previously a part of the API of the class.

None of the methods are mentioned in the instructions for the exercise, and they also don't seem very interesting, so I didn't bring them in.

When regenerating the test suite the test for the #latest_is_personal_best? method got removed, so I removed the corresponding code from the reference solution as well.