### PR TITLE
Sync book-store with problem-specifications

### DIFF
--- a/exercises/practice/book-store/.docs/instructions.md
+++ b/exercises/practice/book-store/.docs/instructions.md
@@ -1,12 +1,10 @@
 # Instructions
 
-To try and encourage more sales of different books from a popular 5 book
-series, a bookshop has decided to offer discounts on multiple book purchases.
+To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts on multiple book purchases.
 
 One copy of any of the five books costs $8.
 
-If, however, you buy two different books, you get a 5%
-discount on those two books.
+If, however, you buy two different books, you get a 5% discount on those two books.
 
 If you buy 3 different books, you get a 10% discount.
 
@@ -14,14 +12,9 @@ If you buy 4 different books, you get a 20% discount.
 
 If you buy all 5, you get a 25% discount.
 
-Note: that if you buy four books, of which 3 are
-different titles, you get a 10% discount on the 3 that
-form part of a set, but the fourth book still costs $8.
+Note: that if you buy four books, of which 3 are different titles, you get a 10% discount on the 3 that form part of a set, but the fourth book still costs $8.
 
-Your mission is to write a piece of code to calculate the
-price of any conceivable shopping basket (containing only
-books of the same series), giving as big a discount as
-possible.
+Your mission is to write a piece of code to calculate the price of any conceivable shopping basket (containing only books of the same series), giving as big a discount as possible.
 
 For example, how much does this basket of books cost?
 
@@ -43,8 +36,8 @@ This would give a total of:
 
 Resulting in:
 
-- 5 x (8 - 2.00) == 5 x 6.00 == $30.00
-- +3 x (8 - 0.80) == 3 x 7.20 == $21.60
+- 5 × (8 - 2.00) = 5 × 6.00 = $30.00
+- +3 × (8 - 0.80) = 3 × 7.20 = $21.60
 
 For a total of $51.60
 
@@ -60,8 +53,8 @@ This would give a total of:
 
 Resulting in:
 
-- 4 x (8 - 1.60) == 4 x 6.40 == $25.60
-- +4 x (8 - 1.60) == 4 x 6.40 == $25.60
+- 4 × (8 - 1.60) = 4 × 6.40 = $25.60
+- +4 × (8 - 1.60) = 4 × 6.40 = $25.60
 
 For a total of $51.20
 

--- a/exercises/practice/book-store/.meta/tests.toml
+++ b/exercises/practice/book-store/.meta/tests.toml
@@ -40,16 +40,25 @@ description = "Two groups of four is cheaper than groups of five and three"
 description = "Group of four plus group of two is cheaper than two groups of three"
 
 [68ea9b78-10ad-420e-a766-836a501d3633]
-description = "Two each of first 4 books and 1 copy each of rest"
+description = "Two each of first four books and one copy each of rest"
 
 [c0a779d5-a40c-47ae-9828-a340e936b866]
 description = "Two copies of each book"
 
 [18fd86fe-08f1-4b68-969b-392b8af20513]
-description = "Three copies of first book and 2 each of remaining"
+description = "Three copies of first book and two each of remaining"
 
 [0b19a24d-e4cf-4ec8-9db2-8899a41af0da]
-description = "Three each of first 2 books and 2 each of remaining books"
+description = "Three each of first two books and two each of remaining books"
 
 [bb376344-4fb2-49ab-ab85-e38d8354a58d]
 description = "Four groups of four are cheaper than two groups each of five and three"
+
+[5260ddde-2703-4915-b45a-e54dbbac4303]
+description = "Check that groups of four are created properly even when there are more groups of three than groups of five"
+
+[b0478278-c551-4747-b0fc-7e0be3158b1f]
+description = "One group of one and four is cheaper than one group of two and three"
+
+[cf868453-6484-4ae1-9dfc-f8ee85bbde01]
+description = "One group of one and two plus three groups of four is cheaper than one group of each size"

--- a/exercises/practice/book-store/book_store_test.rb
+++ b/exercises/practice/book-store/book_store_test.rb
@@ -5,90 +5,108 @@ class BookStoreTest < Minitest::Test
   def test_only_a_single_book
     # skip
     basket = [1]
-    assert_equal 8.00, BookStore.calculate_price(basket)
+    assert_in_delta 8.00, BookStore.calculate_price(basket), 0.001
   end
 
   def test_two_of_the_same_book
     skip
     basket = [2, 2]
-    assert_equal 16.00, BookStore.calculate_price(basket)
+    assert_in_delta 16.00, BookStore.calculate_price(basket), 0.001
   end
 
   def test_empty_basket
     skip
     basket = []
-    assert_equal 0.00, BookStore.calculate_price(basket)
+    assert_in_delta 0.00, BookStore.calculate_price(basket), 0.001
   end
 
   def test_two_different_books
     skip
     basket = [1, 2]
-    assert_equal 15.20, BookStore.calculate_price(basket)
+    assert_in_delta 15.20, BookStore.calculate_price(basket), 0.001
   end
 
   def test_three_different_books
     skip
     basket = [1, 2, 3]
-    assert_equal 21.60, BookStore.calculate_price(basket)
+    assert_in_delta 21.60, BookStore.calculate_price(basket), 0.001
   end
 
   def test_four_different_books
     skip
     basket = [1, 2, 3, 4]
-    assert_equal 25.60, BookStore.calculate_price(basket)
+    assert_in_delta 25.60, BookStore.calculate_price(basket), 0.001
   end
 
   def test_five_different_books
     skip
     basket = [1, 2, 3, 4, 5]
-    assert_equal 30.00, BookStore.calculate_price(basket)
+    assert_in_delta 30.00, BookStore.calculate_price(basket), 0.001
   end
 
   def test_two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three
     skip
     basket = [1, 1, 2, 2, 3, 3, 4, 5]
-    assert_equal 51.20, BookStore.calculate_price(basket)
+    assert_in_delta 51.20, BookStore.calculate_price(basket), 0.001
   end
 
   def test_two_groups_of_four_is_cheaper_than_groups_of_five_and_three
     skip
     basket = [1, 1, 2, 3, 4, 4, 5, 5]
-    assert_equal 51.20, BookStore.calculate_price(basket)
+    assert_in_delta 51.20, BookStore.calculate_price(basket), 0.001
   end
 
   def test_group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three
     skip
     basket = [1, 1, 2, 2, 3, 4]
-    assert_equal 40.80, BookStore.calculate_price(basket)
+    assert_in_delta 40.80, BookStore.calculate_price(basket), 0.001
   end
 
-  def test_two_each_of_first_4_books_and_1_copy_each_of_rest
+  def test_two_each_of_first_four_books_and_one_copy_each_of_rest
     skip
     basket = [1, 1, 2, 2, 3, 3, 4, 4, 5]
-    assert_equal 55.60, BookStore.calculate_price(basket)
+    assert_in_delta 55.60, BookStore.calculate_price(basket), 0.001
   end
 
   def test_two_copies_of_each_book
     skip
     basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-    assert_equal 60.00, BookStore.calculate_price(basket)
+    assert_in_delta 60.00, BookStore.calculate_price(basket), 0.001
   end
 
-  def test_three_copies_of_first_book_and_2_each_of_remaining
+  def test_three_copies_of_first_book_and_two_each_of_remaining
     skip
     basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1]
-    assert_equal 68.00, BookStore.calculate_price(basket)
+    assert_in_delta 68.00, BookStore.calculate_price(basket), 0.001
   end
 
-  def test_three_each_of_first_2_books_and_2_each_of_remaining_books
+  def test_three_each_of_first_two_books_and_two_each_of_remaining_books
     skip
     basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2]
-    assert_equal 75.20, BookStore.calculate_price(basket)
+    assert_in_delta 75.20, BookStore.calculate_price(basket), 0.001
   end
 
   def test_four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three
     skip
     basket = [1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5]
-    assert_equal 102.40, BookStore.calculate_price(basket)
+    assert_in_delta 102.40, BookStore.calculate_price(basket), 0.001
+  end
+
+  def test_check_that_groups_of_four_are_created_properly_even_when_there_are_more_groups_of_three_than_groups_of_five
+    skip
+    basket = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 5, 5]
+    assert_in_delta 145.60, BookStore.calculate_price(basket), 0.001
+  end
+
+  def test_one_group_of_one_and_four_is_cheaper_than_one_group_of_two_and_three
+    skip
+    basket = [1, 1, 2, 3, 4]
+    assert_in_delta 33.60, BookStore.calculate_price(basket), 0.001
+  end
+
+  def test_one_group_of_one_and_two_plus_three_groups_of_four_is_cheaper_than_one_group_of_each_size
+    skip
+    basket = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5]
+    assert_in_delta 100.00, BookStore.calculate_price(basket), 0.001
   end
 end


### PR DESCRIPTION
The sync updated the docs and the tests.toml file.

Regenerating the test suite added several new tests. One of the tests had a failure due to a rounding difference:

    Expected: 145.6
      Actual: 145.60000000000002

I changed the test suite to use assert_in_delta instead.