### PR TITLE
Sync tournament with problem-specifications

### DIFF
--- a/exercises/practice/tournament/.docs/instructions.md
+++ b/exercises/practice/tournament/.docs/instructions.md
@@ -24,7 +24,7 @@ A win earns a team 3 points.
 A draw earns 1.
 A loss earns 0.
 
-The outcome should be ordered by points, descending.
+The outcome is ordered by points, descending.
 In case of a tie, teams are ordered alphabetically.
 
 ## Input

--- a/exercises/practice/tournament/.docs/instructions.md
+++ b/exercises/practice/tournament/.docs/instructions.md
@@ -2,8 +2,7 @@
 
 Tally the results of a small football competition.
 
-Based on an input file containing which team played against which and what the
-outcome was, create a file with a table like this:
+Based on an input file containing which team played against which and what the outcome was, create a file with a table like this:
 
 ```text
 Team                           | MP |  W |  D |  L |  P
@@ -21,9 +20,12 @@ What do those abbreviations mean?
 - L: Matches Lost
 - P: Points
 
-A win earns a team 3 points. A draw earns 1. A loss earns 0.
+A win earns a team 3 points.
+A draw earns 1.
+A loss earns 0.
 
-The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
+The outcome should be ordered by points, descending.
+In case of a tie, teams are ordered alphabetically.
 
 ## Input
 
@@ -38,7 +40,8 @@ Blithering Badgers;Devastating Donkeys;loss
 Allegoric Alaskans;Courageous Californians;win
 ```
 
-The result of the match refers to the first team listed. So this line:
+The result of the match refers to the first team listed.
+So this line:
 
 ```text
 Allegoric Alaskans;Blithering Badgers;win

--- a/exercises/practice/tournament/.meta/example.rb
+++ b/exercises/practice/tournament/.meta/example.rb
@@ -44,7 +44,7 @@ class Tournament
         stats[:draw],
         stats[:loss],
         stats[:points]
-      ].join(' |  ')
+      ].map {|row| "#{row} ".rjust(4)}.join('|').strip
     end
 
     result.join("\n") + "\n"

--- a/exercises/practice/tournament/.meta/tests.toml
+++ b/exercises/practice/tournament/.meta/tests.toml
@@ -41,3 +41,6 @@ description = "incomplete competition (not all pairs have played)"
 
 [3aa0386f-150b-4f99-90bb-5195e7b7d3b8]
 description = "ties broken alphabetically"
+
+[f9e20931-8a65-442a-81f6-503c0205b17a]
+description = "ensure points sorted numerically"

--- a/exercises/practice/tournament/tournament_test.rb
+++ b/exercises/practice/tournament/tournament_test.rb
@@ -188,4 +188,23 @@ class TournamentTest < Minitest::Test
 
     assert_equal expected, Tournament.tally(input)
   end
+
+  def test_ensure_points_sorted_numerically
+    skip
+    input = <<~INPUT
+      Devastating Donkeys;Blithering Badgers;win
+      Devastating Donkeys;Blithering Badgers;win
+      Devastating Donkeys;Blithering Badgers;win
+      Devastating Donkeys;Blithering Badgers;win
+      Blithering Badgers;Devastating Donkeys;win
+    INPUT
+
+    expected = <<~TALLY
+      Team                           | MP |  W |  D |  L |  P
+      Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
+      Blithering Badgers             |  5 |  1 |  0 |  4 |  3
+    TALLY
+
+    assert_equal expected, Tournament.tally(input)
+  end
 end


### PR DESCRIPTION
The sync brought in changes to the docs and tests.toml

The example solution failed the new test due to a small formatting difference in the spec. The new test is the first one that shows a score that has double-digits.

I updated the example solution to pass the new test, but did not spend any time thinking about how to make the code nice.