### PR TITLE
Sync scale-generator with problem-specifications

### DIFF
--- a/exercises/practice/scale-generator/.docs/instructions.md
+++ b/exercises/practice/scale-generator/.docs/instructions.md
@@ -1,49 +1,68 @@
 # Instructions
 
-Given a tonic, or starting note, and a set of intervals, generate
-the musical scale starting with the tonic and following the
-specified interval pattern.
+## Chromatic Scales
 
-Scales in Western music are based on the chromatic (12-note) scale. This
-scale can be expressed as the following group of pitches:
+Scales in Western music are based on the chromatic (12-note) scale.
+This scale can be expressed as the following group of pitches:
 
-A, A#, B, C, C#, D, D#, E, F, F#, G, G#
+> A, A♯, B, C, C♯, D, D♯, E, F, F♯, G, G♯
 
-A given sharp note (indicated by a #) can also be expressed as the flat
-of the note above it (indicated by a b) so the chromatic scale can also be
-written like this:
+A given sharp note (indicated by a ♯) can also be expressed as the flat of the note above it (indicated by a ♭) so the chromatic scale can also be written like this:
 
-A, Bb, B, C, Db, D, Eb, E, F, Gb, G, Ab
+> A, B♭, B, C, D♭, D, E♭, E, F, G♭, G, A♭
 
-The major and minor scale and modes are subsets of this twelve-pitch
-collection. They have seven pitches, and are called diatonic scales.
-The collection of notes in these scales is written with either sharps or
-flats, depending on the tonic. Here is a list of which are which:
+The major and minor scale and modes are subsets of this twelve-pitch collection.
+They have seven pitches, and are called diatonic scales.
+The collection of notes in these scales is written with either sharps or flats, depending on the tonic (starting note).
+Here is a table indicating whether the flat expression or sharp expression of the scale would be used for a given tonic:
 
-No Sharps or Flats:
-C major
-a minor
+| Key Signature | Major                 | Minor                |
+| ------------- | --------------------- | -------------------- |
+| Natural       | C                     | a                    |
+| Sharp         | G, D, A, E, B, F♯     | e, b, f♯, c♯, g♯, d♯ |
+| Flat          | F, B♭, E♭, A♭, D♭, G♭ | d, g, c, f, b♭, e♭   |
 
-Use Sharps:
-G, D, A, E, B, F# major
-e, b, f#, c#, g#, d# minor
+Note that by common music theory convention the natural notes "C" and "a" follow the sharps scale when ascending and the flats scale when descending.
+For the scope of this exercise the scale is only ascending.
 
-Use Flats:
-F, Bb, Eb, Ab, Db, Gb major
-d, g, c, f, bb, eb minor
+### Task
 
-The diatonic scales, and all other scales that derive from the
-chromatic scale, are built upon intervals. An interval is the space
-between two pitches.
+Given a tonic, generate the 12 note chromatic scale starting with the tonic.
 
-The simplest interval is between two adjacent notes, and is called a
-"half step", or "minor second" (sometimes written as a lower-case "m").
-The interval between two notes that have an interceding note is called
-a "whole step" or "major second" (written as an upper-case "M"). The
-diatonic scales are built using only these two intervals between
-adjacent notes.
+- Shift the base scale appropriately so that all 12 notes are returned starting with the given tonic.
+- For the given tonic, determine if the scale is to be returned with flats or sharps.
+- Return all notes in uppercase letters (except for the `b` for flats) irrespective of the casing of the given tonic.
 
-Non-diatonic scales can contain other intervals.  An "augmented second"
-interval, written "A", has two interceding notes (e.g., from A to C or Db to E)
-or a "whole step" plus a "half step". There are also smaller and larger
-intervals, but they will not figure into this exercise.
+## Diatonic Scales
+
+The diatonic scales, and all other scales that derive from the chromatic scale, are built upon intervals.
+An interval is the space between two pitches.
+
+The simplest interval is between two adjacent notes, and is called a "half step", or "minor second" (sometimes written as a lower-case "m").
+The interval between two notes that have an interceding note is called a "whole step" or "major second" (written as an upper-case "M").
+The diatonic scales are built using only these two intervals between adjacent notes.
+
+Non-diatonic scales can contain other intervals.
+An "augmented second" interval, written "A", has two interceding notes (e.g., from A to C or D♭ to E) or a "whole step" plus a "half step".
+There are also smaller and larger intervals, but they will not figure into this exercise.
+
+### Task
+
+Given a tonic and a set of intervals, generate the musical scale starting with the tonic and following the specified interval pattern.
+
+This is similar to generating chromatic scales except that instead of returning 12 notes, you will return N+1 notes for N intervals.
+The first note is always the given tonic.
+Then, for each interval in the pattern, the next note is determined by starting from the previous note and skipping the number of notes indicated by the interval.
+
+For example, starting with G and using the seven intervals MMmMMMm, there would be the following eight notes:
+
+Note | Reason
+--|--
+G | Tonic
+A | M indicates a whole step from G, skipping G♯
+B | M indicates a whole step from A, skipping A♯
+C | m indicates a half step from B, skipping nothing
+D | M indicates a whole step from C, skipping C♯
+E | M indicates a whole step from D, skipping D♯
+F♯ | M indicates a whole step from E, skipping F
+G | m indicates a half step from F♯, skipping nothing

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
+  "blurb": "Generate musical scales, given a starting note and a set of intervals.",
   "authors": [
     "fluxusfrequency"
   ],

--- a/exercises/practice/scale-generator/.meta/example.rb
+++ b/exercises/practice/scale-generator/.meta/example.rb
@@ -1,17 +1,19 @@
 class Scale
   ASCENDING_INTERVALS = %w(m M A)
-  CHROMATIC_SCALE = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+  CHROMATIC_SCALE = %w(C C# D D# E F F# G G# A A# B)
   FLAT_CHROMATIC_SCALE = %w(C Db D Eb E F Gb G Ab A Bb B)
   FLAT_KEYS = %w(F Bb Eb Ab Db Gb d g c f bb eb)
 
-  def initialize(tonic, pattern = nil)
+  def initialize(tonic)
     @tonic = tonic.capitalize
-    @pattern = pattern
     @chromatic_scale = FLAT_KEYS.include?(tonic) ? FLAT_CHROMATIC_SCALE : CHROMATIC_SCALE
   end
 
-  def pitches
-    return reorder_chromatic_scale unless pattern
+  def chromatic
+    reorder_chromatic_scale
+  end
+
+  def interval(pattern)
     last_index = 0
     scale = pattern.each_char.with_object([]) do |c, collector|
       collector << reorder_chromatic_scale[last_index]
@@ -21,10 +23,10 @@ class Scale
 
   private
 
-  attr_reader :tonic, :pattern, :chromatic_scale
+  attr_reader :tonic, :chromatic_scale
 
   def reorder_chromatic_scale
-    return chromatic_scale if tonic == 'C'
+    return chromatic_scale if tonic == "C"
     index = chromatic_scale.index(tonic)
     chromatic_scale[index..-1] + chromatic_scale[0..index - 1]
   end

--- a/exercises/practice/scale-generator/.meta/example.rb
+++ b/exercises/practice/scale-generator/.meta/example.rb
@@ -4,15 +4,10 @@ class Scale
   FLAT_CHROMATIC_SCALE = %w(C Db D Eb E F Gb G Ab A Bb B)
   FLAT_KEYS = %w(F Bb Eb Ab Db Gb d g c f bb eb)
 
-  def initialize(tonic, scale_name, pattern = nil)
+  def initialize(tonic, pattern = nil)
     @tonic = tonic.capitalize
-    @scale_name = scale_name
     @pattern = pattern
     @chromatic_scale = FLAT_KEYS.include?(tonic) ? FLAT_CHROMATIC_SCALE : CHROMATIC_SCALE
-  end
-
-  def name
-    "#{tonic} #{scale_name}"
   end
 
   def pitches
@@ -26,7 +21,7 @@ class Scale
 
   private
 
-  attr_reader :tonic, :scale_name, :pattern, :chromatic_scale
+  attr_reader :tonic, :pattern, :chromatic_scale
 
   def reorder_chromatic_scale
     return chromatic_scale if tonic == 'C'

--- a/exercises/practice/scale-generator/.meta/example.rb
+++ b/exercises/practice/scale-generator/.meta/example.rb
@@ -14,10 +14,10 @@ class Scale
   end
 
   def interval(pattern)
-    last_index = 0
-    scale = pattern.each_char.with_object([]) do |c, collector|
-      collector << reorder_chromatic_scale[last_index]
-      last_index += ASCENDING_INTERVALS.index(c) + 1
+    index = 0
+    pattern.each_char.with_object([reorder_chromatic_scale[index]]) do |char, scale|
+      index = (index + (ASCENDING_INTERVALS.index(char) + 1)) % 12
+      scale << reorder_chromatic_scale[index]
     end
   end
 

--- a/exercises/practice/scale-generator/.meta/tests.toml
+++ b/exercises/practice/scale-generator/.meta/tests.toml
@@ -10,52 +10,127 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [10ea7b14-8a49-40be-ac55-7c62b55f9b47]
-description = "Chromatic scale with sharps"
+description = "Chromatic scales -> Chromatic scale with sharps"
 
 [af8381de-9a72-4efd-823a-48374dbfe76f]
-description = "Chromatic scale with flats"
+description = "Chromatic scales -> Chromatic scale with flats"
+
+[7195998a-7be7-40c9-8877-a1d7949e061b]
+description = "Scales with specified intervals -> Simple major scale"
+reimplements = "6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e"
+
+[fe853b97-1878-4090-b218-4029246abb91]
+description = "Scales with specified intervals -> Major scale with sharps"
+reimplements = "13a92f89-a83e-40b5-b9d4-01136931ba02"
+
+[d60cb414-cc02-4fcb-ad7a-fc7ef0a9eead]
+description = "Scales with specified intervals -> Major scale with flats"
+reimplements = "aa3320f6-a761-49a1-bcf6-978e0c81080a"
+
+[77dab9b3-1bbc-4f9a-afd8-06da693bcc67]
+description = "Scales with specified intervals -> Minor scale with sharps"
+reimplements = "63daeb2f-c3f9-4c45-92be-5bf97f61ff94"
+
+[5fa1728f-5b66-4b43-9b7c-84359b7069d4]
+description = "Scales with specified intervals -> Minor scale with flats"
+reimplements = "616594d0-9c48-4301-949e-af1d4fad16fd"
+
+[f3f1c353-8f7b-4a85-a5b5-ae06c2645823]
+description = "Scales with specified intervals -> Dorian mode"
+reimplements = "390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a"
+
+[5fe14e5a-3ddc-4202-a158-2c1158beb5d0]
+description = "Scales with specified intervals -> Mixolydian mode"
+reimplements = "846d0862-0f3e-4f3b-8a2d-9cc74f017848"
+
+[e6307799-b7f6-43fc-a6d8-a4834d6e2bdb]
+description = "Scales with specified intervals -> Lydian mode"
+reimplements = "7d49a8bb-b5f7-46ad-a207-83bd5032291a"
+
+[7c4a95cd-ecf4-448d-99bc-dbbca51856e0]
+description = "Scales with specified intervals -> Phrygian mode"
+reimplements = "a4e4dac5-1891-4160-a19f-bb06d653d4d0"
+
+[f476f9c9-5a13-473d-bb6c-f884cf8fd9f2]
+description = "Scales with specified intervals -> Locrian mode"
+reimplements = "ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa"
+
+[87fdbcca-d3dd-46d5-9c56-ec79e25b19f4]
+description = "Scales with specified intervals -> Harmonic minor"
+reimplements = "70517400-12b7-4530-b861-fa940ae69ee8"
+
+[b28ecc18-88db-4fd5-a973-cfe6361e2b24]
+description = "Scales with specified intervals -> Octatonic"
+reimplements = "37114c0b-c54d-45da-9f4b-3848201470b0"
+
+[a1c7d333-6fb3-4f3b-9178-8a0cbe043134]
+description = "Scales with specified intervals -> Hexatonic"
+reimplements = "496466e7-aa45-4bbd-a64d-f41030feed9c"
+
+[9acfd139-0781-4926-8273-66a478c3b287]
+description = "Scales with specified intervals -> Pentatonic"
+reimplements = "bee5d9ec-e226-47b6-b62b-847a9241f3cc"
+
+[31c933ca-2251-4a5b-92dd-9d5831bc84ad]
+description = "Scales with specified intervals -> Enigmatic"
+reimplements = "dbee06a6-7535-4ab7-98e8-d8a36c8402d1"
 
 [6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e]
-description = "Simple major scale"
+description = "Scales with specified intervals -> Simple major scale"
+include = false
 
 [13a92f89-a83e-40b5-b9d4-01136931ba02]
-description = "Major scale with sharps"
+description = "Scales with specified intervals -> Major scale with sharps"
+include = false
 
 [aa3320f6-a761-49a1-bcf6-978e0c81080a]
-description = "Major scale with flats"
+description = "Scales with specified intervals -> Major scale with flats"
+include = false
 
 [63daeb2f-c3f9-4c45-92be-5bf97f61ff94]
-description = "Minor scale with sharps"
+description = "Scales with specified intervals -> Minor scale with sharps"
+include = false
 
 [616594d0-9c48-4301-949e-af1d4fad16fd]
-description = "Minor scale with flats"
+description = "Scales with specified intervals -> Minor scale with flats"
+include = false
 
 [390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a]
-description = "Dorian mode"
+description = "Scales with specified intervals -> Dorian mode"
+include = false
 
 [846d0862-0f3e-4f3b-8a2d-9cc74f017848]
-description = "Mixolydian mode"
+description = "Scales with specified intervals -> Mixolydian mode"
+include = false
 
 [7d49a8bb-b5f7-46ad-a207-83bd5032291a]
-description = "Lydian mode"
+description = "Scales with specified intervals -> Lydian mode"
+include = false
 
 [a4e4dac5-1891-4160-a19f-bb06d653d4d0]
-description = "Phrygian mode"
+description = "Scales with specified intervals -> Phrygian mode"
+include = false
 
 [ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa]
-description = "Locrian mode"
+description = "Scales with specified intervals -> Locrian mode"
+include = false
 
 [70517400-12b7-4530-b861-fa940ae69ee8]
-description = "Harmonic minor"
+description = "Scales with specified intervals -> Harmonic minor"
+include = false
 
 [37114c0b-c54d-45da-9f4b-3848201470b0]
-description = "Octatonic"
+description = "Scales with specified intervals -> Octatonic"
+include = false
 
 [496466e7-aa45-4bbd-a64d-f41030feed9c]
-description = "Hexatonic"
+description = "Scales with specified intervals -> Hexatonic"
+include = false
 
 [bee5d9ec-e226-47b6-b62b-847a9241f3cc]
-description = "Pentatonic"
+description = "Scales with specified intervals -> Pentatonic"
+include = false
 
 [dbee06a6-7535-4ab7-98e8-d8a36c8402d1]
-description = "Enigmatic"
+description = "Scales with specified intervals -> Enigmatic"
+include = false

--- a/exercises/practice/scale-generator/scale_generator_test.rb
+++ b/exercises/practice/scale-generator/scale_generator_test.rb
@@ -2,131 +2,105 @@ require 'minitest/autorun'
 require_relative 'scale_generator'
 
 class ScaleGeneratorTest < Minitest::Test
-  def test_chromatic_scale
-    skip
-    chromatic = Scale.new('C')
-    expected = %w[C C# D D# E F F# G G# A A# B]
-    actual = chromatic.pitches
-    assert_equal expected, actual
+  def test_chromatic_scales_chromatic_scale_with_sharps
+    # skip
+    scale = Scale.new("C")
+    assert_equal ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"], scale.chromatic
   end
 
-  def test_another_chromatic_scale
+  def test_chromatic_scales_chromatic_scale_with_flats
     skip
-    chromatic = Scale.new('F')
-    expected = %w[F Gb G Ab A Bb B C Db D Eb E]
-    actual = chromatic.pitches
-    assert_equal expected, actual
+    scale = Scale.new("F")
+    assert_equal %w[F Gb G Ab A Bb B C Db D Eb E], scale.chromatic
   end
 
-  def test_major_scale
+  def test_scales_with_specified_intervals_simple_major_scale
     skip
-    major = Scale.new('C', 'MMmMMMm')
-    expected = %w[C D E F G A B]
-    actual = major.pitches
-    assert_equal expected, actual
+    scale = Scale.new("C")
+    assert_equal %w[C D E F G A B], scale.interval("MMmMMMm")
   end
 
-  def test_another_major_scale
+  def test_scales_with_specified_intervals_major_scale_with_sharps
     skip
-    major = Scale.new('G', 'MMmMMMm')
-    expected = %w[G A B C D E F#]
-    actual = major.pitches
-    assert_equal expected, actual
+    scale = Scale.new("G")
+    assert_equal ["G", "A", "B", "C", "D", "E", "F#"], scale.interval("MMmMMMm")
   end
 
-  def test_minor_scale
+  def test_scales_with_specified_intervals_major_scale_with_flats
     skip
-    minor = Scale.new('f#', 'MmMMmMM')
-    expected = %w[F# G# A B C# D E]
-    actual = minor.pitches
-    assert_equal expected, actual
+    scale = Scale.new("F")
+    assert_equal %w[F G A Bb C D E], scale.interval("MMmMMMm")
   end
 
-  def test_another_minor_scale
+  def test_scales_with_specified_intervals_minor_scale_with_sharps
     skip
-    minor = Scale.new('bb', 'MmMMmMM')
-    expected = %w[Bb C Db Eb F Gb Ab]
-    actual = minor.pitches
-    assert_equal expected, actual
+    scale = Scale.new("f#")
+    assert_equal ["F#", "G#", "A", "B", "C#", "D", "E"], scale.interval("MmMMmMM")
   end
 
-  def test_dorian_mode
+  def test_scales_with_specified_intervals_minor_scale_with_flats
     skip
-    dorian = Scale.new('d', 'MmMMMmM')
-    expected = %w[D E F G A B C]
-    actual = dorian.pitches
-    assert_equal expected, actual
+    scale = Scale.new("bb")
+    assert_equal %w[Bb C Db Eb F Gb Ab], scale.interval("MmMMmMM")
   end
 
-  def test_mixolydian_mode
+  def test_scales_with_specified_intervals_dorian_mode
     skip
-    mixolydian = Scale.new('Eb', 'MMmMMmM')
-    expected = %w[Eb F G Ab Bb C Db]
-    actual = mixolydian.pitches
-    assert_equal expected, actual
+    scale = Scale.new("d")
+    assert_equal %w[D E F G A B C], scale.interval("MmMMMmM")
   end
 
-  def test_lydian_mode
+  def test_scales_with_specified_intervals_mixolydian_mode
     skip
-    lydian = Scale.new('a', 'MMMmMMm')
-    expected = %w[A B C# D# E F# G#]
-    actual = lydian.pitches
-    assert_equal expected, actual
+    scale = Scale.new("Eb")
+    assert_equal %w[Eb F G Ab Bb C Db], scale.interval("MMmMMmM")
   end
 
-  def test_phrygian_mode
+  def test_scales_with_specified_intervals_lydian_mode
     skip
-    phrygian = Scale.new('e', 'mMMMmMM')
-    expected = %w[E F G A B C D]
-    actual = phrygian.pitches
-    assert_equal expected, actual
+    scale = Scale.new("a")
+    assert_equal ["A", "B", "C#", "D#", "E", "F#", "G#"], scale.interval("MMMmMMm")
   end
 
-  def test_locrian_mode
+  def test_scales_with_specified_intervals_phrygian_mode
     skip
-    locrian = Scale.new('g', 'mMMmMMM')
-    expected = %w[G Ab Bb C Db Eb F]
-    actual = locrian.pitches
-    assert_equal expected, actual
+    scale = Scale.new("e")
+    assert_equal %w[E F G A B C D], scale.interval("mMMMmMM")
   end
 
-  def test_harmonic_minor
+  def test_scales_with_specified_intervals_locrian_mode
     skip
-    harmonic_minor = Scale.new('d', 'MmMMmAm')
-    expected = %w[D E F G A Bb Db]
-    actual = harmonic_minor.pitches
-    assert_equal expected, actual
+    scale = Scale.new("g")
+    assert_equal %w[G Ab Bb C Db Eb F], scale.interval("mMMmMMM")
   end
 
-  def test_octatonic
+  def test_scales_with_specified_intervals_harmonic_minor
     skip
-    octatonic = Scale.new('C', 'MmMmMmMm')
-    expected = %w[C D D# F F# G# A B]
-    actual = octatonic.pitches
-    assert_equal expected, actual
+    scale = Scale.new("d")
+    assert_equal %w[D E F G A Bb Db], scale.interval("MmMMmAm")
   end
 
-  def test_hexatonic
+  def test_scales_with_specified_intervals_octatonic
     skip
-    hexatonic = Scale.new('Db', 'MMMMMM')
-    expected = %w[Db Eb F G A B]
-    actual = hexatonic.pitches
-    assert_equal expected, actual
+    scale = Scale.new("C")
+    assert_equal ["C", "D", "D#", "F", "F#", "G#", "A", "B"], scale.interval("MmMmMmMm")
   end
 
-  def test_pentatonic
+  def test_scales_with_specified_intervals_hexatonic
     skip
-    pentatonic = Scale.new('A', 'MMAMA')
-    expected = %w[A B C# E F#]
-    actual = pentatonic.pitches
-    assert_equal expected, actual
+    scale = Scale.new("Db")
+    assert_equal %w[Db Eb F G A B], scale.interval("MMMMMM")
   end
 
-  def test_enigmatic
+  def test_scales_with_specified_intervals_pentatonic
     skip
-    enigmatic = Scale.new('G', 'mAMMMmM')
-    expected = %w[G G# B C# D# F F#]
-    actual = enigmatic.pitches
-    assert_equal expected, actual
+    scale = Scale.new("A")
+    assert_equal ["A", "B", "C#", "E", "F#"], scale.interval("MMAMA")
+  end
+
+  def test_scales_with_specified_intervals_enigmatic
+    skip
+    scale = Scale.new("G")
+    assert_equal ["G", "G#", "B", "C#", "D#", "F", "F#"], scale.interval("mAMMMmm")
   end
 end

--- a/exercises/practice/scale-generator/scale_generator_test.rb
+++ b/exercises/practice/scale-generator/scale_generator_test.rb
@@ -17,90 +17,90 @@ class ScaleGeneratorTest < Minitest::Test
   def test_scales_with_specified_intervals_simple_major_scale
     skip
     scale = Scale.new("C")
-    assert_equal %w[C D E F G A B], scale.interval("MMmMMMm")
+    assert_equal %w[C D E F G A B C], scale.interval("MMmMMMm")
   end
 
   def test_scales_with_specified_intervals_major_scale_with_sharps
     skip
     scale = Scale.new("G")
-    assert_equal ["G", "A", "B", "C", "D", "E", "F#"], scale.interval("MMmMMMm")
+    assert_equal ["G", "A", "B", "C", "D", "E", "F#", "G"], scale.interval("MMmMMMm")
   end
 
   def test_scales_with_specified_intervals_major_scale_with_flats
     skip
     scale = Scale.new("F")
-    assert_equal %w[F G A Bb C D E], scale.interval("MMmMMMm")
+    assert_equal %w[F G A Bb C D E F], scale.interval("MMmMMMm")
   end
 
   def test_scales_with_specified_intervals_minor_scale_with_sharps
     skip
     scale = Scale.new("f#")
-    assert_equal ["F#", "G#", "A", "B", "C#", "D", "E"], scale.interval("MmMMmMM")
+    assert_equal ["F#", "G#", "A", "B", "C#", "D", "E", "F#"], scale.interval("MmMMmMM")
   end
 
   def test_scales_with_specified_intervals_minor_scale_with_flats
     skip
     scale = Scale.new("bb")
-    assert_equal %w[Bb C Db Eb F Gb Ab], scale.interval("MmMMmMM")
+    assert_equal %w[Bb C Db Eb F Gb Ab Bb], scale.interval("MmMMmMM")
   end
 
   def test_scales_with_specified_intervals_dorian_mode
     skip
     scale = Scale.new("d")
-    assert_equal %w[D E F G A B C], scale.interval("MmMMMmM")
+    assert_equal %w[D E F G A B C D], scale.interval("MmMMMmM")
   end
 
   def test_scales_with_specified_intervals_mixolydian_mode
     skip
     scale = Scale.new("Eb")
-    assert_equal %w[Eb F G Ab Bb C Db], scale.interval("MMmMMmM")
+    assert_equal %w[Eb F G Ab Bb C Db Eb], scale.interval("MMmMMmM")
   end
 
   def test_scales_with_specified_intervals_lydian_mode
     skip
     scale = Scale.new("a")
-    assert_equal ["A", "B", "C#", "D#", "E", "F#", "G#"], scale.interval("MMMmMMm")
+    assert_equal ["A", "B", "C#", "D#", "E", "F#", "G#", "A"], scale.interval("MMMmMMm")
   end
 
   def test_scales_with_specified_intervals_phrygian_mode
     skip
     scale = Scale.new("e")
-    assert_equal %w[E F G A B C D], scale.interval("mMMMmMM")
+    assert_equal %w[E F G A B C D E], scale.interval("mMMMmMM")
   end
 
   def test_scales_with_specified_intervals_locrian_mode
     skip
     scale = Scale.new("g")
-    assert_equal %w[G Ab Bb C Db Eb F], scale.interval("mMMmMMM")
+    assert_equal %w[G Ab Bb C Db Eb F G], scale.interval("mMMmMMM")
   end
 
   def test_scales_with_specified_intervals_harmonic_minor
     skip
     scale = Scale.new("d")
-    assert_equal %w[D E F G A Bb Db], scale.interval("MmMMmAm")
+    assert_equal %w[D E F G A Bb Db D], scale.interval("MmMMmAm")
   end
 
   def test_scales_with_specified_intervals_octatonic
     skip
     scale = Scale.new("C")
-    assert_equal ["C", "D", "D#", "F", "F#", "G#", "A", "B"], scale.interval("MmMmMmMm")
+    assert_equal ["C", "D", "D#", "F", "F#", "G#", "A", "B", "C"], scale.interval("MmMmMmMm")
   end
 
   def test_scales_with_specified_intervals_hexatonic
     skip
     scale = Scale.new("Db")
-    assert_equal %w[Db Eb F G A B], scale.interval("MMMMMM")
+    assert_equal %w[Db Eb F G A B Db], scale.interval("MMMMMM")
   end
 
   def test_scales_with_specified_intervals_pentatonic
     skip
     scale = Scale.new("A")
-    assert_equal ["A", "B", "C#", "E", "F#"], scale.interval("MMAMA")
+    assert_equal ["A", "B", "C#", "E", "F#", "A"], scale.interval("MMAMA")
   end
 
   def test_scales_with_specified_intervals_enigmatic
     skip
     scale = Scale.new("G")
-    assert_equal ["G", "G#", "B", "C#", "D#", "F", "F#"], scale.interval("mAMMMmm")
+    assert_equal ["G", "G#", "B", "C#", "D#", "F", "F#", "G"], scale.interval("mAMMMmm")
   end
 end

--- a/exercises/practice/scale-generator/scale_generator_test.rb
+++ b/exercises/practice/scale-generator/scale_generator_test.rb
@@ -2,16 +2,9 @@ require 'minitest/autorun'
 require_relative 'scale_generator'
 
 class ScaleGeneratorTest < Minitest::Test
-  def test_naming_scale
-    chromatic = Scale.new('c', :chromatic)
-    expected = 'C chromatic'
-    actual = chromatic.name
-    assert_equal expected, actual
-  end
-
   def test_chromatic_scale
     skip
-    chromatic = Scale.new('C', :chromatic)
+    chromatic = Scale.new('C')
     expected = %w[C C# D D# E F F# G G# A A# B]
     actual = chromatic.pitches
     assert_equal expected, actual
@@ -19,23 +12,15 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_another_chromatic_scale
     skip
-    chromatic = Scale.new('F', :chromatic)
+    chromatic = Scale.new('F')
     expected = %w[F Gb G Ab A Bb B C Db D Eb E]
     actual = chromatic.pitches
     assert_equal expected, actual
   end
 
-  def test_naming_major_scale
-    skip
-    major = Scale.new('G', :major, 'MMmMMMm')
-    expected = 'G major'
-    actual = major.name
-    assert_equal expected, actual
-  end
-
   def test_major_scale
     skip
-    major = Scale.new('C', :major, 'MMmMMMm')
+    major = Scale.new('C', 'MMmMMMm')
     expected = %w[C D E F G A B]
     actual = major.pitches
     assert_equal expected, actual
@@ -43,7 +28,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_another_major_scale
     skip
-    major = Scale.new('G', :major, 'MMmMMMm')
+    major = Scale.new('G', 'MMmMMMm')
     expected = %w[G A B C D E F#]
     actual = major.pitches
     assert_equal expected, actual
@@ -51,7 +36,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_minor_scale
     skip
-    minor = Scale.new('f#', :minor, 'MmMMmMM')
+    minor = Scale.new('f#', 'MmMMmMM')
     expected = %w[F# G# A B C# D E]
     actual = minor.pitches
     assert_equal expected, actual
@@ -59,7 +44,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_another_minor_scale
     skip
-    minor = Scale.new('bb', :minor, 'MmMMmMM')
+    minor = Scale.new('bb', 'MmMMmMM')
     expected = %w[Bb C Db Eb F Gb Ab]
     actual = minor.pitches
     assert_equal expected, actual
@@ -67,7 +52,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_dorian_mode
     skip
-    dorian = Scale.new('d', :dorian, 'MmMMMmM')
+    dorian = Scale.new('d', 'MmMMMmM')
     expected = %w[D E F G A B C]
     actual = dorian.pitches
     assert_equal expected, actual
@@ -75,7 +60,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_mixolydian_mode
     skip
-    mixolydian = Scale.new('Eb', :mixolydian, 'MMmMMmM')
+    mixolydian = Scale.new('Eb', 'MMmMMmM')
     expected = %w[Eb F G Ab Bb C Db]
     actual = mixolydian.pitches
     assert_equal expected, actual
@@ -83,7 +68,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_lydian_mode
     skip
-    lydian = Scale.new('a', :lydian, 'MMMmMMm')
+    lydian = Scale.new('a', 'MMMmMMm')
     expected = %w[A B C# D# E F# G#]
     actual = lydian.pitches
     assert_equal expected, actual
@@ -91,7 +76,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_phrygian_mode
     skip
-    phrygian = Scale.new('e', :phrygian, 'mMMMmMM')
+    phrygian = Scale.new('e', 'mMMMmMM')
     expected = %w[E F G A B C D]
     actual = phrygian.pitches
     assert_equal expected, actual
@@ -99,7 +84,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_locrian_mode
     skip
-    locrian = Scale.new('g', :locrian, 'mMMmMMM')
+    locrian = Scale.new('g', 'mMMmMMM')
     expected = %w[G Ab Bb C Db Eb F]
     actual = locrian.pitches
     assert_equal expected, actual
@@ -107,7 +92,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_harmonic_minor
     skip
-    harmonic_minor = Scale.new('d', :harmonic_minor, 'MmMMmAm')
+    harmonic_minor = Scale.new('d', 'MmMMmAm')
     expected = %w[D E F G A Bb Db]
     actual = harmonic_minor.pitches
     assert_equal expected, actual
@@ -115,7 +100,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_octatonic
     skip
-    octatonic = Scale.new('C', :octatonic, 'MmMmMmMm')
+    octatonic = Scale.new('C', 'MmMmMmMm')
     expected = %w[C D D# F F# G# A B]
     actual = octatonic.pitches
     assert_equal expected, actual
@@ -123,7 +108,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_hexatonic
     skip
-    hexatonic = Scale.new('Db', :hexatonic, 'MMMMMM')
+    hexatonic = Scale.new('Db', 'MMMMMM')
     expected = %w[Db Eb F G A B]
     actual = hexatonic.pitches
     assert_equal expected, actual
@@ -131,7 +116,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_pentatonic
     skip
-    pentatonic = Scale.new('A', :pentatonic, 'MMAMA')
+    pentatonic = Scale.new('A', 'MMAMA')
     expected = %w[A B C# E F#]
     actual = pentatonic.pitches
     assert_equal expected, actual
@@ -139,7 +124,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_enigmatic
     skip
-    enigmatic = Scale.new('G', :enigma, 'mAMMMmM')
+    enigmatic = Scale.new('G', 'mAMMMmM')
     expected = %w[G G# B C# D# F F#]
     actual = enigmatic.pitches
     assert_equal expected, actual


### PR DESCRIPTION
This is a major overhaul of the exercise.

I did it in three steps, first removing a requirement that didn't add anything to the exercise, then changing the design of the expected solution to have a clearer separation between the base chromatic scale and the requested scale based on intervals.

Finally, syncing with the problem-specifications pulled down a major overhaul of the description and reimplemented most of the tests, due to the last character in the `pattern` having previously been ignored, which was very confusing for people.

