### PR TITLE
Add kytrinyx as contributor to updated exercises

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -5,7 +5,8 @@
   "contributors": [
     "guygastineau",
     "iHiD",
-    "kotp"
+    "kotp",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -9,7 +9,8 @@
     "jpotts244",
     "kotp",
     "PaulT89",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -10,7 +10,8 @@
     "kotp",
     "njbbaer",
     "pgaspar",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -9,7 +9,8 @@
     "jpotts244",
     "kotp",
     "mftaff",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -11,7 +11,8 @@
     "jpotts244",
     "kotp",
     "NeimadTL",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -6,7 +6,8 @@
     "emcoding",
     "iHiD",
     "Insti",
-    "kotp"
+    "kotp",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -9,7 +9,8 @@
     "jpotts244",
     "kotp",
     "pgaspar",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -14,7 +14,8 @@
     "PatrickMcSweeny",
     "pgaspar",
     "securitylater",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -10,7 +10,8 @@
     "Insti",
     "kotp",
     "moveson",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "iHiD",
-    "kotp"
+    "kotp",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -11,7 +11,8 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -14,7 +14,8 @@
     "jpotts244",
     "kotp",
     "pgaspar",
-    "tryantwit"
+    "tryantwit",
+    "kytrinyx"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
In the past three weeks I've gone through most of the practice exercises, updating them according to changes in the problem-specifications repository.

For some exercises there were only docs/metadata changes. I've not added myself as a contributor to these.

I've only added myself to exercises that required updating the test suite.