### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Configlet Status][configlet-workflow-badge]][configlet-workflow]
 [![Exercise Test Status][tests-workflow-badge]][tests-workflow]
-[![Join the chat at https://gitter.im/exercism/ruby][ruby-gitter-badge]][ruby-gitter-channel]
 
 Exercism Exercises in Ruby
 
@@ -361,8 +360,6 @@ Dress :)
 [#ruby-icon]: #ruby-icon
 [#running-the-tests]: #running-the-tests
 [rubocop]: http://batsov.com/rubocop/
-[ruby-gitter-badge]: https://badges.gitter.im/exercism/ruby.svg
-[ruby-gitter-channel]: https://gitter.im/exercism/ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [#setup]: #setup
 [#style-guide]: #style-guide
 [synchronize]: https://help.github.com/articles/syncing-a-fork/

--- a/config.json
+++ b/config.json
@@ -10,7 +10,6 @@
   },
   "blurb": "Ruby is a dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.",
   "version": 3,
-  "gitter": "ruby",
   "online_editor": {
     "indent_style": "space",
     "indent_size": 2,

--- a/docs/24pullrequests.md
+++ b/docs/24pullrequests.md
@@ -14,5 +14,3 @@ Something missing?  Submitting and reviewing exercises on Exercism and
 notice something you don't like?  Create a pull request!
 
 Check out the [Getting Involved in a Track](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md#getting-involved-in-an-exercism-language-track) documentation, and some [ideas for things we are looking for](http://exercism.io/languages/ruby/todo) for exercises that are needed to be implemented.
-
-We are available to answer questions in the [![Join the chat at https://gitter.im/exercism/ruby](https://badges.gitter.im/exercism/ruby.svg)](https://gitter.im/exercism/ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge).


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
