### PR TITLE
Remove erroneous instructions

### DIFF
--- a/exercises/practice/two-fer/two_fer.rb
+++ b/exercises/practice/two-fer/two_fer.rb
@@ -1,7 +1,4 @@
 =begin
 Write your code for the 'Two Fer' exercise in this file. Make the tests in
 `two_fer_test.rb` pass.
-
-To get started with TDD, see the `README.md` file in your
-`ruby/two-fer` directory.
 =end


### PR DESCRIPTION
The `ruby/two-fer/README.md` file says nothing about TDD. I recommend we either remove this (as I've done in this PR) or provide updated instructions if there are docs on TDD elsewhere. Thanks!