### PR TITLE
Add immutibility test cases for high-scores

### DIFF
--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -35,16 +35,12 @@ description = "Top 3 scores -> Personal top when there is only one"
 
 [2df075f9-fec9-4756-8f40-98c52a11504f]
 description = "Top 3 scores -> Latest score after personal top scores"
-include = false
 
 [809c4058-7eb1-4206-b01e-79238b9b71bc]
 description = "Top 3 scores -> Scores after personal top scores"
-include = false
 
 [ddb0efc0-9a86-4f82-bc30-21ae0bdc6418]
 description = "Top 3 scores -> Latest score after personal best"
-include = false
 
 [6a0fd2d1-4cc4-46b9-a5bb-2fb667ca2364]
 description = "Top 3 scores -> Scores after personal best"
-include = false

--- a/exercises/practice/high-scores/high_scores_test.rb
+++ b/exercises/practice/high-scores/high_scores_test.rb
@@ -50,6 +50,34 @@ class HighScoresTest < Minitest::Test
     assert_equal [40], HighScores.new(scores).personal_top_three
   end
 
+  def test_top_3_scores_latest_score_after_personal_top_scores
+    skip
+    high_scores = HighScores.new([70, 50, 20, 30])
+    high_scores.personal_top_three
+    assert_equal 30, high_scores.latest
+  end
+
+  def test_top_3_scores_scores_after_personal_top_scores
+    skip
+    high_scores = HighScores.new([30, 50, 20, 70])
+    high_scores.personal_top_three
+    assert_equal [30, 50, 20, 70], high_scores.scores
+  end
+
+  def test_top_3_scores_latest_score_after_personal_best
+    skip
+    high_scores = HighScores.new([20, 70, 15, 25, 30])
+    high_scores.personal_best
+    assert_equal 30, high_scores.latest
+  end
+
+  def test_top_3_scores_scores_after_personal_best
+    skip
+    high_scores = HighScores.new([20, 70, 15, 25, 30])
+    high_scores.personal_best
+    assert_equal [20, 70, 15, 25, 30], high_scores.scores
+  end
+
   def test_latest_score_is_not_the_personal_best
     skip
     scores = [100, 40, 10, 70]


### PR DESCRIPTION
When I was originally updating this exercise from problem-specifications
I misunderstood the meaning of the test cases that have properties named
`*After*`. I completely missed that these were tagged with the
`immutable` scenario.

These are not actual properties, but named scenarios that
describe expectations around immutability.

I have now implemented these test cases, since the Ruby implementation
would allow students to create an implementation that mutates
internal state in a way that would break the expectations around
`.latest` and `personal_best`.
