### PR TITLE
[Boutique Inventory] Counts all stock that exists

### DIFF
--- a/exercises/concept/boutique-inventory/boutique_inventory_test.rb
+++ b/exercises/concept/boutique-inventory/boutique_inventory_test.rb
@@ -112,4 +112,12 @@ class BoutiqueInventoryTest < Minitest::Test
     items = [shoes, coat, handkerchief]
     assert_equal 5, BoutiqueInventory.new(items).total_stock
   end
+
+  def test_total_stock_for_all_items
+    shoes = { price: 30.00, name: "Shoes", quantity_by_size: { s: 1, xl: 4 } }
+    coat = { price: 65.00, name: "Coat", quantity_by_size: { s: 0, m: 3, l: 0 } }
+    handkerchief = { price: 19.99, name: "Handkerchief", quantity_by_size: { adult: 4, child: 3 } }
+    items = [shoes, coat, handkerchief]
+    assert_equal 15, BoutiqueInventory.new(items).total_stock
+  end
 end


### PR DESCRIPTION
This corrects a bug that would not account for all items in some
inventory that would otherwise pass the tests.
