### PR TITLE
Update documentation to fix numbering issue.

### DIFF
--- a/exercises/concept/amusement-park/.docs/instructions.md
+++ b/exercises/concept/amusement-park/.docs/instructions.md
@@ -40,7 +40,7 @@ attendee.pass_id
 # => 42
 ```
 
-## 4. Revoke the pass
+## 5. Revoke the pass
 
 Some guests break the rules with unsafe behavior, so the park wants to be able to revoke passes. Implement `Attendee#revoke_pass!` to mutate the state of the instance, and set the pass id to `nil`
 


### PR DESCRIPTION
The amusement-park exercise has incorrect numbering and repeats the 4th instruction as an instruction number when it should be 5 instead.