### PR TITLE
Ruby 2.6 is almost one year past EOL

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-        ruby-version: [2.6, 2.7, 3.0]
+        ruby-version: [2.7, 3.0]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
From the Official Ruby Learning website:
https://www.ruby-lang.org/en/downloads/branches/

Ruby 2.6
status: eol
release date: 2018-12-25
EOL date: 2022-04-12
