### PR TITLE
Update explanation of floating point numbers for Ruby Assembly Line exercise

### DIFF
--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -5,7 +5,7 @@
 The two most common types of numbers in Ruby are:
 
 - **Integers:** numbers with no digits behind the decimal separator (whole numbers). Examples are `-6`, `0`, `1`, `25`, `976` and `500000`.
-- **Floating-point numbers:** numbers with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
+- **Floating-point numbers:** numbers with one or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
 They are implemented through the `Integer` and `Float` classes.
 


### PR DESCRIPTION
A floating point number has at least one number after the decimal point, not zero or more.

This explanation conflicts with the integers explanation which states its "numbers with no digits behind the decimal separator".