### PR TITLE
Rewrite pythagorean-triplet

### DIFF
--- a/exercises/practice/pythagorean-triplet/.meta/example.rb
+++ b/exercises/practice/pythagorean-triplet/.meta/example.rb
@@ -1,13 +1,11 @@
 class PythagoreanTriplet
   def self.triplets_with_sum(sum)
     triplets = []
-    (2..(sum/2)).to_a.reverse.each do |c|
+    (2..(sum / 2)).to_a.reverse.each do |c|
       a = 1
-      b = sum-c-a
+      b = sum - c - a
       while a < b
-        if pythagorean?(a, b, c)
-          triplets << [a, b, c]
-        end
+        triplets << [a, b, c] if pythagorean?(a, b, c)
         a += 1
         b -= 1
       end
@@ -16,6 +14,6 @@ class PythagoreanTriplet
   end
 
   def self.pythagorean?(a, b, c)
-    (a*a + b*b == c*c)
+    (a * a + b * b == c * c)
   end
 end

--- a/exercises/practice/pythagorean-triplet/.meta/example.rb
+++ b/exercises/practice/pythagorean-triplet/.meta/example.rb
@@ -1,52 +1,21 @@
-class Triplets
-  attr_reader :factors, :sum
-  def initialize(conditions)
-    min = conditions.fetch(:min_factor) { 1 }
-    max = conditions.fetch(:max_factor)
-    @sum = conditions[:sum]
-    @factors = (min..max).to_a
-  end
-
-  def to_a
+class PythagoreanTriplet
+  def self.triplets_with_sum(sum)
     triplets = []
-    each_triplet do |triplet|
-      triplets << triplet if select?(triplet)
+    (2..(sum/2)).to_a.reverse.each do |c|
+      a = 1
+      b = sum-c-a
+      while a < b
+        if pythagorean?(a, b, c)
+          triplets << [a, b, c]
+        end
+        a += 1
+        b -= 1
+      end
     end
     triplets
   end
 
-  def each_triplet
-    factors.combination(3).each do |a, b, c|
-      yield Triplet.new(a, b, c)
-    end
-  end
-
-  def select?(triplet)
-    triplet.pythagorean? && (!sum || triplet.sum == sum)
-  end
-end
-
-class Triplet
-  def self.where(conditions)
-    Triplets.new(conditions).to_a
-  end
-
-  attr_reader :a, :b, :c
-  def initialize(a, b, c)
-    @a = a
-    @b = b
-    @c = c
-  end
-
-  def sum
-    a + b + c
-  end
-
-  def product
-    a * b * c
-  end
-
-  def pythagorean?
-    a**2 + b**2 == c**2
+  def self.pythagorean?(a, b, c)
+    (a*a + b*b == c*c)
   end
 end

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.rb
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.rb
@@ -1,51 +1,46 @@
 require 'minitest/autorun'
 require_relative 'pythagorean_triplet'
 
-class TripletTest < Minitest::Test
-  def test_sum
-    assert_equal 12, Triplet.new(3, 4, 5).sum
+class PythagoreanTripletTest < Minitest::Test
+  def test_triplets_whose_sum_is_12
+    # skip
+    expected = [[3, 4, 5]]
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(12)
   end
 
-  def test_product
+  def test_triplets_whose_sum_is_108
     skip
-    assert_equal 60, Triplet.new(3, 4, 5).product
+    expected = [[27, 36, 45]]
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(108)
   end
 
-  def test_pythagorean
+  def test_triplets_whose_sum_is_1000
     skip
-    assert Triplet.new(3, 4, 5).pythagorean?
+    expected = [[200, 375, 425]]
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(1000)
   end
 
-  def test_not_pythagorean
+  def test_no_matching_triplets_for_1001
     skip
-    refute Triplet.new(5, 6, 7).pythagorean?
+    expected = []
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(1001)
   end
 
-  def test_triplets_upto_10
+  def test_returns_all_matching_triplets
     skip
-    triplets = Triplet.where(max_factor: 10)
-    products = triplets.map(&:product).sort
-    assert_equal [60, 480], products
+    expected = [[9, 40, 41], [15, 36, 39]]
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(90)
   end
 
-  def test_triplets_from_11_upto_20
+  def test_several_matching_triplets
     skip
-    triplets = Triplet.where(min_factor: 11, max_factor: 20)
-    products = triplets.map(&:product).sort
-    assert_equal [3840], products
+    expected = [[40, 399, 401], [56, 390, 394], [105, 360, 375], [120, 350, 370], [140, 336, 364], [168, 315, 357], [210, 280, 350], [240, 252, 348]]
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(840)
   end
 
-  def test_triplets_where_sum_x
+  def test_triplets_for_large_number
     skip
-    triplets = Triplet.where(sum: 180, max_factor: 100)
-    products = triplets.map(&:product).sort
-    assert_equal [118_080, 168_480, 202_500], products
-  end
-
-  def test_where_sum_1000
-    skip
-    triplets = Triplet.where(sum: 1_000, min_factor: 200, max_factor: 425)
-    products = triplets.map(&:product)
-    assert_equal [31_875_000], products
+    expected = [[1200, 14_375, 14_425], [1875, 14_000, 14_125], [5000, 12_000, 13_000], [6000, 11_250, 12_750], [7500, 10_000, 12_500]]
+    assert_equal expected, PythagoreanTriplet.triplets_with_sum(30_000)
   end
 end


### PR DESCRIPTION
The pythagorean-triplet exercise wasn't following the spec
even a little bit.

This rewrites the test suite to follow the existing
canonical data, and rewrites the solution to make it
pass.

The last test takes a long time to run, which isn't ideal but I couldn't find a way around it without going all mathlete on it.

See discussion here: https://forum.exercism.org/t/the-ruby-pythagorean-triplet-exercise-has-something-wrong-with-it-1497/4259/6
