### PR TITLE
Update microwave_test.rb - Corrected initialised input for test cases

### DIFF
--- a/exercises/practice/microwave/microwave_test.rb
+++ b/exercises/practice/microwave/microwave_test.rb
@@ -15,7 +15,7 @@ class MicrowaveTest < Minitest::Test
   end
 
   def test_one_minute
-    assert_equal '01:00', Microwave.new(100).timer
+    assert_equal '01:00', Microwave.new(60).timer
   end
 
   def test_ninety_seconds
@@ -23,7 +23,7 @@ class MicrowaveTest < Minitest::Test
   end
 
   def test_one_minute_and_one_second
-    assert_equal '01:01', Microwave.new(101).timer
+    assert_equal '01:01', Microwave.new(61).timer
   end
 
   def test_sixty_one_seconds
@@ -31,18 +31,18 @@ class MicrowaveTest < Minitest::Test
   end
 
   def test_one_minute_and_fifty_nine_seconds
-    assert_equal '01:59', Microwave.new(159).timer
+    assert_equal '01:59', Microwave.new(119).timer
   end
 
   def test_two_minutes
-    assert_equal '02:00', Microwave.new(200).timer
+    assert_equal '02:00', Microwave.new(120).timer
   end
 
   def test_over_ten_minutes
-    assert_equal '10:01', Microwave.new(1001).timer
+    assert_equal '10:01', Microwave.new(601).timer
   end
 
   def test_minute_overflow_adds_to_input_minutes
-    assert_equal '03:12', Microwave.new(272).timer
+    assert_equal '03:12', Microwave.new(192).timer
   end
 end


### PR DESCRIPTION
Several lines in the test file treated 1 minute as 100 seconds.

This pull request corrects this and allows for the test cases to pass if supplied with valid input.