### PR TITLE
Don't catch load error in hello-world

### DIFF
--- a/exercises/practice/hello-world/hello_world_test.rb
+++ b/exercises/practice/hello-world/hello_world_test.rb
@@ -1,15 +1,5 @@
-begin
-  gem 'minitest', '>= 5.0.0'
-  require 'minitest/autorun'
-  require_relative 'hello_world'
-rescue Gem::LoadError => e
-  puts "\nMissing Dependency:\n#{e.backtrace.first} #{e.message}"
-  puts 'Minitest 5.0 gem must be installed for the Ruby track.'
-rescue LoadError => e
-  puts "\nError:\n#{e.backtrace.first} #{e.message}"
-  puts DATA.read
-  exit 1
-end
+require 'minitest/autorun'
+require_relative 'hello_world'
 
 class HelloWorldTest < Minitest::Test
   def test_say_hi


### PR DESCRIPTION
Minitest version 5.0.0 was released in May 2013.
That's 10 years ago. We don't need to worry about this anymore.