### PR TITLE
Reimplement minesweeper

### DIFF
--- a/exercises/practice/minesweeper/.meta/example.rb
+++ b/exercises/practice/minesweeper/.meta/example.rb
@@ -1,88 +1,73 @@
-class Board
-  VALID_BORDERS = ['+', '-', '|']
-  VALID_DATA = ['*', '|', '+', '-', ' ']
-
-  def self.transform(input)
-    new(input).transform
+class Minesweeper
+  def self.annotate(minefield)
+    new(minefield).annotate
   end
 
-  def initialize(raw_board)
-    @rows = raw_board
-    validate
+  attr_reader :minefield
+  def initialize(minefield)
+    @minefield = minefield
   end
 
-  def transform
-    rows.map.with_index do |row, i|
-      decorate_row(row, i)
+  def annotate
+    (0..rows).map do |row|
+      (0..columns).map do |column|
+        notation_at(row, column)
+      end.join("")
     end
-  end
-
-  def mine?(char)
-    char == '*'
   end
 
   private
 
-  attr_reader :rows
+  def notation_at(row, column)
+    if mine_coordinates.include?([row, column])
+      return "*"
+    end
+    mines = surrounding_coordinates(row, column).count {|x, y|
+      mine_coordinates.include?([x, y])
+    }
+    if mines.zero?
+      " "
+    else
+      mines.to_s
+    end
+  end
 
-  def decorate_row(row, i)
-    inner = []
-    row.each_char.with_index do |space, j|
-      if space != ' '
-        inner << space
-      else
-        surroundings = surroundings(row, i, j)
-        k = count_mines_nearby(surroundings)
-        if k > 0
-          inner << k.to_s
-        else
-          inner << space
+  def surrounding_coordinates(row, column)
+    [
+      [row-1, column-1],
+      [row-1, column],
+      [row-1, column+1],
+      [row, column-1],
+      [row, column+1],
+      [row+1, column-1],
+      [row+1, column],
+      [row+1, column+1]
+    ].reject {|x, y| invalid_coordinate(x, y)}
+  end
+
+  def invalid_coordinate(x, y)
+    x < 0 || y < 0 || x > rows || y > columns
+  end
+
+  def mine_coordinates
+    return @mine_coordinates if @mine_coordinates
+
+    @mine_coordinates = []
+    minefield.each.with_index do |row, x|
+      row.chars.each.with_index do |cell, y|
+        if cell == "*"
+          @mine_coordinates << [x, y]
         end
       end
     end
-    inner.join
+    @mine_coordinates
   end
 
-  def surroundings(row, i, j)
-    [
-      row[j - 1], row[j + 1], rows[i - 1][j - 1],
-      rows[i - 1][j], rows[i - 1][j + 1],
-      rows[i + 1][j - 1], rows[i + 1][j], rows[i + 1][j + 1]
-    ]
+  def rows
+    @rows ||= minefield.size-1
   end
 
-  def count_mines_nearby(surroundings)
-    surroundings.count { |datum| mine?(datum) }
-  end
-
-  def validate
-    validate_size
-    validate_borders
-    validate_data
-  end
-
-  def validate_size
-    len = rows.first.length
-    if rows.any? { |row| row.length != len }
-      fail ArgumentError, 'Invalid board'
-    end
-  end
-
-  def validate_borders
-    [rows[0], rows[-1]].each do |row|
-      invalid = row.chars.any? do |char|
-        !VALID_BORDERS.include?(char)
-      end
-      fail ArgumentError, 'Invalid board' if invalid
-    end
-  end
-
-  def validate_data
-    rows.each do |row|
-      invalid = row.chars.any? do |char|
-        !VALID_DATA.include?(char)
-      end
-      fail ArgumentError, 'Invalid board' if invalid
-    end
+  def columns
+    @columns ||= minefield.first.size-1
   end
 end

--- a/exercises/practice/minesweeper/minesweeper.rb
+++ b/exercises/practice/minesweeper/minesweeper.rb
@@ -1,7 +1,3 @@
-=begin
-Write your code for the 'Minesweeper' exercise in this file. Make the tests in
-`minesweeper_test.rb` pass.
-
-To get started with TDD, see the `README.md` file in your
-`ruby/minesweeper` directory.
-=end
+class Minesweeper
+  # Implement this class.
+end

--- a/exercises/practice/minesweeper/minesweeper_test.rb
+++ b/exercises/practice/minesweeper/minesweeper_test.rb
@@ -2,95 +2,75 @@ require 'minitest/autorun'
 require_relative 'minesweeper'
 
 class MinesweeperTest < Minitest::Test
-  def test_transform1
-    inp = ['+------+', '| *  * |', '|  *   |', '|    * |', '|   * *|',
-           '| *  * |', '|      |', '+------+']
-    out = ['+------+', '|1*22*1|', '|12*322|', '| 123*2|', '|112*4*|',
-           '|1*22*2|', '|111111|', '+------+']
-    assert_equal out, Board.transform(inp)
+  def test_no_rows
+    input = []
+    expected = []
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform2
-    skip
-    inp = ['+-----+', '| * * |', '|     |', '|   * |', '|  * *|',
-           '| * * |', '+-----+']
-    out = ['+-----+', '|1*2*1|', '|11322|', '| 12*2|', '|12*4*|',
-           '|1*3*2|', '+-----+']
-    assert_equal out, Board.transform(inp)
+  def test_no_columns
+    input = [""]
+    expected = [""]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform3
-    skip
-    inp = ['+-----+', '| * * |', '+-----+']
-    out = ['+-----+', '|1*2*1|', '+-----+']
-    assert_equal out, Board.transform(inp)
+  def test_no_mines
+    input = ["   ", "   ", "   "]
+    expected = ["   ", "   ", "   "]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform4
-    skip
-    inp = ['+-+', '|*|', '| |', '|*|', '| |', '| |', '+-+']
-    out = ['+-+', '|*|', '|2|', '|*|', '|1|', '| |', '+-+']
-    assert_equal out, Board.transform(inp)
+  def test_minefield_with_only_mines
+    input = ["***", "***", "***"]
+    expected = ["***", "***", "***"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform5
-    skip
-    inp = ['+-+', '|*|', '+-+']
-    out = ['+-+', '|*|', '+-+']
-    assert_equal out, Board.transform(inp)
+  def test_mine_surrounded_by_spaces
+    input = ["   ", " * ", "   "]
+    expected = ["111", "1*1", "111"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform6
-    skip
-    inp = ['+--+', '|**|', '|**|', '+--+']
-    out = ['+--+', '|**|', '|**|', '+--+']
-    assert_equal out, Board.transform(inp)
+  def test_space_surrounded_by_mines
+    input = ["***", "* *", "***"]
+    expected = ["***", "*8*", "***"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform7
-    skip
-    inp = ['+--+', '|**|', '|**|', '+--+']
-    out = ['+--+', '|**|', '|**|', '+--+']
-    assert_equal out, Board.transform(inp)
+  def test_horizontal_line
+    input = [" * * "]
+    expected = ["1*2*1"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform8
-    skip
-    inp = ['+---+', '|***|', '|* *|', '|***|', '+---+']
-    out = ['+---+', '|***|', '|*8*|', '|***|', '+---+']
-    assert_equal out, Board.transform(inp)
+  def test_horizontal_line_mines_at_edges
+    input = ["*   *"]
+    expected = ["*1 1*"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_transform9
-    skip
-    inp = ['+-----+', '|     |', '|   * |', '|     |', '|     |',
-           '| *   |', '+-----+']
-    out = ['+-----+', '|  111|', '|  1*1|', '|  111|', '|111  |',
-           '|1*1  |', '+-----+']
-    assert_equal out, Board.transform(inp)
+  def test_vertical_line
+    input = [" ", "*", " ", "*", " "]
+    expected = ["1", "*", "2", "*", "1"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_different_len
-    skip
-    inp = ['+-+', '| |', '|*  |', '|  |', '+-+']
-    assert_raises(ArgumentError) do
-      Board.transform(inp)
-    end
+  def test_vertical_line_mines_at_edges
+    input = ["*", " ", " ", " ", "*"]
+    expected = ["*", "1", " ", "1", "*"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_faulty_border
-    skip
-    inp = ['+-----+', '*   * |', '+-- --+']
-    assert_raises(ArgumentError) do
-      Board.transform(inp)
-    end
+  def test_cross
+    input = ["  *  ", "  *  ", "*****", "  *  ", "  *  "]
+    expected = [" 2*2 ", "25*52", "*****", "25*52", " 2*2 "]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 
-  def test_invalid_char
-    skip
-    inp = ['+-----+', '|X  * |', '+-----+']
-    assert_raises(ArgumentError) do
-      Board.transform(inp)
-    end
+  def test_large_minefield
+    input = [" *  * ", "  *   ", "    * ", "   * *", " *  * ", "      "]
+    expected = ["1*22*1", "12*322", " 123*2", "112*4*", "1*22*2", "111111"]
+    assert_equal expected, Minesweeper.annotate(input)
   end
 end


### PR DESCRIPTION
This exercise was originally implemented before the shared spec was created.

This reimplements the exercise per the spec.

Note that the `tests.toml` (incorrectly) had all of these tests marked as being included, so no changes to the test metadata were necessary.

The biggest changes are:
- The class name is now `Minesweeper` (instead of `Board`), and the property under test is `annotate` (instead of `transform`).
- There is no error handling
- The board no longer has edges, just the cells.

This will break all existing solutions, but I think that it's worth it, in order to bring this in line with the shared canonical data.