### PR TITLE
Normalize perfect-numbers tests.toml

### DIFF
--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -9,41 +9,14 @@
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
 
-[163e8e86-7bfd-4ee2-bd68-d083dc3381a3]
-description = "Smallest perfect number is classified correctly"
-
 [169a7854-0431-4ae0-9815-c3b6d967436d]
 description = "Medium perfect number is classified correctly"
-
-[ee3627c4-7b36-4245-ba7c-8727d585f402]
-description = "Large perfect number is classified correctly"
 
 [80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
 description = "Smallest abundant number is classified correctly"
 
-[3e300e0d-1a12-4f11-8c48-d1027165ab60]
-description = "Medium abundant number is classified correctly"
-
-[ec7792e6-8786-449c-b005-ce6dd89a772b]
-description = "Large abundant number is classified correctly"
-
-[e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
-description = "Smallest prime deficient number is classified correctly"
-
-[0beb7f66-753a-443f-8075-ad7fbd9018f3]
-description = "Smallest non-prime deficient number is classified correctly"
-
 [1c802e45-b4c6-4962-93d7-1cad245821ef]
 description = "Medium deficient number is classified correctly"
-
-[47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
-description = "Large deficient number is classified correctly"
-
-[a696dec8-6147-4d68-afad-d38de5476a56]
-description = "Edge case (no factors other than itself) is classified correctly"
-
-[72445cee-660c-4d75-8506-6c40089dc302]
-description = "Zero is rejected (not a natural number)"
 
 [2d72ce2c-6802-49ac-8ece-c790ba3dae13]
 description = "Negative integer is rejected (not a natural number)"


### PR DESCRIPTION
The tests.toml file was inconsistent with the
test suite for this exercise.

This removes entries for unimplemented tests.
