### PR TITLE
Reimplement saddle-points

### DIFF
--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -5,7 +5,7 @@ Your task is to find the potential trees where you could build your tree house.
 The data company provides the data as grids that show the heights of the trees.
 The rows of the grid represent the east-west direction, and the columns represent the north-south direction.
 
-An acceptable tree will be the the largest in its row, while being the smallest in its column.
+An acceptable tree will be the largest in its row, while being the smallest in its column.
 
 A grid might not have any good trees at all.
 Or it might have one, or even several.

--- a/exercises/practice/saddle-points/.docs/introduction.md
+++ b/exercises/practice/saddle-points/.docs/introduction.md
@@ -1,9 +1,11 @@
 # Introduction
 
-You are planning on building a tree house in the woods near your house so that you can watch the sun rise and set.
+You plan to build a tree house in the woods near your house so that you can watch the sun rise and set.
 
-You've obtained data from a local survey company that shows the heights of all the trees in each rectangular section of the map.
-You need to analyze each grid on the map to find the perfect tree for your tree house.
+You've obtained data from a local survey company that show the height of every tree in each rectangular section of the map.
+You need to analyze each grid on the map to find good trees for your tree house.
 
-The best tree will be the tallest tree compared to all the other trees to the east and west, so that you have the best possible view of the sunrises and sunsets.
-You don't like climbing too much, so the perfect tree will also be the shortest among all the trees to the north and to the south.
+A good tree is both:
+
+- taller than every tree to the east and west, so that you have the best possible view of the sunrises and sunsets.
+- shorter than every tree to the north and south, to minimize the amount of tree climbing.

--- a/exercises/practice/saddle-points/.meta/example.rb
+++ b/exercises/practice/saddle-points/.meta/example.rb
@@ -1,43 +1,13 @@
-class Matrix
-  attr_reader :rows, :columns
-  def initialize(input)
-    @rows = extract_rows(input)
-    @columns = extract_columns(rows)
-  end
-
-  def saddle_points
-    unless @saddle_points
-      coordinates = []
-      rows.each_with_index do |row, j|
-        max = row.max
-        row.each_with_index do |number, i|
-          min = columns[i].min
-          if number == max && number == min
-            coordinates << [j, i]
-          end
+class Grid
+  def self.saddle_points(grid)
+    coordinates = []
+    grid.each.with_index do |row, x|
+      row.each.with_index do |value, y|
+        if value == row.max && value == grid.map {|row| row[y]}.min
+          coordinates << {"row" => x+1, "column" => y+1}
         end
       end
-      @saddle_points = coordinates
     end
-    @saddle_points
-  end
-
-  private
-
-  def extract_rows(s)
-    s.split("\n").map do |row|
-      row.split(' ').map(&:to_i)
-    end
-  end
-
-  def extract_columns(rows)
-    columns = []
-    rows.each do |row|
-      row.each_with_index do |number, i|
-        columns[i] ||= []
-        columns[i] << number
-      end
-    end
-    columns
+    coordinates
   end
 end

--- a/exercises/practice/saddle-points/saddle_points_test.rb
+++ b/exercises/practice/saddle-points/saddle_points_test.rb
@@ -1,63 +1,112 @@
 require 'minitest/autorun'
 require_relative 'saddle_points'
 
-class MatrixTest < Minitest::Test
-  def test_extract_a_row
-    matrix = Matrix.new("1 2\n10 20")
-    assert_equal [1, 2], matrix.rows[0]
+class SaddlePointsTest < Minitest::Test
+  def test_can_identify_single_saddle_point
+    # skip
+    input = [[9, 8, 7], [5, 3, 2], [6, 6, 7]]
+    expected = [{ "row" => 2, "column" => 1 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_extract_same_row_again
+  def test_can_identify_that_empty_matrix_has_no_saddle_points
     skip
-    matrix = Matrix.new("9 7\n8 6")
-    assert_equal [9, 7], matrix.rows[0]
+    input = [[]]
+    expected = [].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_extract_other_row
+  def test_can_identify_lack_of_saddle_points_when_there_are_none
     skip
-    matrix = Matrix.new("9 8 7\n19 18 17")
-    assert_equal [19, 18, 17], matrix.rows[1]
+    input = [[1, 2, 3], [3, 1, 2], [2, 3, 1]]
+    expected = [].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_extract_other_row_again
+  def test_can_identify_multiple_saddle_points_in_a_column
     skip
-    matrix = Matrix.new("1 4 9\n16 25 36")
-    assert_equal [16, 25, 36], matrix.rows[1]
+    input = [[4, 5, 4], [3, 5, 5], [1, 5, 4]]
+    expected = [{ "row" => 1, "column" => 2 }, { "row" => 2, "column" => 2 }, { "row" => 3, "column" => 2 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_extract_a_column
+  def test_can_identify_multiple_saddle_points_in_a_row
     skip
-    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
-    assert_equal [1, 4, 7, 8], matrix.columns[0]
+    input = [[6, 7, 8], [5, 5, 5], [7, 5, 6]]
+    expected = [{ "row" => 2, "column" => 1 }, { "row" => 2, "column" => 2 }, { "row" => 2, "column" => 3 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_extract_another_column
+  def test_can_identify_saddle_point_in_bottom_right_corner
     skip
-    matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
-    assert_equal [1903, 3, 4], matrix.columns[1]
+    input = [[8, 7, 9], [6, 7, 6], [3, 2, 5]]
+    expected = [{ "row" => 3, "column" => 3 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_no_saddle_point
+  def test_can_identify_saddle_points_in_a_non_square_matrix
     skip
-    matrix = Matrix.new("2 1\n1 2")
-    assert_empty matrix.saddle_points
+    input = [[3, 1, 3], [3, 2, 4]]
+    expected = [{ "row" => 1, "column" => 3 }, { "row" => 1, "column" => 1 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_a_saddle_point
+  def test_can_identify_that_saddle_points_in_a_single_column_matrix_are_those_with_the_minimum_value
     skip
-    matrix = Matrix.new("1 2\n3 4")
-    assert_equal [[0, 1]], matrix.saddle_points
+    input = [[2], [1], [4], [1]]
+    expected = [{ "row" => 2, "column" => 1 }, { "row" => 4, "column" => 1 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 
-  def test_another_saddle_point
+  def test_can_identify_that_saddle_points_in_a_single_row_matrix_are_those_with_the_maximum_value
     skip
-    matrix = Matrix.new("18 3 39 19 91\n38 10 8 77 320\n3 4 8 6 7")
-    assert_equal [[2, 2]], matrix.saddle_points
-  end
-
-  def test_multiple_saddle_points
-    skip
-    matrix = Matrix.new("4 5 4\n3 5 5\n1 5 4")
-    assert_equal [[0, 1], [1, 1], [2, 1]], matrix.saddle_points
+    input = [[2, 5, 3, 5]]
+    expected = [{ "row" => 1, "column" => 2 }, { "row" => 1, "column" => 4 }].sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    actual = Grid.saddle_points(input).sort_by do |coordinates|
+      [coordinates["row"], coordinates["column"]]
+    end
+    assert_equal expected, actual
   end
 end


### PR DESCRIPTION
This changes the test suite to follow the canonical spec,
and updates the example implementation to match.

The original version of this exercise was implemented before
the shared specs were a thing, and it has therefore not
benefited from the improvements that have been made to the
inputs and outputs over the years.

This will break all existing solutions.

Note that this also brings in a tweak to the instructions.
