### PR TITLE
Remove redundant tests in gigasecond

### DIFF
--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -11,12 +11,15 @@
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
+include = false
 
 [6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
 description = "second test for date only specification of time"
+include = false
 
 [77eb8502-2bca-4d92-89d9-7b39ace28dd5]
 description = "third test for date only specification of time"
+include = false
 
 [c9d89a7d-06f8-4e28-a305-64f1b2abc693]
 description = "full time specified"

--- a/exercises/practice/gigasecond/gigasecond_test.rb
+++ b/exercises/practice/gigasecond/gigasecond_test.rb
@@ -2,21 +2,6 @@ require 'minitest/autorun'
 require_relative 'gigasecond'
 
 class GigasecondTest < Minitest::Test
-  def test_date_only_specification_of_time
-    # skip
-    assert_equal Time.utc(2043, 1, 1, 1, 46, 40), Gigasecond.from(Time.utc(2011, 4, 25, 0, 0, 0))
-  end
-
-  def test_second_test_for_date_only_specification_of_time
-    skip
-    assert_equal Time.utc(2009, 2, 19, 1, 46, 40), Gigasecond.from(Time.utc(1977, 6, 13, 0, 0, 0))
-  end
-
-  def test_third_test_for_date_only_specification_of_time
-    skip
-    assert_equal Time.utc(1991, 3, 27, 1, 46, 40), Gigasecond.from(Time.utc(1959, 7, 19, 0, 0, 0))
-  end
-
   def test_full_time_specified
     skip
     assert_equal Time.utc(2046, 10, 2, 23, 46, 40), Gigasecond.from(Time.utc(2015, 1, 24, 22, 0, 0))


### PR DESCRIPTION
The gigasecond second is fully specified with only the two test
cases that pass in a fully qualified time.

Let's get rid of the other test cases.
