### PR TITLE
Unskip first test in gigasecond

### DIFF
--- a/exercises/practice/gigasecond/gigasecond_test.rb
+++ b/exercises/practice/gigasecond/gigasecond_test.rb
@@ -3,7 +3,7 @@ require_relative 'gigasecond'
 
 class GigasecondTest < Minitest::Test
   def test_full_time_specified
-    skip
+    # skip
     assert_equal Time.utc(2046, 10, 2, 23, 46, 40), Gigasecond.from(Time.utc(2015, 1, 24, 22, 0, 0))
   end
 


### PR DESCRIPTION
I forgot to do this in the previous PR where I deleted
the unnecessary tests.
