### PR TITLE
Normalize resistor-color-trio exercise

### DIFF
--- a/exercises/practice/resistor-color-trio/.meta/example.rb
+++ b/exercises/practice/resistor-color-trio/.meta/example.rb
@@ -23,18 +23,10 @@ class ResistorColorTrio
   end
 
   def value
-    raise ArgumentError.new('Invalid color') unless valid_colors?
-
     significants * multiplier
   end
 
   def to_s
     value < 1000 ? "#{value} ohms" : "#{(value.to_f/1000).to_i} kiloohms"
-  end
-
-  def valid_colors?
-    COLOR_CODES.include?(tens) && \
-      COLOR_CODES.include?(ones) && \
-      COLOR_CODES.include?(zeros)
   end
 end

--- a/exercises/practice/resistor-color-trio/resistor_color_trio_test.rb
+++ b/exercises/practice/resistor-color-trio/resistor_color_trio_test.rb
@@ -26,11 +26,4 @@ class ResistorColorTrioTest < Minitest::Test
     skip
     assert_equal "Resistor value: 470 kiloohms", ResistorColorTrio.new(%w[yellow violet yellow]).label
   end
-
-  def test_invalid_color
-    skip
-    assert_raises(ArgumentError) do
-      ResistorColorTrio.new(%w[yellow purple black]).label
-    end
-  end
 end


### PR DESCRIPTION
I don't think error handling adds anything interesting
to the exercise, so I've deleted the test for it.

This brings the exercise in line with the data in the
problem-specifications.

Note that there are unimplemented tests upstream, which
this doesn't address.

This doesn't break existing solutions.
