### PR TITLE
Tweak matrix implementation

### DIFF
--- a/exercises/practice/matrix/.meta/example.rb
+++ b/exercises/practice/matrix/.meta/example.rb
@@ -5,6 +5,14 @@ class Matrix
     @columns = extract_columns(rows)
   end
 
+  def row(number)
+    rows[number-1]
+  end
+
+  def column(number)
+    columns[number-1]
+  end
+
   private
 
   def extract_rows(s)

--- a/exercises/practice/matrix/matrix_test.rb
+++ b/exercises/practice/matrix/matrix_test.rb
@@ -2,44 +2,51 @@ require 'minitest/autorun'
 require_relative 'matrix'
 
 class MatrixTest < Minitest::Test
-  def test_extract_a_row
+  def test_extract_row_from_one_number_matrix
+    # skip
+    matrix = Matrix.new("1")
+    assert_equal [1], matrix.row(1)
+  end
+
+  def test_can_extract_row
+    skip
+    matrix = Matrix.new("1 2\n3 4")
+    assert_equal [3, 4], matrix.row(2)
+  end
+
+  def test_extract_row_where_numbers_have_different_widths
+    skip
     matrix = Matrix.new("1 2\n10 20")
-    assert_equal [1, 2], matrix.rows[0]
+    assert_equal [10, 20], matrix.row(2)
   end
 
-  def test_extract_same_row_again
+  def test_can_extract_row_from_non_square_matrix_with_no_corresponding_column
     skip
-    matrix = Matrix.new("9 7\n8 6")
-    assert_equal [9, 7], matrix.rows[0]
+    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9\n8 7 6")
+    assert_equal [8, 7, 6], matrix.row(4)
   end
 
-  def test_extract_other_row
+  def test_extract_column_from_one_number_matrix
     skip
-    matrix = Matrix.new("9 8 7\n19 18 17")
-    assert_equal [19, 18, 17], matrix.rows[1]
+    matrix = Matrix.new("1")
+    assert_equal [1], matrix.column(1)
   end
 
-  def test_extract_other_row_again
+  def test_can_extract_column
     skip
-    matrix = Matrix.new("1 4 9\n16 25 36")
-    assert_equal [16, 25, 36], matrix.rows[1]
+    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9")
+    assert_equal [3, 6, 9], matrix.column(3)
   end
 
-  def test_extract_a_column
+  def test_can_extract_column_from_non_square_matrix_with_no_corresponding_row
     skip
-    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
-    assert_equal [1, 4, 7, 8], matrix.columns[0]
+    matrix = Matrix.new("1 2 3 4\n5 6 7 8\n9 8 7 6")
+    assert_equal [4, 8, 6], matrix.column(4)
   end
 
-  def test_extract_another_column
+  def test_extract_column_where_numbers_have_different_widths
     skip
     matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
-    assert_equal [1903, 3, 4], matrix.columns[1]
-  end
-
-  def test_extract_last_column
-    skip
-    matrix = Matrix.new("1 2 3\n10 20 30\n100 200 300")
-    assert_equal [3, 30, 300], matrix.columns.last
+    assert_equal [1903, 3, 4], matrix.column(2)
   end
 end


### PR DESCRIPTION
The tests.toml for matrix didn't correspond
to the implementation at all.

This implements all the tests per the spec
and the tests.toml.

This also changes the expected implementation
to match the expectations described in the
canonical data.

The Ruby implementation was accessing the underlying
rows/columns directly using the zero-based index, whereas
the spec works with the more human-readable 1-based
row number and column number.

Note that this breaks all existing solutions.
I think that it is worth it, in order to be able to use the canonical data.
