### PR TITLE
Fix rubocop error for the constant by converting to uppercase

### DIFF
--- a/exercises/concept/port-palermo/.docs/instructions.md
+++ b/exercises/concept/port-palermo/.docs/instructions.md
@@ -12,10 +12,10 @@ The system has to handle identifiers for ships, but also for destinations.
 The first thing you need to do is to create the identifier for the port of Palermo.
 The identifier are the first four letters of the name of the port, in uppercase.
 
-Define the `Port.Identifier` constant to be a symbol with the value `:PALE`.
+Define the `Port::IDENTIFIER` constant to be a symbol with the value `:PALE`.
     
 ```ruby
-Port::Identifier 
+Port::IDENTIFIER 
 # => :PALE
 ```
 

--- a/exercises/concept/port-palermo/.meta/config.json
+++ b/exercises/concept/port-palermo/.meta/config.json
@@ -1,6 +1,7 @@
 {
   "authors": [
-    "meatball133"
+    "meatball133",
+    "egemen-dev"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/port-palermo/.meta/exemplar.rb
+++ b/exercises/concept/port-palermo/.meta/exemplar.rb
@@ -1,5 +1,5 @@
 module Port
-  Identifier = :PALE
+  IDENTIFIER = :PALE
 
   def self.get_identifier(city)
     return city[0..3].upcase.to_sym

--- a/exercises/concept/port-palermo/port_palermo.rb
+++ b/exercises/concept/port-palermo/port_palermo.rb
@@ -1,6 +1,4 @@
 module Port
-  # TODO: define the 'Identifier' constant
-
   def self.get_identifier(city)
     raise 'Please implement the Port.get_identifier method'
   end

--- a/exercises/concept/port-palermo/port_palermo_test.rb
+++ b/exercises/concept/port-palermo/port_palermo_test.rb
@@ -3,7 +3,7 @@ require_relative 'port_palermo'
 
 class MoviegoerTest < Minitest::Test
   def test_identifier
-    assert_equal :PALE, Port::Identifier
+    assert_equal :PALE, Port::IDENTIFIER
   end
 
   def test_get_identifier_for_hamburg


### PR DESCRIPTION
This PR fixes the rubocop issue of the [Constant Name](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/ConstantName) for the exercise concept of port-palermo. Since usage of uppercase constants are recommended by the rubocop docs and it is a good practice.