### PR TITLE
Fix typo's in comments for skip tests Minitest Patch

### DIFF
--- a/lib/disable_skip.rb
+++ b/lib/disable_skip.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
-# You can use this to disabe all skips in the current exercise by issuing the
+# You can use this to disable all skips in the current exercise by issuing the
 # following command:
-#     ruby -I../lib -rdisable_skip <fiename_test.rb>
+#     ruby -I../lib -rdisable_skip <filename_test.rb>
 
 module Minitest
   class Test


### PR DESCRIPTION
Long lived and perhaps overdue not very irritating typos are fixed by
this patch.
