### PR TITLE
Fix duplicate hints number

### DIFF
--- a/exercises/concept/amusement-park/.docs/hints.md
+++ b/exercises/concept/amusement-park/.docs/hints.md
@@ -25,7 +25,7 @@
 
 - In the `Attendee#issue_pass!` method, set the instance's state to the argument.
 
-## 4. Revoke the pass
+## 5. Revoke the pass
 
 - In the `Attendee#revoke_pass!` setter method set the instance's state so that no pass exists.
 


### PR DESCRIPTION
Change duplicate hint number 4 to hint number 5.

Instead of duplicate hints number : 
4. Allow people to buy a pass
4. Revoke the pass
This should be hints number :
4. Allow people to buy a pass
5. Revoke the pass

Maybe it will show up the hint number '5. Revoke the pass' too, as it doesn't show up yet with the screenshot below !

![Screenshot_20230822161958](https://github.com/exercism/ruby/assets/85173375/5afc5219-7e37-47e9-bcfe-9499aca91198)
