### PR TITLE
Fix typo in method name

### DIFF
--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## More enumeration methods
 
-In Bird Count, you were introduced to the `count`, `any?`, `select`, `all` and `map` enumeration methods.
+In Bird Count, you were introduced to the `count`, `any?`, `select`, `all?` and `map` enumeration methods.
 Here's a recap of those, with a few extras added:
 
 ```ruby


### PR DESCRIPTION
Add the missing question mark (?) to method all. 

Instead of method `all`, it should be method `all?` (with the question mark)