### PR TITLE
Improve syntax error output

### DIFF
--- a/exercises/concept/locomotive-engineer/.docs/introduction.md
+++ b/exercises/concept/locomotive-engineer/.docs/introduction.md
@@ -115,10 +115,12 @@ If the decomposition has variables with incorrect placement and/or an incorrect 
 
 ```ruby
 fruits_vegetables = [["apple", "banana"], ["carrot", "potato"]]
-(a, b), (d) = fruits_vegetables
 
-syntax error, unexpected ')', expecting '.' or &. or :: or '['
+(a, b), (d) = fruits_vegetables
+syntax error, unexpected '=', expecting '.' or &. or :: or '['
+
 ((a, b), (d)) = fruits_vegetables
+syntax error, unexpected ')', expecting '.' or &. or :: or '['
 ```
 
 Experiment here, and you will notice that the first pattern dictates, not the available values on the right hand side.

--- a/exercises/concept/locomotive-engineer/.docs/introduction.md
+++ b/exercises/concept/locomotive-engineer/.docs/introduction.md
@@ -117,10 +117,10 @@ If the decomposition has variables with incorrect placement and/or an incorrect 
 fruits_vegetables = [["apple", "banana"], ["carrot", "potato"]]
 
 (a, b), (d) = fruits_vegetables
-syntax error, unexpected '=', expecting '.' or &. or :: or '['
+# syntax error, unexpected '=', expecting '.' or &. or :: or '['
 
 ((a, b), (d)) = fruits_vegetables
-syntax error, unexpected ')', expecting '.' or &. or :: or '['
+# syntax error, unexpected ')', expecting '.' or &. or :: or '['
 ```
 
 Experiment here, and you will notice that the first pattern dictates, not the available values on the right hand side.


### PR DESCRIPTION
Improve syntax error output on array decomposition :
- on `(a, b), (d) = fruits_vegetables` decomposition, add a new syntax error output
- on `((a, b), (d)) = fruits_vegetables` decomposition, move the syntax error output below

For two decomposition, having two distinct syntax errors outputs are more clear rather than having only one syntax error output.