### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -47,9 +47,9 @@ Finally, bear in mind that the `Integer` object holds values that may be defined
 
 [integers-docs]: https://ruby-doc.org/core-2.7.0/Integer.html
 
-```exercism/note
+~~~~exercism/note
 The communication in documentation often will reference instance methods using syntax like `Class#method_name` while class or module level methods are referenced as `Class::method_name`.
 The `::` is called the _Scope Resolution Operator_, the constant or method at the class or module level being referenced.
 You will encounter this in the Ruby documentation, and in mailing lists and other support areas.
 You will find that we reference class and module methods in our writing as `ClassName.method_name` or `ModuleName.method_name`, instead.
-```
+~~~~

--- a/concepts/multiple-assignment-and-decomposition/about.md
+++ b/concepts/multiple-assignment-and-decomposition/about.md
@@ -17,10 +17,10 @@ This is often used in multiple assignment to group all "remaining" elements that
 It is common in Ruby to use this decomposing/composing behavior when using or defining methods that take an arbitrary number of positional or keyword arguments.
 You will often see these arguments defined as `def some_method(*arguments, **keyword_arguments)` and the arguments used as `some_method(*some_array, **some_hash)`.
 
-```exercism/caution
+~~~~exercism/caution
 `*<variable_name>` and `**<variable_name>` should not be confused with `*` and `**`.
 While `*` and `**` are used for multiplication and exponentiation, respectively, `*<variable_name>` and `**<variable_name>` are used as composition and decomposition operators.
-```
+~~~~
 
 ## Multiple assignment
 
@@ -60,9 +60,9 @@ For example:
 => [2, 1]
 ```
 
-```exercism/note
+~~~~exercism/note
 This is also known as "Parallel Assignment", and can be used to avoid a temporary variable.
-```
+~~~~
 
 If there are more variables than values, the extra variables will be assigned `nil`:
 
@@ -335,13 +335,13 @@ my_method(1, 2, 3, a: 1, b: 2, c: 3)
 You can also write arguments before and after `*arguments` to allow for specific positional arguments.
 This works the same way as decomposing an array.
 
-```exercism/caution
+~~~~exercism/caution
 Arguments have to be structured in a specific order:
 
 `def my_method(<positional_arguments>, *arguments, <positional_arguments>, <key-word_arguments>, **keyword_arguments)`
 
 If you don't follow this order then you will get an error.
-```
+~~~~
 
 ```ruby
 def my_method(a, b, *arguments)

--- a/concepts/multiple-assignment-and-decomposition/introduction.md
+++ b/concepts/multiple-assignment-and-decomposition/introduction.md
@@ -17,9 +17,9 @@ This is often used in multiple assignment to group all "remaining" elements that
 It is common in Ruby to use this decomposing/composing behavior when using or defining methods that take an arbitrary number of positional or keyword arguments.
 You will often see these arguments defined as `def some_method(*args, **kwargs)` and the arguments used as `some_method(*some_array, **some_hash)`.
 
-```exercism/caution
+~~~~exercism/caution
 `*<variable_name>` and `**<variable_name>` should not be confused with `*` and `**`.
 While `*` and `**` are used for multiplication and exponentiation, respectively, `*<variable_name>` and `**<variable_name>` are used as composition and decomposition operators.
-```
+~~~~
 
 [multiple assignment]: https://docs.ruby-lang.org/en/3.1/syntax/assignment_rdoc.html#label-Multiple+Assignment

--- a/concepts/ranges/about.md
+++ b/concepts/ranges/about.md
@@ -21,7 +21,7 @@ Ranges can also be created using the `Range` initializer.
 Range.new(1, 5) # A range containing 1, 2, 3, 4, 5
 ```
 
-````exercism/note
+~~~~exercism/note
 When creating a range in Ruby using the range operators `..` or `...`, and wanting to call a method on the range, you need to wrap the range in parentheses.
 This is because the otherwise will the method be called on the 2nd argument of the range operator.
 
@@ -29,7 +29,7 @@ This is because the otherwise will the method be called on the 2nd argument of t
 (1..5).sum # => 15
 1..5.sum # => Error: undefined method `sum' for 5:Integer (NoMethodError)
 ```
-````
+~~~~
 
 ## Getting substrings
 
@@ -72,9 +72,9 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 "Hello World"[..5] # => "Hello"
 ```
 
-```exercism/caution
+~~~~exercism/caution
 If not used on a collection, the endless range can cause an endless sequence, if not used with caution.
-```
+~~~~
 
 ## String ranges
 
@@ -87,7 +87,7 @@ Its behavior can be a bit unexpected when using certain strings, so use it with 
 
 ## Custom objects in ranges
 
-````exercism/advanced
+~~~~exercism/advanced
 Ruby allows you to use custom objects in ranges. 
 The requirement for this is that the object implements the following:
 
@@ -119,7 +119,7 @@ end
 (Foo.new(1)..Foo.new(5))
 # => #<Foo:0x7f3552bebe70 @value=1>, #<Foo:0x7f3552bebe50 @value=2>, #<Foo:0x7f3552bebe40 @value=3>, #<Foo:0x7f3552bebe30 @value=4>, #<Foo:0x7f3552bebe20 @value=5>
 ```
-````
+~~~~
 
 [range]: https://rubyapi.org/o/range
 [sum]: https://rubyapi.org/o/enumerable#method-i-sum

--- a/concepts/ranges/introduction.md
+++ b/concepts/ranges/introduction.md
@@ -21,7 +21,7 @@ Ranges can also be created using the `Range` initializer.
 Range.new(1, 5) # A range containing 1, 2, 3, 4, 5
 ```
 
-````exercism/note
+~~~~exercism/note
 When creating a range in Ruby using the range operators `..` or `...`, and wanting to call a method on the range, you need to wrap the range in parentheses.
 This is because the otherwise will the method be called on the 2nd argument of the range operator.
 
@@ -29,7 +29,7 @@ This is because the otherwise will the method be called on the 2nd argument of t
 (1..5).sum # => 15
 1..5.sum # => Error: undefined method `sum' for 5:Integer (NoMethodError)
 ```
-````
+~~~~
 
 ## Getting substrings
 
@@ -72,9 +72,9 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 "Hello World"[..5] # => "Hello"
 ```
 
-```exercism/caution
+~~~~exercism/caution
 If not used on a collection, the endless range can cause an endless sequence, if not used with caution.
-```
+~~~~
 
 ## String ranges
 

--- a/exercises/concept/chess-game/.docs/introduction.md
+++ b/exercises/concept/chess-game/.docs/introduction.md
@@ -21,7 +21,7 @@ Ranges can also be created using the `Range` initializer.
 Range.new(1, 5) # A range containing 1, 2, 3, 4, 5
 ```
 
-````exercism/note
+~~~~exercism/note
 When creating a range in Ruby using the range operators `..` or `...`, and wanting to call a method on the range, you need to wrap the range in parentheses.
 This is because the otherwise will the method be called on the 2nd argument of the range operator.
 
@@ -29,7 +29,7 @@ This is because the otherwise will the method be called on the 2nd argument of t
 (1..5).sum # => 15
 1..5.sum # => Error: undefined method `sum' for 5:Integer (NoMethodError)
 ```
-````
+~~~~
 
 ## Getting substrings
 
@@ -72,9 +72,9 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 "Hello World"[..5] # => "Hello"
 ```
 
-```exercism/caution
+~~~~exercism/caution
 If not used on a collection, the endless range can cause an endless sequence, if not used with caution.
-```
+~~~~
 
 ## String ranges
 

--- a/exercises/concept/locomotive-engineer/.docs/instructions.md
+++ b/exercises/concept/locomotive-engineer/.docs/instructions.md
@@ -4,10 +4,10 @@ Your friend Linus is a Locomotive Engineer who drives cargo trains between citie
 Although they are amazing at handling trains, they are not amazing at handling logistics or computers.
 They would like to enlist your programming help organizing train details and correcting mistakes in route data.
 
-```exercism/note
+~~~~exercism/note
 This exercise could easily be solved using slicing, indexing, and various `hash` methods.
 However, we would like you to practice packing, unpacking, and multiple assignment in solving each of the tasks below.
-```
+~~~~
 
 ## 1. Create a list of all wagons
 
@@ -74,9 +74,9 @@ The first **hash** contains the origin and destination cities the train route ru
 The second **hash** contains other routing details such as train speed, length, or temperature.
 The method should return a consolidated **hash** with all routing information.
 
-```exercism/note
+~~~~exercism/note
 The second **hash** can contain different/more properties than the ones shown in the example.
-```
+~~~~
 
 ```ruby
 LocomotiveEngineer.extend_route_information({"from": "Berlin", "to": "Hamburg"}, {"length": "100", "speed": "50"})

--- a/exercises/concept/locomotive-engineer/.docs/introduction.md
+++ b/exercises/concept/locomotive-engineer/.docs/introduction.md
@@ -8,10 +8,10 @@ This allows for code to be more concise and readable, and is done by separating 
 
 The splat operator(`*`), and double splat operator, (`**`), are often used in decomposition contexts.
 
-```exercism/caution
+~~~~exercism/caution
 `*<variable_name>` and `**<variable_name>` should not be confused with `*` and `**`.
 While `*` and `**` are used for multiplication and exponentiation, respectively, `*<variable_name>` and `**<variable_name>` are used as composition and decomposition operators.
-```
+~~~~
 
 ## Multiple assignment
 
@@ -51,9 +51,9 @@ For example:
 => [2, 1]
 ```
 
-```exercism/note
+~~~~exercism/note
 This is also known as "Parallel Assignment", and can be used to avoid a temporary variable.
-```
+~~~~
 
 If there are more variables than values, the extra variables will be assigned `nil`:
 
@@ -317,13 +317,13 @@ my_method(1, 2, 3, a: 1, b: 2, c: 3)
 You can also write arguments before and after `*arguments` to allow for specific positional arguments.
 This works the same way as decomposing an array.
 
-```exercism/caution
+~~~~exercism/caution
 Arguments have to be structured in a specific order:
 
 `def my_method(<positional_arguments>, *arguments, <positional_arguments>, <keyword_arguments>, **keyword_arguments)`
 
 If you don't follow this order then you will get an error.
-```
+~~~~
 
 ```ruby
 def my_method(a, b, *arguments)


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705