### PR TITLE
Add test for element not found

### DIFF
--- a/exercises/concept/boutique-inventory/boutique_inventory_test.rb
+++ b/exercises/concept/boutique-inventory/boutique_inventory_test.rb
@@ -56,6 +56,12 @@ class BoutiqueInventoryTest < Minitest::Test
     assert_empty BoutiqueInventory.new([]).out_of_stock
   end
 
+  def test_stock_for_item_not_existing
+    shoes = { price: 30.00, name: "Shoes", quantity_by_size: {} }
+    items = [shoes]
+    refute(BoutiqueInventory.new(items).stock_for_item("Coat"))
+  end
+
   def test_out_of_stock_for_all_items
     shoes = { price: 30.00, name: "Shoes", quantity_by_size: {} }
     coat = { price: 65.00, name: "Coat", quantity_by_size: {} }


### PR DESCRIPTION
I think it could be good to add this test, specially because the method stock_for_item can be developed like this i = items.find { |item| item[:name] == name }[:quantity_by_size] without taking in consideration the possibility of a find nil.

The method should be something like this to pass this test, it think is more realistic:

def stock_for_item(name)
    i = items.find { |item| item[:name] == name }
    if i
      i[:quantity_by_size]
    end
  end