### PR TITLE
Add space in chess-game's README

### DIFF
--- a/exercises/concept/chess-game/.docs/introduction.md
+++ b/exercises/concept/chess-game/.docs/introduction.md
@@ -69,7 +69,7 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 ```ruby
 "Hello World"[0..] # => "Hello World"
 "Hello World"[4..] # => "o World"
-"Hello World"[..5] # => "Hello"
+"Hello World"[..5] # => "Hello "
 ```
 
 ~~~~exercism/caution


### PR DESCRIPTION
"Hello World"[..5] should evaluate to "Hello " to include the space at the end since the range is inclusive.