### PR TITLE
Fix typo in BlackJack problem for Ruby

### DIFF
--- a/exercises/concept/blackjack/blackjack_test.rb
+++ b/exercises/concept/blackjack/blackjack_test.rb
@@ -131,7 +131,7 @@ class BlackjackTest < Minitest::Test
   end
 
   def test_first_turn_blackjack_with_nine_for_dealer
-    assert_equal "W", Blackjack.first_turn("ace", "king", "none")
+    assert_equal "W", Blackjack.first_turn("ace", "king", "nine")
   end
 
   def test_first_turn_score_of_20


### PR DESCRIPTION
The function call `Blackjack.first_turn("ace", "king", "none")` in the test `test_first_turn_blackjack_with_nine_for_dealer` is supposed to take "nine" as the third argument instead of "none" as it is stated in the test name itself.