### PR TITLE
Fix wrong example path in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
       "%{snake_slug}_test.rb"
     ],
     "example": [
-      ".meta/solutions/%{snake_slug}.rb"
+      ".meta/example.rb"
     ],
     "exemplar": [
       ".meta/exemplar.rb"


### PR DESCRIPTION
Aligns this variable with the truth of this repo.

(see https://github.com/exercism/ruby/pull/1623#issuecomment-1910595560)