### PR TITLE
Update Bundler to version 2.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.2.22
+   2.5.6


### PR DESCRIPTION
This commit updates Bundler to version 2.5.6 which is now available.

Ref:
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.5.6