### PR TITLE
Update parallel_letter_frequency_test.rb

### DIFF
--- a/exercises/practice/parallel-letter-frequency/parallel_letter_frequency_test.rb
+++ b/exercises/practice/parallel-letter-frequency/parallel_letter_frequency_test.rb
@@ -61,7 +61,7 @@ class ParallelLetterFrequencyTest < Minitest::Test
 
   def test_ignore_punctuation
     skip
-    texts = ['!', '?', ';', ',', '.', '-', "'", '"', '/', ':', '{}', '[]', '()']
+    texts = ['!', '?', ';', ',', '.', '-', '—', '’', "'", '"', '/', ':', '{}', '[]', '()']
     expected = {}
     actual = ParallelLetterFrequency.count(texts)
     assert_equal expected, actual
@@ -86,7 +86,7 @@ class ParallelLetterFrequencyTest < Minitest::Test
   def test_combo_lower_upper_punctuation_whitespace
     skip
     ruby_wiki = File.read(File.expand_path('data/ruby_wiki.txt', __dir__))
-    texts = ruby_wiki
+    texts = [ruby_wiki]
     expected = {
       "r" => 34,
       "u" => 20,


### PR DESCRIPTION
Two changes:
1. I think the `texts` should always be an array. It's a string in one case.
2. There is punctuation used in the later tests that does not occur in the punctuation one.