### PR TITLE
Typo in Locomotive Engineer

### DIFF
--- a/concepts/multiple-assignment-and-decomposition/about.md
+++ b/concepts/multiple-assignment-and-decomposition/about.md
@@ -317,7 +317,7 @@ If the method defined does not have any defined parameters for keyword arguments
 `*arguments` and `**keyword_arguments` can also be used in combination with one another:
 
 ```ruby
-def my_method(*arguments, **keywword_arguments)
+def my_method(*arguments, **keyword_arguments)
   p arguments.sum
   for (key, value) in keyword_arguments.to_a
     p key.to_s + " = " + value.to_s

--- a/exercises/concept/locomotive-engineer/.docs/instructions.md
+++ b/exercises/concept/locomotive-engineer/.docs/instructions.md
@@ -37,7 +37,7 @@ Linus would be really grateful to you for fixing their mistakes and consolidatin
 
 Implement a method `fix_list_of_wagons()` that takes two **arrays** containing wagon IDs.
 It should reposition the first two items of the first **array** to the end, and insert the values from the second **array** behind (_on the right hand side of_) the locomotive ID (**1**).
-The method should then `return` a **array** with the modifications.
+The method should then `return` an **array** with the modifications.
 
 ```ruby
 LocomotiveEngineer.fix_list_of_wagons([2, 5, 1, 7, 4, 12, 6, 3, 13], [3, 17, 6, 15])

--- a/exercises/concept/locomotive-engineer/.docs/introduction.md
+++ b/exercises/concept/locomotive-engineer/.docs/introduction.md
@@ -299,7 +299,7 @@ If the method defined does not have any defined parameters for keyword arguments
 `*arguments` and `**keyword_arguments` can also be used in combination with one another:
 
 ```ruby
-def my_method(*arguments, **keywword_arguments)
+def my_method(*arguments, **keyword_arguments)
   p arguments.sum
   for (key, value) in keyword_arguments.to_a
     p key.to_s + " = " + value.to_s

--- a/exercises/concept/locomotive-engineer/locomotive_engineer_test.rb
+++ b/exercises/concept/locomotive-engineer/locomotive_engineer_test.rb
@@ -39,8 +39,8 @@ class LocomotiveEngineerTest < Minitest::Test
   end
 
   def test_add_missing_stops_a_few_stops
-    assert_equal({ from: 'Berlin', to: 'Hamburg', stops: %w[Lepzig Hannover Frankfurt] },
-      LocomotiveEngineer.add_missing_stops({ from: 'Berlin', to: 'Hamburg' }, stop_1: 'Lepzig', stop_2: 'Hannover', stop_3: 'Frankfurt'))
+    assert_equal({ from: 'Berlin', to: 'Hamburg', stops: %w[Leipzig Hannover Frankfurt] },
+      LocomotiveEngineer.add_missing_stops({ from: 'Berlin', to: 'Hamburg' }, stop_1: 'Leipzig', stop_2: 'Hannover', stop_3: 'Frankfurt'))
   end
 
   def test_add_missing_stops_with_one_stop


### PR DESCRIPTION
exercises/concept/locomotive-engineer/locomotive_engineer_test.rb
- Corrected typo in the name of "Leipzig" (×2)
- Add line-break for legibility in 1 test method
- [no important files changed]

exercises/concept/locomotive-engineer/.docs/introduction.md
- "keywword" → "keyword"

exercises/concept/locomotive-engineer/.docs/instructions.md
- "a array" → "an array"