### PR TITLE
Add easier hint and example solution for Knapsack exercise

### DIFF
--- a/exercises/practice/knapsack/.docs/hints.md
+++ b/exercises/practice/knapsack/.docs/hints.md
@@ -2,13 +2,14 @@
 
 ## General
 
-- A good starting point is a brute-force recursive solution.
-You can see it sketched out in the first half of the article ["Demystifying the 0-1 knapsack problem: top solutions explained"](demystifying-the-knapsack-problem).
-- For a more efficient solution, you can improve your recursive solution using _dynamic programming_, which is introduced in the second half of [the above-mentioned article](demystifying-the-knapsack-problem).
-For a more general explainer, see the video ["5 Simple Steps for Solving Dynamic Programming Problems"](solving-dynamic-programming-problems)
-- If you need a more visual walkthrough of how to apply dynamic programming to the knapsack problem, see the video ["0/1 Knapsack problem | Dynamic Programming"](0-1-knapsack-problem).
-Also worth mentioning is [this answer](intuition-of-dp-for-knapsack-problem) to a question on Reddit, _"What is the intuition behind Knapsack problem solution using dynamic programming?"_.
-Below is the answer in full.
+- If you're not sure where to start, try a brute-force solution:
+  - First, generate all possible combinations of items. [`Array#combination`](https://rubyapi.org/3.3/o/array#method-i-combination) might come in handy.
+  - Then, find the combination that has the highest value and is within the weight limit.
+- If you want to make your solution as efficient as possible, look into an algorithmic technique called _dynamic programming_. Here are some resources:
+  - ["Demystifying the 0-1 knapsack problem: top solutions explained"](demystifying-the-knapsack-problem).
+  - ["5 Simple Steps for Solving Dynamic Programming Problems"](solving-dynamic-programming-problems)
+  - ["0/1 Knapsack problem | Dynamic Programming"](0-1-knapsack-problem).
+  - [This answer](intuition-of-dp-for-knapsack-problem) to a question on Reddit, _"What is the intuition behind Knapsack problem solution using dynamic programming?"_. Below is the answer in full.
 
 > The intuition behind the solution is basically like any dynamic programming solution: split the task into many sub-tasks, and save solutions to these sub-tasks for later use.
 >

--- a/exercises/practice/knapsack/.meta/example.rb
+++ b/exercises/practice/knapsack/.meta/example.rb
@@ -1,25 +1,22 @@
-# This solution uses dynamic programming to memoize solutions to overlapping
-# subproblems, so that they don't need to be recomputed. It's essentially a
-# recursive solution that remembers best-so-far outputs of previous inputs. The
-# algorithm has a time complexity of O(n * W), where n is the number of items
-# and W is the knapsack's maximum weight.
+# This brute-force solution is not as efficient as an approach that uses dynamic
+# programming, such as the former example solution in Ruby:
+# https://github.com/exercism/ruby/blob/8925745e6301a56cadb49f18b91b19778e9e6642/exercises/practice/knapsack/.meta/example.rb
+#
+# But this solution is simpler, and the tests still run in <100 ms, so it would
+# only be unsuitable for huge input sets.
 class Knapsack
+  private attr_reader :max_weight
+
   def initialize(max_weight)
     @max_weight = max_weight
   end
 
   def max_value(items)
-    # e.g. max_values[3] is the maximum value so far for a maximum weight of 3.
-    max_values = Array.new(@max_weight + 1, 0)
+    item_combinations = (1..items.length).flat_map { |n| items.combination(n).to_a }
 
-    items.each do |item|
-      @max_weight.downto(item.weight) do |weight|
-        value_with_item = max_values[weight - item.weight] + item.value
-
-        max_values[weight] = [max_values[weight], value_with_item].max
-      end
-    end
-
-    max_values[@max_weight]
+    item_combinations
+      .reject { _1.sum(&:weight) > max_weight }
+      .map { _1.sum(&:value) }
+      .max || 0
   end
 end


### PR DESCRIPTION
After recently implementing Knapsack (#1644), I realized that there's a much simpler brute-force approach that is still performant with the small input sets that are in the tests.

This PR:

- Adds hints on this brute-force approach as a starting point.
- Replaces the example solution, just to add variety to the example solutions across different tracks. (The existing example solution is based directly on the C++ version.)