### PR TITLE
Changes for upcoming default frozen strings

### DIFF
--- a/exercises/concept/bird-count/bird_count_test.rb
+++ b/exercises/concept/bird-count/bird_count_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'minitest/autorun'
 require_relative 'bird_count'
 

--- a/exercises/concept/lasagna/lasagna_test.rb
+++ b/exercises/concept/lasagna/lasagna_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'minitest/autorun'
 require_relative 'lasagna'
 

--- a/exercises/concept/log-line-parser/log_line_parser_test.rb
+++ b/exercises/concept/log-line-parser/log_line_parser_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'minitest/autorun'
 require_relative 'log_line_parser'
 

--- a/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.rb
+++ b/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.rb
@@ -49,12 +49,12 @@ class RailFenceCipherTest < Minitest::Test
   def test_decode_with_two_rails
     skip
     assert_equal 'XOXOXOXOXOXOXOXOXO',
-      RailFenceCipher.decode('XXXXXXXXXOOOOOOOOO', 2)
+      RailFenceCipher.decode(+'XXXXXXXXXOOOOOOOOO', 2)
   end
 
   def test_decode_with_three_rails
     skip
     assert_equal 'THEDEVILISINTHEDETAILS',
-      RailFenceCipher.decode('TEITELHDVLSNHDTISEIIEA', 3)
+      RailFenceCipher.decode(+'TEITELHDVLSNHDTISEIIEA', 3)
   end
 end

--- a/exercises/practice/raindrops/.meta/example.rb
+++ b/exercises/practice/raindrops/.meta/example.rb
@@ -13,7 +13,7 @@ class Raindrops
       return number.to_s
     end
 
-    s = ''
+    s = String.new
     s << 'Pling' if pling?
     s << 'Plang' if plang?
     s << 'Plong' if plong?

--- a/exercises/practice/roman-numerals/.meta/example.rb
+++ b/exercises/practice/roman-numerals/.meta/example.rb
@@ -18,7 +18,7 @@ class Integer
 
   def to_roman
     i = self
-    s = ''
+    s = String.new
     ROMAN_MAPPINGS.each do |arabic, roman|
       while i >= arabic
         s << roman

--- a/exercises/practice/run-length-encoding/.meta/example.rb
+++ b/exercises/practice/run-length-encoding/.meta/example.rb
@@ -1,12 +1,12 @@
 class RunLengthEncoding
   def self.encode(str)
-    str.chars.chunk { |char| char }.each_with_object('') do |chunk, out|
+    str.chars.chunk { |char| char }.each_with_object(+'') do |chunk, out|
       out << encoded(chunk)
     end
   end
 
   def self.decode(str)
-    str.scan(/(\d+)?(\D)/).each_with_object('') do |captures, out|
+    str.scan(/(\d+)?(\D)/).each_with_object(+'') do |captures, out|
       out << decoded(captures)
     end
   end

--- a/exercises/practice/say/.meta/example.rb
+++ b/exercises/practice/say/.meta/example.rb
@@ -16,13 +16,13 @@ class Chunk
   private
 
   def say_hundreds
-    return '' unless hundreds?
+    return +'' unless hundreds?
     "#{small_numbers[hundreds]} hundred"
   end
 
   def say_double_digits
     return '' if double_digits.zero?
-    s = ' '
+    s = +' '
     if double_digits < 20
       s << small_numbers[double_digits]
     else


### PR DESCRIPTION
The changes remove the magic comment for frozen strings, but also makes
mutable strings were necessary to avoid unnecessary test failures for
students.
