### PR TITLE
Series: Test is not testing for zero length series

### DIFF
--- a/exercises/practice/series/.meta/example.rb
+++ b/exercises/practice/series/.meta/example.rb
@@ -1,5 +1,6 @@
 class Series
   def initialize(series)
+    raise ArgumentError if series.length.zero?
     @series = series
   end
   def slices(n)

--- a/exercises/practice/series/series_test.rb
+++ b/exercises/practice/series/series_test.rb
@@ -68,9 +68,8 @@ class SeriesTest < Minitest::Test
   def test_empty_series_is_invalid
     skip
     slice_string = ""
-    series = Series.new(slice_string)
     assert_raises ArgumentError do
-      series.slices(1)
+      Series.new(slice_string)
     end
   end
 end


### PR DESCRIPTION
This test now raises if the series is 0 instead of of the slice slice
size being larger than the series.

This allows one to raise on normalization of user input, the series
given, rather than incidentally having the slice size of 1 be larger
than the series size from a zero length string.

The example solution is updated to raise specifically for a zero length
series, rather than the incidental raising when slices are asked for.
