### PR TITLE
Address deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'base64'
 gem 'minitest'
 gem 'rake'
 gem 'mocha', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.2.0)
     docile (1.4.0)
     json (2.7.2)
     minitest (5.22.3)
@@ -47,6 +48,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
   minitest
   mocha
   racc

--- a/bin/rubocop-quick
+++ b/bin/rubocop-quick
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs bundle exec rubocop --except Metrics --auto-correct --format quiet --force-exclusion Gemfile.lock && \
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs bundle exec rubocop --except Metrics --autocorrect --format quiet --force-exclusion Gemfile.lock && \
 git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs git add


### PR DESCRIPTION
- Rubocop changed auto-correct to autocorrect
- base64 will be dropped from stdlib in Ruby 3.4
