### PR TITLE
[Fix] [parallel-letter-frequency] Inconsistent test

### DIFF
--- a/exercises/practice/parallel-letter-frequency/parallel_letter_frequency_test.rb
+++ b/exercises/practice/parallel-letter-frequency/parallel_letter_frequency_test.rb
@@ -183,8 +183,8 @@ class ParallelLetterFrequencyTest < Minitest::Test
   def sequential_letter_frequency(texts)
     tally = Hash.new(0)
     texts.each do |text|
-      text.each_grapheme_cluster do |cluster|
-        tally[cluster] += 1
+      text.each_char do |char|
+        tally[char.downcase] += 1 if char.match?(/\p{L}/)
       end
     end
 


### PR DESCRIPTION
Hello 👋 

exercise: parallel-letter-frequency

The sequential implementation used behind "test_faster_than_serialized_answer" test must also pass itself the entire test suite. This is not the case today.
This relates to the use of "each_grapheme_cluster".

This commit solution allows the tests to pass. However, it is maybe not optimal (matching every character).
Perhaps it would be better to keep "each_grapheme_cluster" and modify the test suite?

It's an open discussion to find the best suited approach.