### PR TITLE
Append leap instructions to instruct user not use Ruby Date class

### DIFF
--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,0 +1,3 @@
+# Restrictions
+
+Avoid using `Date#leap?` from the Standard Library.


### PR DESCRIPTION
The discussion in #1532 called for appending the instructions for leap to instruct the user not to use the Date class in Ruby.

Discussion on forums is:  [Append Ruby leap instructions to instruct user not use Date class](https://forum.exercism.org/t/append-ruby-leap-instructions-to-instruct-user-not-use-date-class/17515).