### PR TITLE
Bump GHA runner to 24.04

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         ruby-version: [3.2, 3.3]
 
     steps:


### PR DESCRIPTION
The GHA for testing exercises has been failing for a few weeks because GitHub has phased out Ubuntu 20.04 completely.