### PR TITLE
[Assembly Line] Fix incorrect `<` comparison

### DIFF
--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -35,7 +35,7 @@ Here is a list of the operators and an example of when they give a `true` value:
 
 | Method | Description           | Example |
 | ------ | --------------------- | ------- |
-| <      | less than             | 5 < 4   |
+| <      | less than             | 4 < 5   |
 | <=     | less than or equal    | 4 <= 4  |
 | >      | greater than          | 3 > 1   |
 | >=     | greater than or equal | 2 >= 2  |


### PR DESCRIPTION
The documentation specifies a list of comparisons that will return `true`, but has `5 < 4`, which is `false`. This swaps the values to provide the correct comparison.