### PR TITLE
Chess Game: Rename nick_name method to nickname for consistency

### DIFF
--- a/exercises/concept/chess-game/.docs/instructions.md
+++ b/exercises/concept/chess-game/.docs/instructions.md
@@ -45,11 +45,11 @@ The game will have to get the nickname of the player.
 The nickname is the first 2 characters of the player's first name and the last 2 characters of the player's last name.
 The nickname should be capitalized.
 
-Define the `Chess.nick_name` method that takes the arguments `first_name` that holds a string of the player's first name and `last_name` that holds a string of the player's last name.
+Define the `Chess.nickname` method that takes the arguments `first_name` that holds a string of the player's first name and `last_name` that holds a string of the player's last name.
 The method should return the nickname of the player as capitalized string.
 
 ```ruby
-Chess.nick_name("John", "Doe")
+Chess.nickname("John", "Doe")
 # => "JOOE"
 ```
 

--- a/exercises/concept/chess-game/.docs/instructions.md
+++ b/exercises/concept/chess-game/.docs/instructions.md
@@ -45,11 +45,11 @@ The game will have to get the nickname of the player.
 The nickname is the first 2 characters of the player's first name and the last 2 characters of the player's last name.
 The nickname should be capitalized.
 
-Define the `Chess.nickname` method that takes the arguments `first_name` that holds a string of the player's first name and `last_name` that holds a string of the player's last name.
+Define the `Chess.nick_name` method that takes the arguments `first_name` that holds a string of the player's first name and `last_name` that holds a string of the player's last name.
 The method should return the nickname of the player as capitalized string.
 
 ```ruby
-Chess.nickname("John", "Doe")
+Chess.nick_name("John", "Doe")
 # => "JOOE"
 ```
 

--- a/exercises/concept/chess-game/.meta/exemplar.rb
+++ b/exercises/concept/chess-game/.meta/exemplar.rb
@@ -6,14 +6,14 @@ module Chess
     RANKS.include?(rank) && FILES.include?(file)
   end
 
-  def self.nick_name(first_name, last_name)
+  def self.nickname(first_name, last_name)
     "#{first_name[...2]}#{last_name[-2..]}".upcase
   end
 
   def self.move_message(first_name, last_name, square)
     rank = square[1].to_i
     file = square[0]
-    name = nick_name(first_name, last_name)
+    name = nickname(first_name, last_name)
     if valid_square?(rank, file)
       "#{name} moved to #{square}"
     else

--- a/exercises/concept/chess-game/.meta/exemplar.rb
+++ b/exercises/concept/chess-game/.meta/exemplar.rb
@@ -6,14 +6,14 @@ module Chess
     RANKS.include?(rank) && FILES.include?(file)
   end
 
-  def self.nickname(first_name, last_name)
+  def self.nick_name(first_name, last_name)
     "#{first_name[...2]}#{last_name[-2..]}".upcase
   end
 
   def self.move_message(first_name, last_name, square)
     rank = square[1].to_i
     file = square[0]
-    name = nickname(first_name, last_name)
+    name = nick_name(first_name, last_name)
     if valid_square?(rank, file)
       "#{name} moved to #{square}"
     else

--- a/exercises/concept/chess-game/chess_game.rb
+++ b/exercises/concept/chess-game/chess_game.rb
@@ -6,8 +6,8 @@ module Chess
     raise "Please implement the Chess.valid_square? method"
   end
 
-  def self.nick_name(first_name, last_name)
-    raise "Please implement the Chess.nick_name method"
+  def self.nickname(first_name, last_name)
+    raise "Please implement the Chess.nickname method"
   end
 
   def self.move_message(first_name, last_name, square)

--- a/exercises/concept/chess-game/chess_game.rb
+++ b/exercises/concept/chess-game/chess_game.rb
@@ -6,8 +6,8 @@ module Chess
     raise "Please implement the Chess.valid_square? method"
   end
 
-  def self.nickname(first_name, last_name)
-    raise "Please implement the Chess.nickname method"
+  def self.nick_name(first_name, last_name)
+    raise "Please implement the Chess.nick_name method"
   end
 
   def self.move_message(first_name, last_name, square)

--- a/exercises/concept/chess-game/chess_game_test.rb
+++ b/exercises/concept/chess-game/chess_game_test.rb
@@ -34,11 +34,11 @@ class ChessTest < Minitest::Test
     assert_equal "JOOE", Chess.nick_name("John", "Doe")
   end
 
-  def test_correct_nickname_for_2_letter_last_name
+  def test_correct_nick_name_for_2_letter_last_name
     assert_equal "LILI", Chess.nick_name("Lisa", "Li")
   end
 
-  def test_correct_nickname_for_2_letter_first_name
+  def test_correct_nick_name_for_2_letter_first_name
     assert_equal "DJER", Chess.nick_name("Dj", "Walker")
   end
 

--- a/exercises/concept/chess-game/chess_game_test.rb
+++ b/exercises/concept/chess-game/chess_game_test.rb
@@ -34,11 +34,11 @@ class ChessTest < Minitest::Test
     assert_equal "JOOE", Chess.nick_name("John", "Doe")
   end
 
-  def test_correct_nick_name_for_2_letter_last_name
+  def test_correct_nickname_for_2_letter_last_name
     assert_equal "LILI", Chess.nick_name("Lisa", "Li")
   end
 
-  def test_correct_nick_name_for_2_letter_first_name
+  def test_correct_nickname_for_2_letter_first_name
     assert_equal "DJER", Chess.nick_name("Dj", "Walker")
   end
 

--- a/exercises/concept/chess-game/chess_game_test.rb
+++ b/exercises/concept/chess-game/chess_game_test.rb
@@ -30,16 +30,16 @@ class ChessTest < Minitest::Test
     refute Chess.valid_square?(0, 'A')
   end
 
-  def test_correct_player_nickname
-    assert_equal "JOOE", Chess.nickname("John", "Doe")
+  def test_correct_player_nick_name
+    assert_equal "JOOE", Chess.nick_name("John", "Doe")
   end
 
   def test_correct_nickname_for_2_letter_last_name
-    assert_equal "LILI", Chess.nickname("Lisa", "Li")
+    assert_equal "LILI", Chess.nick_name("Lisa", "Li")
   end
 
   def test_correct_nickname_for_2_letter_first_name
-    assert_equal "DJER", Chess.nickname("Dj", "Walker")
+    assert_equal "DJER", Chess.nick_name("Dj", "Walker")
   end
 
   def test_correct_message_for_a_move

--- a/exercises/concept/chess-game/chess_game_test.rb
+++ b/exercises/concept/chess-game/chess_game_test.rb
@@ -30,16 +30,16 @@ class ChessTest < Minitest::Test
     refute Chess.valid_square?(0, 'A')
   end
 
-  def test_correct_player_nick_name
-    assert_equal "JOOE", Chess.nick_name("John", "Doe")
+  def test_correct_player_nickname
+    assert_equal "JOOE", Chess.nickname("John", "Doe")
   end
 
   def test_correct_nickname_for_2_letter_last_name
-    assert_equal "LILI", Chess.nick_name("Lisa", "Li")
+    assert_equal "LILI", Chess.nickname("Lisa", "Li")
   end
 
   def test_correct_nickname_for_2_letter_first_name
-    assert_equal "DJER", Chess.nick_name("Dj", "Walker")
+    assert_equal "DJER", Chess.nickname("Dj", "Walker")
   end
 
   def test_correct_message_for_a_move


### PR DESCRIPTION
The [problem description](https://exercism.org/tracks/ruby/exercises/chess-game#:~:text=3.%20Get%20player%27s,as%20capitalized%20string) uses `nickname`, but the exercise code defined `nick_name`.
This update renames the method to `nickname` for consistency between the description and the code.
Please review. 

 [Exercism Community Topics（Rename nick_name method to nickname for consistency）](https://forum.exercism.org/t/rename-nick-name-method-to-nickname-for-consistency/19034)
