### PR TITLE
Fix exercise naming in generator (#1770)

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -9,6 +9,10 @@ def exercises
     .select { |file| File.directory? File.join('./exercises/practice', file) }
 end
 
+def underscore(str)
+  str.gsub(/[^\w\s-]/, '').gsub(/[-\s]/, '_').downcase
+end
+
 class VerificationError < StandardError
   MESSAGE = 'The result generated for %<exercise>s, does not match the current file'
 
@@ -39,7 +43,7 @@ end
 parser.on('--verify', 'Verify all exercises') do
   exercises.each do |exercise|
     if File.exist?("./exercises/practice/#{exercise}/.meta/test_template.erb")
-      current_code = File.read("./exercises/practice/#{exercise}/#{exercise}_test.rb")
+      current_code = File.read("./exercises/practice/#{exercise}/#{underscore(exercise)}_test.rb")
       f = File.new("./exercises/practice/#{exercise}/temp_test.rb", 'w+')
       Generator.new(exercise).generate(f.path)
       generated_code = f.read

--- a/generatorv2/lib/generator.rb
+++ b/generatorv2/lib/generator.rb
@@ -21,17 +21,17 @@ class Generator
     additional_json(json)
     json["cases"] = remove_tests(uuid, json)
     status = proc { status }
-    template = ERB.new File.read("./exercises/practice/#{@exercise}/.meta/test_template.erb")
+    template = ERB.new(File.read("./exercises/practice/#{@exercise}/.meta/test_template.erb"), trim_mode: '-')
 
     result = template.result(binding)
 
     File.write(result_path, result)
     RuboCop::CLI.new.
-      run(['-x', '-c', '.rubocop.yml', '-o', NullDevice.path, result_path])
+      run(['-a', '-c', '.rubocop.yml', '-o', NullDevice.path, result_path])
   end
 
   def underscore(str)
-    str.gsub(/[-\s]/, '_').downcase
+    str.gsub(/[^\w\s-]/, '').gsub('  ', ' ').gsub(/[-\s]/, '_').downcase
   end
 
   def camel_case(str)

--- a/generatorv2/lib/utils.rb
+++ b/generatorv2/lib/utils.rb
@@ -47,7 +47,7 @@ module Utils
   def remove_tests(uuid, json)
     json["cases"].each_with_object([]) do |x, acc|
       if x["cases"]
-        acc << { "cases" => remove_tests(uuid, x) }
+        acc << { "cases" => remove_tests(uuid, x), "description" => x["description"] }
       elsif uuid.include?(x["uuid"])
         acc << x
       end

--- a/generatorv2/test/utils_test.rb
+++ b/generatorv2/test/utils_test.rb
@@ -22,6 +22,16 @@ class UtilTest < Minitest::Test
       Generator.new("two-fer").underscore("two-fer")
   end
 
+  def test_underscore_with_special_characters
+    assert_equal "two_fer",
+      Generator.new("two-fer").underscore("two,!@#$%^&*()-fer")
+  end
+
+  def test_underscore_with_special_characters_should_not_create_multiple_spaces
+    assert_equal "two_fer",
+      Generator.new("two-fer").underscore("two = fer")
+  end
+
   def test_first_time_includes_hastag
     assert_equal "# skip",
       Generator.new("acronym").skip?


### PR DESCRIPTION
* Enhance underscore method to filter invalid characters and update test file naming convention
* Add test case which test underscore for special characters
* Use character classes in regex. Also expose description for nested test cases.
* Underscore must not create multiple underscores around special characters