### PR TITLE
Fix verification script 

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -48,7 +48,7 @@ parser.on('--verify', 'Verify all exercises') do
       Generator.new(exercise).generate(f.path)
       generated_code = f.read
       File.delete(f.path)
-      fail VerificationError.new(exercise) unless current_code == generated_code
+      fail VerificationError, exercise unless current_code == generated_code
     end
   end
 end

--- a/bin/generate
+++ b/bin/generate
@@ -16,8 +16,8 @@ end
 class VerificationError < StandardError
   MESSAGE = 'The result generated for %<exercise>s, does not match the current file'
 
-  def initialize(message = MESSAGE)
-    super
+  def initialize(exercise, message = MESSAGE)
+    super(message % { exercise: exercise })
   end
 end
 
@@ -48,10 +48,8 @@ parser.on('--verify', 'Verify all exercises') do
       Generator.new(exercise).generate(f.path)
       generated_code = f.read
       File.delete(f.path)
-      fail VerificationError unless current_code == generated_code
+      fail VerificationError.new(exercise) unless current_code == generated_code
     end
-    rescue VerificationError => e
-      STDERR.puts e.message % {exercise:}
   end
 end
 

--- a/exercises/practice/atbash-cipher/.meta/test_template.erb
+++ b/exercises/practice/atbash-cipher/.meta/test_template.erb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
-require_relative 'armstrong_numbers'
+require_relative 'atbash_cipher'
 
-class ArmstrongNumbersTest < Minitest::Test
+class AtbashCipherTest < Minitest::Test
 <% json["cases"].each do |cases| %>
     <% cases["cases"].each do |sub_case| %>
         def test_<%= underscore(sub_case["description"]) %>


### PR DESCRIPTION
When the script threw an error, it would rescue it. Now it doesn't do that; instead, it instantly fails.