### PR TITLE
Fix typo in moviegoer

### DIFF
--- a/exercises/concept/moviegoer/.docs/hints.md
+++ b/exercises/concept/moviegoer/.docs/hints.md
@@ -6,7 +6,7 @@
 
 ## 2. Check if a moviegoer is allowed to see scary movies
 
-- [Compare][doc-integer-gtoe] the moviegoer's age with the minimum age allowed to see scary movies. You don't even need thee ternary operator in this task.
+- [Compare][doc-integer-gtoe] the moviegoer's age with the minimum age allowed to see scary movies. You don't even need the ternary operator in this task.
 
 ## 3. Check if a moviegoer is entitled to free popcorn
 

--- a/exercises/concept/moviegoer/.docs/instructions.md
+++ b/exercises/concept/moviegoer/.docs/instructions.md
@@ -24,7 +24,7 @@ The cinema has a simplified age-verification system.
 If you are 18 or over you can watch scary movies.
 If you are younger, you cannot.
 
-Implement the `Moviegoer.watch_scary_movie?` method.
+Implement the `Moviegoer#watch_scary_movie?` method.
 It should return whether someone is allowed to watch the movie or not.
 
 ```ruby


### PR DESCRIPTION
Typos in the Moviegoer documentation file have been corrected.
Please review.

Reference:
- [Moviegoer](https://exercism.org/tracks/ruby/exercises/moviegoer)
- [Exercism Community Topics（Fix typo in Moviegoer HINTS.md）](https://forum.exercism.org/t/fix-typo-in-moviegoer-hints-md/19038)