### PR TITLE
Fix typo in boutique inventory

### DIFF
--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -40,7 +40,7 @@ This helps both in terms of developer clarity and also is a performance optimisa
 
 ```ruby
 pet_names = {cat: "bob", horse: "caris", mouse: "arya"}
-pet_names.map { |_, name| name }  #=> ["bob, "caris", "arya"]
+pet_names.map { |_, name| name }  #=> ["bob", "caris", "arya"]
 ```
 
 ## Nested Enumerations

--- a/exercises/concept/boutique-inventory/boutique_inventory_test.rb
+++ b/exercises/concept/boutique-inventory/boutique_inventory_test.rb
@@ -86,7 +86,7 @@ class BoutiqueInventoryTest < Minitest::Test
     assert_equal({ s: 1, xl: 4 }, BoutiqueInventory.new(items).stock_for_item("Shoes"))
   end
 
-  def test_stock_for_item_for_some_in_stock_in_last_postion
+  def test_stock_for_item_for_some_in_stock_in_last_position
     shoes = { price: 30.00, name: "Shoes", quantity_by_size: { s: 1, xl: 4 } }
     coat = { price: 65.00, name: "Coat", quantity_by_size: { s: 2 } }
     handkerchief = { price: 19.99, name: "Handkerchief", quantity_by_size: { m: 3, l: 2 } }


### PR DESCRIPTION
The typos in the Boutique Inventory documentation and test files have been corrected.
Please review.

Reference:
- [Boutique Inventory](https://exercism.org/tracks/ruby/exercises/boutique-inventory)
- [Exercism Community Topics（Fix typo in BoutiqueInventory）](https://forum.exercism.org/t/fix-typo-in-boutiqueinventory/19037)