### PR TITLE
Fix typo in "test_error_for_largest_if_min_more_than_max"

### DIFF
--- a/exercises/practice/palindrome-products/palindrome_products_test.rb
+++ b/exercises/practice/palindrome-products/palindrome_products_test.rb
@@ -106,7 +106,7 @@ class PalindromesTest < Minitest::Test
     error = assert_raises(ArgumentError) do
       palindromes = Palindromes.new(min_factor: 2, max_factor: 1)
       palindromes.generate
-      palindromes.smallest
+      palindromes.largest
     end
     assert_equal "min must be <= max", error.message
   end


### PR DESCRIPTION
The two tests "test_error_for_smallest_if_min_more_than_max" and "test_error_for_largest_if_min_more_than_max" were both calling `smallest`. The latter now calls `largest` as advertised.