### PR TITLE
Fix wording about arrays from `create` to `contain`

### DIFF
--- a/exercises/concept/bird-count/.docs/introduction.md
+++ b/exercises/concept/bird-count/.docs/introduction.md
@@ -9,7 +9,7 @@ A negative index is assumed to be relative to the end of the array — e.g.. an 
 ### Creating arrays
 
 Arrays are normally created using the `[]` notation.
-They can create any different type of object.
+They can contain any different type of object.
 
 ```ruby
 array = [1, "two", 3.0]


### PR DESCRIPTION
This pull request makes a minor wording correction to the documentation for arrays in Ruby. The change clarifies that arrays can "contain" any different type of object, rather than "create" them.