### PR TITLE
[SimpleCalculator] added note about exception scope

### DIFF
--- a/exercises/concept/simple-calculator/.docs/instructions.md
+++ b/exercises/concept/simple-calculator/.docs/instructions.md
@@ -33,6 +33,10 @@ SimpleCalculator.calculate(1, 2, '-')
 # => Raises an UnsupportedOperation
 ```
 
+~~~~exercism/note
+In this exercise, you are expected to define the `UnsupportedOperation` exception for a specific scope.
+~~~~
+
 ## 3. Handle invalid arguments
 
 Update the `SimpleCalculator.calculate()` method to raise an `ArgumentError` exception for invalid argument types.


### PR DESCRIPTION
A note was added to instructions clarifying that UnsupportedOperation is expected to be defined for a specific scope. Solves issue #6772