### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Advanced
+# Instructions append
+
+## Advanced
 
 It is typical to call [#to_enum][to_enum] when defining methods for a generic Enumerable, in case no block is passed.
 

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/dnd-character/.docs/instructions.append.md
+++ b/exercises/practice/dnd-character/.docs/instructions.append.md
@@ -1,5 +1,8 @@
 # Instructions Append
 
+## Implementation
+
 In this exercise you should define a `DndCharacter` class with:
+
 - A static method for `modifier(constitution)`.
 - Methods for `strength`, `dexterity`, `constitution`, `intelligence`, `wisdom`, `charisma`, and `hitpoints`

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,8 +1,11 @@
 # Instructions append
 
+## Implementation
+
 In this exercise you're going to instantiate a class and add some instance methods, you can refer to [Writing Classes in Ruby][writing-classes] for how to do this.
 
-A HighScore accepts an array with one or more numbers, each representing one 'game score'. The Array class can offer inspiration for working with arrays, see [ruby-docs][ruby-docs-array].
+A HighScore accepts an array with one or more numbers, each representing one 'game score'.
+The Array class can offer inspiration for working with arrays, see [ruby-docs][ruby-docs-array].
 
 [ruby-docs-array]: https://docs.ruby-lang.org/en/master/Array.html
 [writing-classes]: http://ruby-for-beginners.rubymonstas.org/writing_classes/initializers.html

--- a/exercises/practice/kindergarten-garden/.docs/instructions.append.md
+++ b/exercises/practice/kindergarten-garden/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The exercise requires you to write a class that provides a method for each child in the kindergarten.
 You can make your work less repetitive (and more fun!) if, instead of manually defining 12 different methods, you use a bit of metaprogramming.
 If you're not sure where to start, explore the `method_missing` or `define_method` methods.

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Restrictions
+# Instructions append
+
+## Restrictions
 
 Avoid using `Date#leap?` from the Standard Library.

--- a/exercises/practice/ocr-numbers/.docs/instructions.append.md
+++ b/exercises/practice/ocr-numbers/.docs/instructions.append.md
@@ -1,6 +1,8 @@
 # Instructions append
 
-Some editors trim whitespace. If you rely on trailing whitespace in a multiline string,
-instead use a format that doesn't rely on trailing whitespace, or adjust the settings in your editor.
+## Implementation
+
+Some editors trim whitespace.
+If you rely on trailing whitespace in a multiline string, instead use a format that doesn't rely on trailing whitespace, or adjust the settings in your editor.
 
 [A multiline string cheatsheet for ruby](https://commandercoriander.net/blog/2014/11/09/a-multiline-string-cheatsheet-for-ruby/)

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,9 +1,7 @@
 # Instructions append
 
+## Implementation
 
-In order to make this easier to test, your solution will need to implement a
-`Robot.forget` method that clears any shared state that might exist to track
-duplicate robot names.
+In order to make this easier to test, your solution will need to implement a `Robot.forget` method that clears any shared state that might exist to track duplicate robot names.
 
 Bonus points if this method does not need to do anything for your solution.
-

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,8 +1,14 @@
 # Instructions append
 
-In this exercise you're practicing iterating over an array, meaning: executing an operation on each element of an array. Ruby has many useful built-in methods for iterations. Take a look at [this article][how-to-iterate].
+## Implementation
 
-Most of the methods listed in the article are not methods specifically for Array, but come from [Enumerable][Enumerable]. The article doesn't list iterating over _consecutive elements_. The first challenge is to find a method that does.
+In this exercise you're practicing iterating over an array, meaning: executing an operation on each element of an array.
+Ruby has many useful built-in methods for iterations.
+Take a look at [this article][how-to-iterate].
+
+Most of the methods listed in the article are not methods specifically for Array, but come from [Enumerable][Enumerable].
+The article doesn't list iterating over _consecutive elements_.
+The first challenge is to find a method that does.
 
 [Enumerable]: https://docs.ruby-lang.org/en/master/Enumerable.html
 [how-to-iterate]: http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.