### PR TITLE
Fix: Transpose - must skip only first test

### DIFF
--- a/exercises/practice/transpose/.meta/test_template.erb
+++ b/exercises/practice/transpose/.meta/test_template.erb
@@ -4,7 +4,7 @@ require_relative 'transpose'
 class TransposeTest < Minitest::Test
 <% json["cases"].each do |cases| %>
     def test_<%= underscore(cases["description"]) %>
-      #<%= skip? %>
+      <%= skip? %>
       actual = Transpose.transpose("<%= cases["input"]["lines"].join("\\n") %>")
       expected = "<%= cases["expected"].join("\\n") %>"
       assert_equal expected, actual

--- a/exercises/practice/transpose/transpose_test.rb
+++ b/exercises/practice/transpose/transpose_test.rb
@@ -3,84 +3,84 @@ require_relative 'transpose'
 
 class TransposeTest < Minitest::Test
   def test_empty_string
-    ## skip
+    # skip
     actual = Transpose.transpose("")
     expected = ""
     assert_equal expected, actual
   end
 
   def test_two_characters_in_a_row
-    # skip
+    skip
     actual = Transpose.transpose("A1")
     expected = "A\n1"
     assert_equal expected, actual
   end
 
   def test_two_characters_in_a_column
-    # skip
+    skip
     actual = Transpose.transpose("A\n1")
     expected = "A1"
     assert_equal expected, actual
   end
 
   def test_simple
-    # skip
+    skip
     actual = Transpose.transpose("ABC\n123")
     expected = "A1\nB2\nC3"
     assert_equal expected, actual
   end
 
   def test_single_line
-    # skip
+    skip
     actual = Transpose.transpose("Single line.")
     expected = "S\ni\nn\ng\nl\ne\n \nl\ni\nn\ne\n."
     assert_equal expected, actual
   end
 
   def test_first_line_longer_than_second_line
-    # skip
+    skip
     actual = Transpose.transpose("The fourth line.\nThe fifth line.")
     expected = "TT\nhh\nee\n  \nff\noi\nuf\nrt\nth\nh \n l\nli\nin\nne\ne.\n."
     assert_equal expected, actual
   end
 
   def test_second_line_longer_than_first_line
-    # skip
+    skip
     actual = Transpose.transpose("The first line.\nThe second line.")
     expected = "TT\nhh\nee\n  \nfs\nie\nrc\nso\ntn\n d\nl \nil\nni\nen\n.e\n ."
     assert_equal expected, actual
   end
 
   def test_mixed_line_length
-    # skip
+    skip
     actual = Transpose.transpose("The longest line.\nA long line.\nA longer line.\nA line.")
     expected = "TAAA\nh   \nelll\n ooi\nlnnn\nogge\nn e.\nglr\nei \nsnl\ntei\n .n\nl e\ni .\nn\ne\n."
     assert_equal expected, actual
   end
 
   def test_square
-    # skip
+    skip
     actual = Transpose.transpose("HEART\nEMBER\nABUSE\nRESIN\nTREND")
     expected = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
     assert_equal expected, actual
   end
 
   def test_rectangle
-    # skip
+    skip
     actual = Transpose.transpose("FRACTURE\nOUTLINED\nBLOOMING\nSEPTETTE")
     expected = "FOBS\nRULE\nATOP\nCLOT\nTIME\nUNIT\nRENT\nEDGE"
     assert_equal expected, actual
   end
 
   def test_triangle
-    # skip
+    skip
     actual = Transpose.transpose("T\nEE\nAAA\nSSSS\nEEEEE\nRRRRRR")
     expected = "TEASER\n EASER\n  ASER\n   SER\n    ER\n     R"
     assert_equal expected, actual
   end
 
   def test_jagged_triangle
-    # skip
+    skip
     actual = Transpose.transpose("11\n2\n3333\n444\n555555\n66666")
     expected = "123456\n1 3456\n  3456\n  3 56\n    56\n    5"
     assert_equal expected, actual


### PR DESCRIPTION
Only the first test should be skipped when delivered to the student.


fixes: 1846